### PR TITLE
fix: topk flagos backend API alignment with sglang

### DIFF
--- a/sglang_fl/dispatch/backends/flagos/impl/topk.py
+++ b/sglang_fl/dispatch/backends/flagos/impl/topk.py
@@ -32,7 +32,7 @@ def topk_flagos(
     Returns:
         TopKOutput (StandardTopKOutput format)
     """
-    topk = obj.topk_config.topk
+    topk = obj.topk_config.top_k
     renormalize = obj.topk_config.renormalize
 
     M = hidden_states.shape[0]
@@ -51,5 +51,5 @@ def topk_flagos(
     return StandardTopKOutput(
         topk_weights=topk_weights,
         topk_ids=topk_ids,
-        token_expert_indices=token_expert_indices,
+        router_logits=router_logits,
     )


### PR DESCRIPTION
## Summary

Fix two API misalignments in `sglang_fl/dispatch/backends/flagos/impl/topk.py` that cause `default.flagos` backend to fail on every `topk` call.

## Changes

1. `obj.topk_config.topk` → `obj.topk_config.top_k` — sglang `TopKConfig` attribute uses underscore
2. `token_expert_indices=token_expert_indices` → `router_logits=router_logits` — `StandardTopKOutput` has 3 fields: `topk_weights`, `topk_ids`, `router_logits`

## Before

```
Op 'topk' using 'default.flagos' → failed ('TopKConfig' object has no attribute 'topk')
  → fallback to vendor.musa
```

## After

```
Op 'topk' using 'default.flagos' → passed
All validations passed.
```

Verified on Qwen3.6-35B-A3B + 27B with MTT S5000.

Closes #17