### PR TITLE
feat: fused RoPE + KV cache write as dispatch ops

### DIFF
--- a/sglang_fl/dispatch/backends/flagos/flagos.py
+++ b/sglang_fl/dispatch/backends/flagos/flagos.py
@@ -51,6 +51,22 @@ class FlagOSBackend(Backend):
             obj, query, key, cos, sin, position_ids, rotary_interleaved, inplace
         )
 
+    def rotary_embedding_with_kv_cache(
+        self,
+        obj,
+        query,
+        key,
+        cos,
+        sin,
+        position_ids,
+        fused_set_kv_buffer_arg,
+        rotary_interleaved=False,
+    ):
+        raise NotImplementedError(
+            "rotary_embedding_with_kv_cache is not implemented in FlagOS backend. "
+            "Requires a fused RoPE + KV cache write kernel from FlagGems."
+        )
+
     def topk(
         self,
         obj,

--- a/sglang_fl/dispatch/backends/reference/reference.py
+++ b/sglang_fl/dispatch/backends/reference/reference.py
@@ -74,6 +74,22 @@ class ReferenceBackend(Backend):
             inplace=inplace,
         )
 
+    def rotary_embedding_with_kv_cache(
+        self,
+        obj,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        position_ids: torch.Tensor,
+        fused_set_kv_buffer_arg,
+        rotary_interleaved: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError(
+            "rotary_embedding_with_kv_cache is not implemented in reference backend. "
+            "Requires a fused RoPE + KV cache write kernel."
+        )
+
     def topk(
         self,
         obj,
@@ -113,3 +129,16 @@ class ReferenceBackend(Backend):
         from .impl.mrotary_embedding import mrotary_embedding_torch
 
         return mrotary_embedding_torch(obj, positions, query, key)
+
+    def mrotary_embedding_with_kv_cache(
+        self,
+        obj,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        fused_set_kv_buffer_arg,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError(
+            "mrotary_embedding_with_kv_cache is not implemented in reference backend. "
+            "Requires a fused RoPE + KV cache write kernel."
+        )

--- a/sglang_fl/dispatch/backends/reference/register_ops.py
+++ b/sglang_fl/dispatch/backends/reference/register_ops.py
@@ -67,6 +67,22 @@ def register_builtins(registry) -> None:
             priority=BackendPriority.REFERENCE,
         ),
         OpImpl(
+            op_name="rotary_embedding_with_kv_cache",
+            impl_id="reference.torch",
+            kind=BackendImplKind.REFERENCE,
+            fn=_bind_is_available(backend.rotary_embedding_with_kv_cache, is_avail),
+            vendor=None,
+            priority=BackendPriority.REFERENCE,
+        ),
+        OpImpl(
+            op_name="mrotary_embedding_with_kv_cache",
+            impl_id="reference.torch",
+            kind=BackendImplKind.REFERENCE,
+            fn=_bind_is_available(backend.mrotary_embedding_with_kv_cache, is_avail),
+            vendor=None,
+            priority=BackendPriority.REFERENCE,
+        ),
+        OpImpl(
             op_name="topk",
             impl_id="reference.torch",
             kind=BackendImplKind.REFERENCE,

--- a/sglang_fl/dispatch/backends/vendor/ascend/ascend.py
+++ b/sglang_fl/dispatch/backends/vendor/ascend/ascend.py
@@ -78,3 +78,19 @@ class AscendBackend(Backend):
             rotary_interleaved=rotary_interleaved,
             inplace=inplace,
         )
+
+    def rotary_embedding_with_kv_cache(
+        self,
+        obj,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        position_ids: torch.Tensor,
+        fused_set_kv_buffer_arg,
+        rotary_interleaved: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError(
+            "rotary_embedding_with_kv_cache is not implemented in Ascend backend. "
+            "Requires a fused RoPE + KV cache write kernel from torch_npu."
+        )

--- a/sglang_fl/dispatch/backends/vendor/ascend/register_ops.py
+++ b/sglang_fl/dispatch/backends/vendor/ascend/register_ops.py
@@ -50,6 +50,14 @@ def register_builtins(registry) -> None:
             vendor="ascend",
             priority=BackendPriority.VENDOR,
         ),
+        OpImpl(
+            op_name="rotary_embedding_with_kv_cache",
+            impl_id="vendor.ascend",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.rotary_embedding_with_kv_cache, is_avail),
+            vendor="ascend",
+            priority=BackendPriority.VENDOR,
+        ),
     ]
 
     registry.register_many(impls)

--- a/sglang_fl/dispatch/backends/vendor/cuda/cuda.py
+++ b/sglang_fl/dispatch/backends/vendor/cuda/cuda.py
@@ -86,6 +86,30 @@ class CudaBackend(Backend):
             inplace=inplace,
         )
 
+    def rotary_embedding_with_kv_cache(
+        self,
+        obj,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        position_ids: torch.Tensor,
+        fused_set_kv_buffer_arg,
+        rotary_interleaved: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        from .impl.rotary import rotary_embedding_with_kv_cache_cuda
+
+        return rotary_embedding_with_kv_cache_cuda(
+            obj,
+            query,
+            key,
+            cos,
+            sin,
+            position_ids,
+            fused_set_kv_buffer_arg,
+            rotary_interleaved=rotary_interleaved,
+        )
+
     def topk(
         self,
         obj,
@@ -130,6 +154,20 @@ class CudaBackend(Backend):
         from .impl.mrotary_embedding import mrotary_embedding_cuda
 
         return mrotary_embedding_cuda(obj, positions, query, key)
+
+    def mrotary_embedding_with_kv_cache(
+        self,
+        obj,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        fused_set_kv_buffer_arg,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        from .impl.mrotary_embedding import mrotary_embedding_with_kv_cache_cuda
+
+        return mrotary_embedding_with_kv_cache_cuda(
+            obj, positions, query, key, fused_set_kv_buffer_arg
+        )
 
     def chunk_gated_delta_rule(
         self,

--- a/sglang_fl/dispatch/backends/vendor/cuda/impl/mrotary_embedding.py
+++ b/sglang_fl/dispatch/backends/vendor/cuda/impl/mrotary_embedding.py
@@ -25,3 +25,34 @@ def mrotary_embedding_cuda(
     from sglang.srt.layers.rotary_embedding.base import RotaryEmbedding
 
     return RotaryEmbedding.forward_cuda(obj, positions, query, key)
+
+
+def mrotary_embedding_with_kv_cache_cuda(
+    obj,
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    fused_set_kv_buffer_arg,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Fused MRotaryEmbedding + KV cache write using SGLang's native CUDA kernels.
+
+    For 2D positions with mrope_section: fused KV cache not supported,
+    raises NotImplementedError.
+    For 1D positions: delegates to RotaryEmbedding.forward_cuda with fused_args.
+    """
+    if positions.ndim == 2 and hasattr(obj, "mrope_section") and obj.mrope_section:
+        raise NotImplementedError(
+            "Fused RoPE + KV cache write is not supported for 2D multimodal positions. "
+            "SGLang's triton_mrope_fused does not support fused_set_kv_buffer_arg."
+        )
+    # 1D positions: delegate to base RotaryEmbedding which supports fused KV write
+    from sglang.srt.layers.rotary_embedding.base import RotaryEmbedding
+
+    return RotaryEmbedding.forward_cuda(
+        obj,
+        positions,
+        query,
+        key,
+        fused_set_kv_buffer_arg=fused_set_kv_buffer_arg,
+    )

--- a/sglang_fl/dispatch/backends/vendor/cuda/impl/rotary.py
+++ b/sglang_fl/dispatch/backends/vendor/cuda/impl/rotary.py
@@ -42,3 +42,48 @@ def rotary_embedding_cuda(
         rotary_interleaved,
     )
     return query, key
+
+
+def rotary_embedding_with_kv_cache_cuda(
+    obj,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    position_ids: torch.Tensor,
+    fused_set_kv_buffer_arg,
+    rotary_interleaved: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Fused RoPE + KV cache write using sgl_kernel.
+
+    Single kernel applies rotary embedding to q/k and writes rotated k + v to KV cache.
+
+    Args:
+        obj: The calling obj (for interface consistency)
+        query: Query tensor [num_tokens, num_heads, head_dim]
+        key: Key tensor [num_tokens, num_kv_heads, head_dim]
+        cos: Cosine cache
+        sin: Sine cache
+        position_ids: Position indices
+        fused_set_kv_buffer_arg: FusedSetKVBufferArg or dict with KV cache info
+        rotary_interleaved: Whether to use interleaved rotary
+
+    Returns:
+        Tuple of (embedded_query, embedded_key)
+    """
+    from sglang.jit_kernel.rope import apply_rope_with_cos_sin_cache_inplace
+
+    # Reconstruct cos_sin_cache from separate cos and sin
+    cos_sin_cache = torch.cat([cos, sin], dim=-1)
+    is_neox = not rotary_interleaved
+
+    apply_rope_with_cos_sin_cache_inplace(
+        positions=position_ids,
+        q=query,
+        k=key,
+        cos_sin_cache=cos_sin_cache,
+        is_neox=is_neox,
+        fused_args=fused_set_kv_buffer_arg,
+    )
+    return query, key

--- a/sglang_fl/dispatch/backends/vendor/cuda/register_ops.py
+++ b/sglang_fl/dispatch/backends/vendor/cuda/register_ops.py
@@ -67,6 +67,22 @@ def register_builtins(registry) -> None:
             priority=BackendPriority.VENDOR,
         ),
         OpImpl(
+            op_name="rotary_embedding_with_kv_cache",
+            impl_id="vendor.cuda",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.rotary_embedding_with_kv_cache, is_avail),
+            vendor="cuda",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="mrotary_embedding_with_kv_cache",
+            impl_id="vendor.cuda",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.mrotary_embedding_with_kv_cache, is_avail),
+            vendor="cuda",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
             op_name="topk",
             impl_id="vendor.cuda",
             kind=BackendImplKind.VENDOR,

--- a/sglang_fl/dispatch/bridge/mrotary_embedding.py
+++ b/sglang_fl/dispatch/bridge/mrotary_embedding.py
@@ -4,13 +4,19 @@
 #   forward_cuda(self, positions, query, key, fused_set_kv_buffer_arg=None)
 #     -> tuple[Tensor, Tensor]
 #
-# Dispatch signature:
-#   fn(obj, positions, query, key) -> tuple[Tensor, Tensor]
+# Dispatch signatures:
+#   mrotary_embedding:
+#     fn(obj, positions, query, key) -> tuple[Tensor, Tensor]
+#
+#   mrotary_embedding_with_kv_cache:
+#     fn(obj, positions, query, key, fused_set_kv_buffer_arg)
+#     -> tuple[Tensor, Tensor]
 #
 # SGLang-specific handling:
 #   - positions can be 1D [num_tokens] or 2D [3, num_tokens] (multimodal)
 #   - mrope_section splits rotary_dim across 3 axes (text/image/video)
-#   - fused_set_kv_buffer_arg: not supported by dispatch, fall through to native
+#   - fused_set_kv_buffer_arg: dispatch as separate fused op
+#     "mrotary_embedding_with_kv_cache" (fused RoPE + KV cache write)
 
 from __future__ import annotations
 
@@ -29,8 +35,13 @@ def mrotary_embedding_bridge(
     fused_set_kv_buffer_arg=None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """SGLang MRotaryEmbedding forward → dispatch call_op("mrotary_embedding", ...)."""
-    # fused_set_kv_buffer_arg requires native kernel — fall through
     if fused_set_kv_buffer_arg is not None:
-        return self.forward_native(positions, query, key, fused_set_kv_buffer_arg)
-
+        return call_op(
+            "mrotary_embedding_with_kv_cache",
+            self,
+            positions,
+            query,
+            key,
+            fused_set_kv_buffer_arg,
+        )
     return call_op("mrotary_embedding", self, positions, query, key)

--- a/sglang_fl/dispatch/bridge/rotary_embedding.py
+++ b/sglang_fl/dispatch/bridge/rotary_embedding.py
@@ -5,16 +5,23 @@
 #                fused_set_kv_buffer_arg=None)
 #     -> tuple[Tensor, Tensor]
 #
-# Dispatch signature:
-#   fn(obj, query, key, cos, sin, position_ids, rotary_interleaved=False,
-#      inplace=True)
+# Dispatch signatures:
+#   rotary_embedding:
+#     fn(obj, query, key, cos, sin, position_ids, rotary_interleaved=False,
+#        inplace=True)
+#     -> tuple[Tensor, Tensor]
+#
+#   rotary_embedding_with_kv_cache:
+#     fn(obj, query, key, cos, sin, position_ids, fused_set_kv_buffer_arg,
+#        rotary_interleaved=False)
 #     -> tuple[Tensor, Tensor]
 #
 # SGLang-specific handling:
 #   - Extract cos/sin from self.cos_sin_cache (shape [max_seq_len, rotary_dim])
 #   - Handle offsets (add to positions)
 #   - Handle partial rotary_dim (only apply to first rotary_dim dimensions)
-#   - fused_set_kv_buffer_arg: not supported by dispatch, fall through to native
+#   - fused_set_kv_buffer_arg: dispatch as separate fused op
+#     "rotary_embedding_with_kv_cache" (fused RoPE + KV cache write)
 #   - Reshape query/key from [batch, num_heads*head_size] to [batch, num_heads, head_size]
 
 from __future__ import annotations
@@ -37,13 +44,9 @@ def rotary_embedding_bridge(
     """SGLang RotaryEmbedding forward → dispatch call_op("rotary_embedding", ...).
 
     Handles SGLang-specific parameter translation before delegating to dispatch.
+    When fused_set_kv_buffer_arg is provided, dispatches to the fused
+    "rotary_embedding_with_kv_cache" op instead.
     """
-    # fused_set_kv_buffer_arg requires native kernel (HIP-specific optimization)
-    if fused_set_kv_buffer_arg is not None:
-        return self.forward_native(
-            positions, query, key, offsets, fused_set_kv_buffer_arg
-        )
-
     # Handle offsets
     if offsets is not None:
         positions = positions + offsets
@@ -66,6 +69,19 @@ def rotary_embedding_bridge(
     query = query.view(batch_size, -1, head_size)
     key = key.view(batch_size, -1, head_size)
 
+    # Choose op based on whether fused KV cache write is requested
+    if fused_set_kv_buffer_arg is not None:
+        op_name = "rotary_embedding_with_kv_cache"
+        op_kwargs = dict(
+            rotary_interleaved=rotary_interleaved,
+        )
+    else:
+        op_name = "rotary_embedding"
+        op_kwargs = dict(
+            rotary_interleaved=rotary_interleaved,
+            inplace=True,
+        )
+
     # If rotary_dim < head_size, only apply to first rotary_dim dimensions
     rotary_dim = cos.shape[-1] * 2  # cos is half_dim, full rotary_dim = 2 * half_dim
     if rotary_dim < head_size:
@@ -74,32 +90,56 @@ def rotary_embedding_bridge(
         query_pass = query[..., rotary_dim:]
         key_pass = key[..., rotary_dim:]
 
-        q_embed, k_embed = call_op(
-            "rotary_embedding",
-            self,
-            query_rot,
-            key_rot,
-            cos,
-            sin,
-            positions,
-            rotary_interleaved=rotary_interleaved,
-            inplace=True,
-        )
+        if fused_set_kv_buffer_arg is not None:
+            q_embed, k_embed = call_op(
+                op_name,
+                self,
+                query_rot,
+                key_rot,
+                cos,
+                sin,
+                positions,
+                fused_set_kv_buffer_arg,
+                **op_kwargs,
+            )
+        else:
+            q_embed, k_embed = call_op(
+                op_name,
+                self,
+                query_rot,
+                key_rot,
+                cos,
+                sin,
+                positions,
+                **op_kwargs,
+            )
 
         query = torch.cat((q_embed, query_pass), dim=-1)
         key = torch.cat((k_embed, key_pass), dim=-1)
     else:
-        q_embed, k_embed = call_op(
-            "rotary_embedding",
-            self,
-            query,
-            key,
-            cos,
-            sin,
-            positions,
-            rotary_interleaved=rotary_interleaved,
-            inplace=True,
-        )
+        if fused_set_kv_buffer_arg is not None:
+            q_embed, k_embed = call_op(
+                op_name,
+                self,
+                query,
+                key,
+                cos,
+                sin,
+                positions,
+                fused_set_kv_buffer_arg,
+                **op_kwargs,
+            )
+        else:
+            q_embed, k_embed = call_op(
+                op_name,
+                self,
+                query,
+                key,
+                cos,
+                sin,
+                positions,
+                **op_kwargs,
+            )
         query = q_embed
         key = k_embed
 

--- a/sglang_fl/dispatch/ops.py
+++ b/sglang_fl/dispatch/ops.py
@@ -111,3 +111,40 @@ class FLBackendBase(ABC):
             Tuple of (embedded_query, embedded_key)
         """
         pass
+
+    @abstractmethod
+    def rotary_embedding_with_kv_cache(
+        self,
+        obj,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        position_ids: torch.Tensor,
+        fused_set_kv_buffer_arg,
+        rotary_interleaved: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Fused rotary position embedding + KV cache write.
+
+        Single kernel applies RoPE to q/k, then writes rotated k and v to KV cache.
+        This avoids a separate memory round-trip for KV cache store.
+
+        Args:
+            obj: The calling nn.Module (for interface consistency)
+            query: Query tensor [num_tokens, num_heads, head_dim]
+            key: Key tensor [num_tokens, num_kv_heads, head_dim]
+            cos: Cosine cache [max_seq_len, rotary_dim]
+            sin: Sine cache [max_seq_len, rotary_dim]
+            position_ids: Position indices [num_tokens]
+            fused_set_kv_buffer_arg: FusedSetKVBufferArg or dict containing:
+                - value: V tensor [num_tokens, num_v_heads * head_dim]
+                - k_buffer/key_cache: KV cache key buffer
+                - v_buffer/value_cache: KV cache value buffer
+                - cache_loc/slot_mapping: indices for cache write
+            rotary_interleaved: Whether to use interleaved rotary
+
+        Returns:
+            Tuple of (embedded_query, embedded_key)
+        """
+        pass


### PR DESCRIPTION
## Summary
  - Register `rotary_embedding_with_kv_cache` and `mrotary_embedding_with_kv_cache` as independent dispatch ops
  - Previously `fused_set_kv_buffer_arg` bypassed `call_op` and fell through to `forward_cuda` directly
  - Bridge layer routes based on `fused_set_kv_buffer_arg` presence
  - CUDA vendor: implements via `apply_rope_with_cos_sin_cache_inplace(fused_args=...)`
  - FlagOS/Ascend/Reference: `NotImplementedError` (pending vendor fused kernel)