### PR TITLE
feat: complete FlagCX full communication replacement for PP support

### DIFF
--- a/examples/qwen3_6_27b_multinode.py
+++ b/examples/qwen3_6_27b_multinode.py
@@ -25,8 +25,6 @@ Full tested command (2 nodes × 2 GPUs each, TP=2 PP=2):
     CUDA_VISIBLE_DEVICES=0,1 \
     SGLANG_FL_DIST_BACKEND=flagcx \
     FLAGCX_PATH=/mine/FlagCX_v0.13.0 \
-    SGLANG_FL_COMM_STRICT=1 \
-    SGLANG_FL_COMM_DEBUG=1 \
     SGLANG_FL_FLAGOS_BLACKLIST=count_nonzero \
     SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0 \
     GLOO_SOCKET_IFNAME=eth0 NCCL_SOCKET_IFNAME=eth0 \
@@ -36,8 +34,6 @@ Full tested command (2 nodes × 2 GPUs each, TP=2 PP=2):
     CUDA_VISIBLE_DEVICES=0,1 \
     SGLANG_FL_DIST_BACKEND=flagcx \
     FLAGCX_PATH=/mine/FlagCX_v0.13.0 \
-    SGLANG_FL_COMM_STRICT=1 \
-    SGLANG_FL_COMM_DEBUG=1 \
     SGLANG_FL_FLAGOS_BLACKLIST=count_nonzero \
     SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0 \
     GLOO_SOCKET_IFNAME=eth0 NCCL_SOCKET_IFNAME=eth0 \
@@ -52,8 +48,6 @@ Environment variables:
   NCCL_SOCKET_IFNAME    Network interface for NCCL (default: eth0)
   SGLANG_FL_DIST_BACKEND  Communication backend (flagcx / nccl)
   FLAGCX_PATH           Path to FlagCX installation
-  SGLANG_FL_COMM_STRICT   Enable GPU comm leak detection (1/0)
-  SGLANG_FL_COMM_DEBUG    Enable comm debug logging (1/0)
   SGLANG_FL_FLAGOS_BLACKLIST         Ops to exclude from FlagGems
   SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK  Set to 0 to skip memory check
 

--- a/examples/qwen3_6_27b_multinode.py
+++ b/examples/qwen3_6_27b_multinode.py
@@ -4,7 +4,7 @@
 
 Validates that sglang-plugin-FL correctly handles multi-node tensor parallelism
 for the dense Qwen3.6-27B model by launching a distributed SGLang server across
-2 nodes and running text, concurrent, and multimodal (VL) inference tests.
+2 nodes and running text, concurrent, multimodal (VL), and high-concurrency tests.
 
 ============================================================================
 Usage:
@@ -23,14 +23,22 @@ Full tested command (2 nodes × 2 GPUs each, TP=2 PP=2):
 
   [Node 0 / Master / 192.168.0.66]
     CUDA_VISIBLE_DEVICES=0,1 \
-    SGLANG_FL_FLAGOS_BLACKLIST=count_nonzero,index_put_,_index_put_impl,_index_put_impl_ \
+    SGLANG_FL_DIST_BACKEND=flagcx \
+    FLAGCX_PATH=/mine/FlagCX_v0.13.0 \
+    SGLANG_FL_COMM_STRICT=1 \
+    SGLANG_FL_COMM_DEBUG=1 \
+    SGLANG_FL_FLAGOS_BLACKLIST=count_nonzero \
     SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0 \
     GLOO_SOCKET_IFNAME=eth0 NCCL_SOCKET_IFNAME=eth0 \
         python examples/qwen3_6_27b_multinode.py --role master --master-addr 192.168.0.66 --tp 2 --pp 2
 
   [Node 1 / Worker / 192.168.0.65]
     CUDA_VISIBLE_DEVICES=0,1 \
-    SGLANG_FL_FLAGOS_BLACKLIST=count_nonzero,index_put_,_index_put_impl,_index_put_impl_ \
+    SGLANG_FL_DIST_BACKEND=flagcx \
+    FLAGCX_PATH=/mine/FlagCX_v0.13.0 \
+    SGLANG_FL_COMM_STRICT=1 \
+    SGLANG_FL_COMM_DEBUG=1 \
+    SGLANG_FL_FLAGOS_BLACKLIST=count_nonzero \
     SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0 \
     GLOO_SOCKET_IFNAME=eth0 NCCL_SOCKET_IFNAME=eth0 \
         python examples/qwen3_6_27b_multinode.py --role worker --master-addr 192.168.0.66 --tp 2 --pp 2
@@ -42,8 +50,10 @@ Environment variables:
   CUDA_VISIBLE_DEVICES  GPU selection (e.g. 0,1)
   GLOO_SOCKET_IFNAME    Network interface for Gloo (default: eth0)
   NCCL_SOCKET_IFNAME    Network interface for NCCL (default: eth0)
-  NCCL_IB_DISABLE       Set to 1 to disable InfiniBand
-  NCCL_NET              Set to "Socket" to force TCP transport
+  SGLANG_FL_DIST_BACKEND  Communication backend (flagcx / nccl)
+  FLAGCX_PATH           Path to FlagCX installation
+  SGLANG_FL_COMM_STRICT   Enable GPU comm leak detection (1/0)
+  SGLANG_FL_COMM_DEBUG    Enable comm debug logging (1/0)
   SGLANG_FL_FLAGOS_BLACKLIST         Ops to exclude from FlagGems
   SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK  Set to 0 to skip memory check
 
@@ -111,6 +121,18 @@ def parse_args():
         default=600,
         help="Max seconds to wait for server ready (master only)",
     )
+    parser.add_argument(
+        "--text-concurrency",
+        type=int,
+        default=32,
+        help="Number of concurrent text requests for high-concurrency test",
+    )
+    parser.add_argument(
+        "--vl-concurrency",
+        type=int,
+        default=8,
+        help="Number of concurrent VL requests for high-concurrency test",
+    )
     return parser.parse_args()
 
 
@@ -135,7 +157,9 @@ def wait_for_server(port: int, timeout: int) -> bool:
     return False
 
 
-def chat_request(port: int, prompt: str, max_tokens: int = 32) -> str:
+def chat_request(
+    port: int, prompt: str, max_tokens: int = 32, timeout: int = 300
+) -> str:
     """Send a text chat completion request."""
     url = f"http://localhost:{port}/v1/chat/completions"
     payload = {
@@ -150,14 +174,16 @@ def chat_request(port: int, prompt: str, max_tokens: int = 32) -> str:
         req = urllib.request.Request(
             url, data=data, headers={"Content-Type": "application/json"}
         )
-        with urllib.request.urlopen(req, timeout=120) as resp:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             result = json.loads(resp.read())
             return result["choices"][0]["message"]["content"]
     except Exception as e:
         return f"ERROR: {e}"
 
 
-def vl_request(port: int, img_path: Path, question: str, max_tokens: int = 16) -> str:
+def vl_request(
+    port: int, img_path: Path, question: str, max_tokens: int = 16, timeout: int = 300
+) -> str:
     """Send a vision-language chat request with a base64-encoded image."""
     url = f"http://localhost:{port}/v1/chat/completions"
     mime = "image/png" if img_path.suffix == ".png" else "image/jpeg"
@@ -185,7 +211,7 @@ def vl_request(port: int, img_path: Path, question: str, max_tokens: int = 16) -
         req = urllib.request.Request(
             url, data=data, headers={"Content-Type": "application/json"}
         )
-        with urllib.request.urlopen(req, timeout=120) as resp:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             result = json.loads(resp.read())
             return result["choices"][0]["message"]["content"]
     except Exception as e:
@@ -224,12 +250,18 @@ class TestRunner:
         return self.failed == 0
 
 
-def run_tests(port: int, tp_size: int, nnodes: int) -> bool:
+def run_tests(
+    port: int,
+    tp_size: int,
+    nnodes: int,
+    text_concurrency: int = 32,
+    vl_concurrency: int = 8,
+) -> bool:
     """Run all verification tests. Returns True if all passed."""
     t = TestRunner()
 
-    # Test 1: Text Inference
-    print("\n=== Test 1: Text Inference ===")
+    # Test 1: Text Inference (Sequential)
+    print("\n=== Test 1: Text Inference (Sequential) ===")
     r = chat_request(
         port,
         "How many states are there in the United States? Answer with just the number.",
@@ -253,8 +285,9 @@ def run_tests(port: int, tp_size: int, nnodes: int) -> bool:
     t.check("Contains '2'", "2", r)
     t.check("Contains '7'", "7", r)
 
-    # Test 3: Concurrent Requests
-    print("\n=== Test 3: Concurrent Requests ===")
+    # Test 3: Concurrent Text x4
+    print("\n=== Test 3: Concurrent Text x4 ===")
+    t0 = time.time()
     with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
         futures = {}
         for i in range(1, 5):
@@ -267,20 +300,58 @@ def run_tests(port: int, tp_size: int, nnodes: int) -> bool:
         for i in range(1, 5):
             r = futures[i].result()
             expected = str(i + i)
-            if expected not in r:
+            ok = expected in r
+            print(f"  {'PASS' if ok else 'FAIL'}: {i}+{i}={expected} -> {r}")
+            if not ok:
                 all_ok = False
-                print(f"  FAIL: {i}+{i} expected {expected}, got: {r}")
 
     t.total += 1
     if all_ok:
-        print("  PASS: All 4 concurrent requests correct")
         t.passed += 1
     else:
-        print("  FAIL: Some concurrent requests failed")
         t.failed += 1
+    print(f"  Time: {time.time() - t0:.1f}s")
 
-    # Test 4: Multimodal (VL)
-    print("\n=== Test 4: Multimodal (Vision-Language) ===")
+    # Test 4: High-Concurrency Text
+    print(f"\n=== Test 4: High-Concurrency Text x{text_concurrency} ===")
+    t0 = time.time()
+    ok_count = 0
+    fail_count = 0
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=text_concurrency
+    ) as executor:
+        futures = {}
+        for i in range(text_concurrency):
+            a, b = i + 1, i + 2
+            f = executor.submit(
+                chat_request, port, f"What is {a}+{b}? Answer with just the number.", 10
+            )
+            futures[i] = (a, b, f)
+
+        for i, (a, b, f) in futures.items():
+            try:
+                r = f.result(timeout=300)
+                expected = str(a + b)
+                if expected in r:
+                    ok_count += 1
+                else:
+                    fail_count += 1
+                    print(f"  FAIL: {a}+{b}={expected} -> {r}")
+            except Exception as e:
+                fail_count += 1
+                print(f"  FAIL: {a}+{b} -> ERROR: {e}")
+
+    t.total += 1
+    if fail_count == 0:
+        print(f"  PASS: {ok_count}/{text_concurrency} correct")
+        t.passed += 1
+    else:
+        print(f"  FAIL: {ok_count}/{text_concurrency} correct, {fail_count} failed")
+        t.failed += 1
+    print(f"  Time: {time.time() - t0:.1f}s")
+
+    # Test 5: Multimodal (VL) Sequential
+    print("\n=== Test 5: Multimodal (VL) Sequential ===")
     if IMG_DIR.is_dir():
         r = vl_request(
             port,
@@ -311,6 +382,53 @@ def run_tests(port: int, tp_size: int, nnodes: int) -> bool:
     else:
         print(f"  SKIP: test_images directory not found at {IMG_DIR}")
 
+    # Test 6: High-Concurrency VL
+    if IMG_DIR.is_dir() and vl_concurrency > 1:
+        print(f"\n=== Test 6: High-Concurrency VL x{vl_concurrency} ===")
+        vl_cases = [
+            (IMG_DIR / "red_square.jpg", "What color is this? One word.", "red"),
+            (IMG_DIR / "cat.jpg", "What animal? One word.", "cat"),
+            (IMG_DIR / "digit_seven.png", "What digit? Just the number.", "7"),
+            (IMG_DIR / "stop_sign.png", "What does this sign say? One word.", "stop"),
+        ]
+        # Cycle through images
+        all_cases = (vl_cases * ((vl_concurrency // len(vl_cases)) + 1))[
+            :vl_concurrency
+        ]
+        t0 = time.time()
+        ok_count = 0
+        fail_count = 0
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=vl_concurrency
+        ) as executor:
+            futures = {}
+            for i, (img, q, exp) in enumerate(all_cases):
+                futures[i] = (
+                    img.name,
+                    exp,
+                    executor.submit(vl_request, port, img, q, 10),
+                )
+            for i, (name, expected, f) in futures.items():
+                try:
+                    r = f.result(timeout=300)
+                    if expected.lower() in r.lower():
+                        ok_count += 1
+                    else:
+                        fail_count += 1
+                        print(f"  FAIL: {name} -> {r}")
+                except Exception as e:
+                    fail_count += 1
+                    print(f"  FAIL: {name} -> ERROR: {e}")
+
+        t.total += 1
+        if fail_count == 0:
+            print(f"  PASS: {ok_count}/{vl_concurrency} correct")
+            t.passed += 1
+        else:
+            print(f"  FAIL: {ok_count}/{vl_concurrency} correct, {fail_count} failed")
+            t.failed += 1
+        print(f"  Time: {time.time() - t0:.1f}s")
+
     return t.summary(tp_size, nnodes)
 
 
@@ -339,6 +457,9 @@ def run_master(args):
     print(f"  TP:     {args.tp}    PP: {args.pp}    Nodes: {args.nnodes}")
     print(f"  Master: {args.master_addr}  dist={args.dist_port}  nccl={args.nccl_port}")
     print(f"  API:    http://localhost:{args.port}")
+    print(
+        f"  Text concurrency: {args.text_concurrency}  VL concurrency: {args.vl_concurrency}"
+    )
     print("=" * 56)
 
     cmd = [
@@ -391,7 +512,13 @@ def run_master(args):
             sys.exit(1)
         print("\nServer ready!")
 
-        success = run_tests(args.port, args.tp, args.nnodes)
+        success = run_tests(
+            args.port,
+            args.tp,
+            args.nnodes,
+            text_concurrency=args.text_concurrency,
+            vl_concurrency=args.vl_concurrency,
+        )
         cleanup()
         sys.exit(0 if success else 1)
 

--- a/examples/qwen3_6_35b_a3b_multinode.py
+++ b/examples/qwen3_6_35b_a3b_multinode.py
@@ -25,8 +25,6 @@ Full tested command (2 nodes × 2 GPUs each, TP=2 PP=2):
     CUDA_VISIBLE_DEVICES=0,1 \
     SGLANG_FL_DIST_BACKEND=flagcx \
     FLAGCX_PATH=/mine/FlagCX_v0.13.0 \
-    SGLANG_FL_COMM_STRICT=1 \
-    SGLANG_FL_COMM_DEBUG=1 \
     SGLANG_FL_FLAGOS_BLACKLIST=count_nonzero \
     SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0 \
     GLOO_SOCKET_IFNAME=eth0 NCCL_SOCKET_IFNAME=eth0 \
@@ -36,8 +34,6 @@ Full tested command (2 nodes × 2 GPUs each, TP=2 PP=2):
     CUDA_VISIBLE_DEVICES=0,1 \
     SGLANG_FL_DIST_BACKEND=flagcx \
     FLAGCX_PATH=/mine/FlagCX_v0.13.0 \
-    SGLANG_FL_COMM_STRICT=1 \
-    SGLANG_FL_COMM_DEBUG=1 \
     SGLANG_FL_FLAGOS_BLACKLIST=count_nonzero \
     SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0 \
     GLOO_SOCKET_IFNAME=eth0 NCCL_SOCKET_IFNAME=eth0 \
@@ -52,8 +48,6 @@ Environment variables:
   NCCL_SOCKET_IFNAME    Network interface for NCCL (default: eth0)
   SGLANG_FL_DIST_BACKEND  Communication backend (flagcx / nccl)
   FLAGCX_PATH           Path to FlagCX installation
-  SGLANG_FL_COMM_STRICT   Enable GPU comm leak detection (1/0)
-  SGLANG_FL_COMM_DEBUG    Enable comm debug logging (1/0)
   SGLANG_FL_FLAGOS_BLACKLIST         Ops to exclude from FlagGems
   SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK  Set to 0 to skip memory check
 

--- a/examples/qwen3_6_35b_a3b_multinode.py
+++ b/examples/qwen3_6_35b_a3b_multinode.py
@@ -4,7 +4,7 @@
 
 Validates that sglang-plugin-FL correctly handles multi-node tensor parallelism
 by launching a distributed SGLang server across 2 nodes and running text,
-concurrent, and multimodal (VL) inference tests.
+concurrent, multimodal (VL), and high-concurrency inference tests.
 
 ============================================================================
 Usage:
@@ -12,7 +12,7 @@ Usage:
   controlled by the --role argument.
 
   Step 1 — Start master on node 0 (e.g. 192.168.0.66):
-    python examples/qwen3_6_35b_a3b_multinode.py --role master --master-addr 192.168.0.66 --tp 2 --pp 2
+    python examples/qwen3_6_35b_a3b_multinode.py --role master --master-addr 192.1-tp 2 --pp 2
 
   Step 2 — Start worker on node 1 (e.g. 192.168.0.65):
     python examples/qwen3_6_35b_a3b_multinode.py --role worker --master-addr 192.168.0.66 --tp 2 --pp 2
@@ -23,14 +23,22 @@ Full tested command (2 nodes × 2 GPUs each, TP=2 PP=2):
 
   [Node 0 / Master / 192.168.0.66]
     CUDA_VISIBLE_DEVICES=0,1 \
-    SGLANG_FL_FLAGOS_BLACKLIST=count_nonzero,index_put_,_index_put_impl,_index_put_impl_ \
+    SGLANG_FL_DIST_BACKEND=flagcx \
+    FLAGCX_PATH=/mine/FlagCX_v0.13.0 \
+    SGLANG_FL_COMM_STRICT=1 \
+    SGLANG_FL_COMM_DEBUG=1 \
+    SGLANG_FL_FLAGOS_BLACKLIST=count_nonzero \
     SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0 \
     GLOO_SOCKET_IFNAME=eth0 NCCL_SOCKET_IFNAME=eth0 \
         python examples/qwen3_6_35b_a3b_multinode.py --role master --master-addr 192.168.0.66 --tp 2 --pp 2
 
   [Node 1 / Worker / 192.168.0.65]
     CUDA_VISIBLE_DEVICES=0,1 \
-    SGLANG_FL_FLAGOS_BLACKLIST=count_nonzero,index_put_,_index_put_impl,_index_put_impl_ \
+    SGLANG_FL_DIST_BACKEND=flagcx \
+    FLAGCX_PATH=/mine/FlagCX_v0.13.0 \
+    SGLANG_FL_COMM_STRICT=1 \
+    SGLANG_FL_COMM_DEBUG=1 \
+    SGLANG_FL_FLAGOS_BLACKLIST=count_nonzero \
     SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0 \
     GLOO_SOCKET_IFNAME=eth0 NCCL_SOCKET_IFNAME=eth0 \
         python examples/qwen3_6_35b_a3b_multinode.py --role worker --master-addr 192.168.0.66 --tp 2 --pp 2
@@ -42,8 +50,10 @@ Environment variables:
   CUDA_VISIBLE_DEVICES  GPU selection (e.g. 0,1)
   GLOO_SOCKET_IFNAME    Network interface for Gloo (default: eth0)
   NCCL_SOCKET_IFNAME    Network interface for NCCL (default: eth0)
-  NCCL_IB_DISABLE       Set to 1 to disable InfiniBand
-  NCCL_NET              Set to "Socket" to force TCP transport
+  SGLANG_FL_DIST_BACKEND  Communication backend (flagcx / nccl)
+  FLAGCX_PATH           Path to FlagCX installation
+  SGLANG_FL_COMM_STRICT   Enable GPU comm leak detection (1/0)
+  SGLANG_FL_COMM_DEBUG    Enable comm debug logging (1/0)
   SGLANG_FL_FLAGOS_BLACKLIST         Ops to exclude from FlagGems
   SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK  Set to 0 to skip memory check
 
@@ -110,6 +120,18 @@ def parse_args():
         default=600,
         help="Max seconds to wait for server ready (master only)",
     )
+    parser.add_argument(
+        "--text-concurrency",
+        type=int,
+        default=32,
+        help="Number of concurrent text requests for high-concurrency test",
+    )
+    parser.add_argument(
+        "--vl-concurrency",
+        type=int,
+        default=8,
+        help="Number of concurrent VL requests for high-concurrency test",
+    )
     return parser.parse_args()
 
 
@@ -134,7 +156,9 @@ def wait_for_server(port: int, timeout: int) -> bool:
     return False
 
 
-def chat_request(port: int, prompt: str, max_tokens: int = 32) -> str:
+def chat_request(
+    port: int, prompt: str, max_tokens: int = 32, timeout: int = 300
+) -> str:
     """Send a text chat completion request."""
     url = f"http://localhost:{port}/v1/chat/completions"
     payload = {
@@ -149,14 +173,16 @@ def chat_request(port: int, prompt: str, max_tokens: int = 32) -> str:
         req = urllib.request.Request(
             url, data=data, headers={"Content-Type": "application/json"}
         )
-        with urllib.request.urlopen(req, timeout=120) as resp:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             result = json.loads(resp.read())
             return result["choices"][0]["message"]["content"]
     except Exception as e:
         return f"ERROR: {e}"
 
 
-def vl_request(port: int, img_path: Path, question: str, max_tokens: int = 16) -> str:
+def vl_request(
+    port: int, img_path: Path, question: str, max_tokens: int = 16, timeout: int = 300
+) -> str:
     """Send a vision-language chat request with a base64-encoded image."""
     url = f"http://localhost:{port}/v1/chat/completions"
     mime = "image/png" if img_path.suffix == ".png" else "image/jpeg"
@@ -184,7 +210,7 @@ def vl_request(port: int, img_path: Path, question: str, max_tokens: int = 16) -
         req = urllib.request.Request(
             url, data=data, headers={"Content-Type": "application/json"}
         )
-        with urllib.request.urlopen(req, timeout=120) as resp:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             result = json.loads(resp.read())
             return result["choices"][0]["message"]["content"]
     except Exception as e:
@@ -223,12 +249,18 @@ class TestRunner:
         return self.failed == 0
 
 
-def run_tests(port: int, tp_size: int, nnodes: int) -> bool:
+def run_tests(
+    port: int,
+    tp_size: int,
+    nnodes: int,
+    text_concurrency: int = 32,
+    vl_concurrency: int = 8,
+) -> bool:
     """Run all verification tests. Returns True if all passed."""
     t = TestRunner()
 
-    # Test 1: Text Inference
-    print("\n=== Test 1: Text Inference ===")
+    # Test 1: Text Inference (Sequential)
+    print("\n=== Test 1: Text Inference (Sequential) ===")
     r = chat_request(
         port,
         "How many states are there in the United States? Answer with just the number.",
@@ -252,8 +284,9 @@ def run_tests(port: int, tp_size: int, nnodes: int) -> bool:
     t.check("Contains '2'", "2", r)
     t.check("Contains '7'", "7", r)
 
-    # Test 3: Concurrent Requests
-    print("\n=== Test 3: Concurrent Requests ===")
+    # Test 3: Concurrent Text x4
+    print("\n=== Test 3: Concurrent Text x4 ===")
+    t0 = time.time()
     with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
         futures = {}
         for i in range(1, 5):
@@ -266,20 +299,58 @@ def run_tests(port: int, tp_size: int, nnodes: int) -> bool:
         for i in range(1, 5):
             r = futures[i].result()
             expected = str(i + i)
-            if expected not in r:
+            ok = expected in r
+            print(f"  {'PASS' if ok else 'FAIL'}: {i}+{i}={expected} -> {r}")
+            if not ok:
                 all_ok = False
-                print(f"  FAIL: {i}+{i} expected {expected}, got: {r}")
 
     t.total += 1
     if all_ok:
-        print("  PASS: All 4 concurrent requests correct")
         t.passed += 1
     else:
-        print("  FAIL: Some concurrent requests failed")
         t.failed += 1
+    print(f"  Time: {time.time() - t0:.1f}s")
 
-    # Test 4: Multimodal (VL)
-    print("\n=== Test 4: Multimodal (Vision-Language) ===")
+    # Test 4: High-Concurrency Text
+    print(f"\n=== Test 4: High-Concurrency Text x{text_concurrency} ===")
+    t0 = time.time()
+    ok_count = 0
+    fail_count = 0
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=text_concurrency
+    ) as executor:
+        futures = {}
+        for i in range(text_concurrency):
+            a, b = i + 1, i + 2
+            f = executor.submit(
+                chat_request, port, f"What is {a}+{b}? Answer with just the number.", 10
+            )
+            futures[i] = (a, b, f)
+
+        for i, (a, b, f) in futures.items():
+            try:
+                r = f.result(timeout=300)
+                expected = str(a + b)
+                if expected in r:
+                    ok_count += 1
+                else:
+                    fail_count += 1
+                    print(f"  FAIL: {a}+{b}={expected} -> {r}")
+            except Exception as e:
+                fail_count += 1
+                print(f"  FAIL: {a}+{b} -> ERROR: {e}")
+
+    t.total += 1
+    if fail_count == 0:
+        print(f"  PASS: {ok_count}/{text_concurrency} correct")
+        t.passed += 1
+    else:
+        print(f"  FAIL: {ok_count}/{text_concurrency} correct, {fail_count} failed")
+        t.failed += 1
+    print(f"  Time: {time.time() - t0:.1f}s")
+
+    # Test 5: Multimodal (VL) Sequential
+    print("\n=== Test 5: Multimodal (VL) Sequential ===")
     if IMG_DIR.is_dir():
         r = vl_request(
             port,
@@ -310,6 +381,53 @@ def run_tests(port: int, tp_size: int, nnodes: int) -> bool:
     else:
         print(f"  SKIP: test_images directory not found at {IMG_DIR}")
 
+    # Test 6: High-Concurrency VL
+    if IMG_DIR.is_dir() and vl_concurrency > 1:
+        print(f"\n=== Test 6: High-Concurrency VL x{vl_concurrency} ===")
+        vl_cases = [
+            (IMG_DIR / "red_square.jpg", "What color is this? One word.", "red"),
+            (IMG_DIR / "cat.jpg", "What animal? One word.", "cat"),
+            (IMG_DIR / "digit_seven.png", "What digit? Just the number.", "7"),
+            (IMG_DIR / "stop_sign.png", "What does this sign say? One word.", "stop"),
+        ]
+        # Cycle through images
+        all_cases = (vl_cases * ((vl_concurrency // len(vl_cases)) + 1))[
+            :vl_concurrency
+        ]
+        t0 = time.time()
+        ok_count = 0
+        fail_count = 0
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=vl_concurrency
+        ) as executor:
+            futures = {}
+            for i, (img, q, exp) in enumerate(all_cases):
+                futures[i] = (
+                    img.name,
+                    exp,
+                    executor.submit(vl_request, port, img, q, 10),
+                )
+            for i, (name, expected, f) in futures.items():
+                try:
+                    r = f.result(timeout=300)
+                    if expected.lower() in r.lower():
+                        ok_count += 1
+                    else:
+                        fail_count += 1
+                        print(f"  FAIL: {name} -> {r}")
+                except Exception as e:
+                    fail_count += 1
+                    print(f"  FAIL: {name} -> ERROR: {e}")
+
+        t.total += 1
+        if fail_count == 0:
+            print(f"  PASS: {ok_count}/{vl_concurrency} correct")
+            t.passed += 1
+        else:
+            print(f"  FAIL: {ok_count}/{vl_concurrency} correct, {fail_count} failed")
+            t.failed += 1
+        print(f"  Time: {time.time() - t0:.1f}s")
+
     return t.summary(tp_size, nnodes)
 
 
@@ -327,6 +445,9 @@ def run_master(args):
     print(f"  TP:     {args.tp}    PP: {args.pp}    Nodes: {args.nnodes}")
     print(f"  Master: {args.master_addr}  dist={args.dist_port}  nccl={args.nccl_port}")
     print(f"  API:    http://localhost:{args.port}")
+    print(
+        f"  Text concurrency: {args.text_concurrency}  VL concurrency: {args.vl_concurrency}"
+    )
     print("=" * 56)
 
     cmd = [
@@ -379,7 +500,13 @@ def run_master(args):
             sys.exit(1)
         print("\nServer ready!")
 
-        success = run_tests(args.port, args.tp, args.nnodes)
+        success = run_tests(
+            args.port,
+            args.tp,
+            args.nnodes,
+            text_concurrency=args.text_concurrency,
+            vl_concurrency=args.vl_concurrency,
+        )
         cleanup()
         sys.exit(0 if success else 1)
 

--- a/sglang_fl/__init__.py
+++ b/sglang_fl/__init__.py
@@ -417,78 +417,6 @@ def _setup_flaggems(config: dict = None):
                 h.addFilter(_AtenOnlyFilter())
 
 
-# ─── Strict mode: detect any torch.distributed GPU comm bypassing FlagCX ─────
-
-
-def _install_dist_traps():
-    """Monkey-patch torch.distributed GPU comm functions to detect leaks.
-
-    When SGLANG_FL_COMM_STRICT=1 and backend=flagcx, any call to
-    torch.distributed collective ops on a GPU (non-Gloo) group
-    will log a warning with a traceback, proving the call bypassed FlagCX.
-
-    CPU group (Gloo) calls are allowed — those are for metadata/object comm.
-
-    NOTE: This is a temporary verification tool. Remove after cross-machine
-    validation is complete. (TODO: delete _install_dist_traps)
-    """
-    import traceback
-
-    import torch.distributed as dist
-
-    # Gloo groups are safe (CPU metadata comm) — only trap NCCL/device groups
-    def _is_gpu_group(group):
-        if group is None:
-            return True  # default group is usually NCCL
-        try:
-            backend = dist.get_backend(group)
-            return backend != "gloo"
-        except Exception:
-            return True  # assume GPU if we can't tell
-
-    _trapped_fns = {}
-
-    def _make_trap(fn_name, original_fn):
-        def _trap(*args, **kwargs):
-            group = kwargs.get("group", None)
-            # For positional: all_reduce(tensor, op, group), broadcast(tensor, src, group)
-            # Try to extract group from common positional patterns
-            if group is None and len(args) >= 3:
-                candidate = args[2] if fn_name in ("send", "recv") else args[-1]
-                if isinstance(candidate, dist.ProcessGroup):
-                    group = candidate
-            if _is_gpu_group(group):
-                stack = "".join(traceback.format_stack(limit=8))
-                msg = (
-                    f"[COMM LEAK] torch.distributed.{fn_name}() called on GPU group! "
-                    f"This should go through FlagCX.\n{stack}"
-                )
-                os.write(2, msg.encode())
-            return original_fn(*args, **kwargs)
-
-        return _trap
-
-    for fn_name in [
-        "all_reduce",
-        "broadcast",
-        "send",
-        "recv",
-        "isend",
-        "irecv",
-        "reduce_scatter_tensor",
-        "all_gather_into_tensor",
-        "all_to_all",
-        "all_to_all_single",
-        "gather",
-    ]:
-        original = getattr(dist, fn_name, None)
-        if original is not None:
-            _trapped_fns[fn_name] = original
-            setattr(dist, fn_name, _make_trap(fn_name, original))
-
-    os.write(2, b"[COMM STRICT] torch.distributed GPU comm traps installed\n")
-
-
 # ─── Communicator AROUND hooks ────────────────────────────────────────────────
 
 
@@ -508,13 +436,6 @@ def _setup_communicator_hooks():
     from sglang.srt.plugins.hook_registry import HookRegistry, HookType
 
     _GC_TARGET = "sglang.srt.distributed.parallel_state.GroupCoordinator"
-
-    _COMM_DEBUG = os.environ.get("SGLANG_FL_COMM_DEBUG", "0") == "1"
-
-    def _comm_log(msg):
-        """Write debug message directly to fd 2 (stderr), bypassing Python logging/buffering."""
-        if _COMM_DEBUG:
-            os.write(2, f"[pid={os.getpid()}] {msg}\n".encode())
 
     # ── __init__ hook: create and attach CommunicatorFL ──
 
@@ -542,11 +463,6 @@ def _setup_communicator_hooks():
                     and self.pynccl_comm is not None
                 ):
                     self.pynccl_comm.disabled = True
-                    if _COMM_DEBUG:
-                        _comm_log(
-                            f"[Layer3] PyNccl disabled on rank={self.rank_in_group}, "
-                            f"all comm routed through FlagCX"
-                        )
             except Exception as e:
                 logger.warning(f"CommunicatorFL creation failed: {e}")
                 self.fl_communicator = None
@@ -558,8 +474,6 @@ def _setup_communicator_hooks():
     def _all_reduce_hook(original_fn, self, input_):
         comm = getattr(self, "fl_communicator", None)
         if comm is not None and not comm.disabled:
-            if _COMM_DEBUG:
-                _comm_log(f"[FlagCX] all_reduce: shape={input_.shape}")
             return comm.all_reduce(input_)
         return original_fn(self, input_)
 
@@ -568,8 +482,6 @@ def _setup_communicator_hooks():
     def _reduce_scatter_tensor_hook(original_fn, self, output, input_):
         comm = getattr(self, "fl_communicator", None)
         if comm is not None and not comm.disabled:
-            if _COMM_DEBUG:
-                _comm_log(f"[FlagCX] reduce_scatter: shape={input_.shape}")
             comm.reduce_scatter(output, input_)
             return
         return original_fn(self, output, input_)
@@ -579,8 +491,6 @@ def _setup_communicator_hooks():
     def _all_gather_into_tensor_hook(original_fn, self, output, input_):
         comm = getattr(self, "fl_communicator", None)
         if comm is not None and not comm.disabled:
-            if _COMM_DEBUG:
-                _comm_log(f"[FlagCX] all_gather: shape={input_.shape}")
             comm.all_gather(output, input_)
             return
         return original_fn(self, output, input_)
@@ -590,8 +500,6 @@ def _setup_communicator_hooks():
     def _reduce_scatterv_hook(original_fn, self, input_, output=None, sizes=None):
         comm = getattr(self, "fl_communicator", None)
         if comm is not None and not comm.disabled:
-            if _COMM_DEBUG:
-                _comm_log(f"[FlagCX] reduce_scatterv: shape={input_.shape}")
             return comm.reduce_scatterv(input_, output=output, sizes=sizes)
         return original_fn(self, input_, output=output, sizes=sizes)
 
@@ -600,8 +508,6 @@ def _setup_communicator_hooks():
     def _all_gatherv_hook(original_fn, self, input_, sizes=None):
         comm = getattr(self, "fl_communicator", None)
         if comm is not None and not comm.disabled:
-            if _COMM_DEBUG:
-                _comm_log(f"[FlagCX] all_gatherv: sizes={sizes}")
             return comm.all_gatherv(input_, sizes=sizes)
         return original_fn(self, input_, sizes=sizes)
 
@@ -612,8 +518,6 @@ def _setup_communicator_hooks():
         if comm is not None and not comm.disabled:
             if dst is None:
                 dst = (self.rank_in_group + 1) % self.world_size
-            if _COMM_DEBUG:
-                _comm_log(f"[FlagCX] send: dst={dst}, shape={tensor.shape}")
             comm.send(tensor, dst)
             return
         return original_fn(self, tensor, dst=dst)
@@ -625,8 +529,6 @@ def _setup_communicator_hooks():
         if comm is not None and not comm.disabled:
             if src is None:
                 src = (self.rank_in_group - 1) % self.world_size
-            if _COMM_DEBUG:
-                _comm_log(f"[FlagCX] recv: src={src}, size={size}")
             tensor = torch.empty(size, dtype=dtype, device=self.device)
             comm.recv(tensor, src)
             return tensor
@@ -637,8 +539,6 @@ def _setup_communicator_hooks():
     def _broadcast_hook(original_fn, self, input_, src=0):
         comm = getattr(self, "fl_communicator", None)
         if comm is not None and not comm.disabled:
-            if _COMM_DEBUG:
-                _comm_log(f"[FlagCX] broadcast: src={src}, shape={input_.shape}")
             return comm.broadcast(input_, src)
         return original_fn(self, input_, src)
 
@@ -651,8 +551,6 @@ def _setup_communicator_hooks():
         if comm is not None and not comm.disabled:
             if not torch.distributed.is_initialized() or self.world_size == 1:
                 return tensor_dict
-            if _COMM_DEBUG:
-                _comm_log(f"[FlagCX] broadcast_tensor_dict: src={src}")
             return comm.broadcast_tensor_dict(
                 tensor_dict=tensor_dict,
                 src=src,
@@ -683,8 +581,6 @@ def _setup_communicator_hooks():
                 return tensor_dict
             if dst is None:
                 dst = (self.rank_in_group + 1) % self.world_size
-            if _COMM_DEBUG:
-                _comm_log(f"[FlagCX] send_tensor_dict: dst={dst}")
             return comm.send_tensor_dict(
                 tensor_dict=tensor_dict,
                 dst=dst,
@@ -713,8 +609,6 @@ def _setup_communicator_hooks():
                 return None
             if src is None:
                 src = (self.rank_in_group - 1) % self.world_size
-            if _COMM_DEBUG:
-                _comm_log(f"[FlagCX] recv_tensor_dict: src={src}")
             return comm.recv_tensor_dict(
                 src=src,
                 recv_object_fn=self.recv_object,
@@ -761,11 +655,6 @@ def _setup_communicator_hooks():
         "CommunicatorFL AROUND hooks registered on GroupCoordinator "
         "(12 hooks: init + 8 collectives + broadcast_tensor_dict + send/recv_tensor_dict)"
     )
-
-    # ── Strict mode: trap any torch.distributed GPU comm that bypasses FlagCX ──
-    _COMM_STRICT = os.environ.get("SGLANG_FL_COMM_STRICT", "0") == "1"
-    if _COMM_STRICT and os.environ.get("SGLANG_FL_DIST_BACKEND", "") == "flagcx":
-        _install_dist_traps()
 
 
 # ─── Platform Plugin entry point ─────────────────────────────────────────────

--- a/sglang_fl/__init__.py
+++ b/sglang_fl/__init__.py
@@ -417,6 +417,78 @@ def _setup_flaggems(config: dict = None):
                 h.addFilter(_AtenOnlyFilter())
 
 
+# ─── Strict mode: detect any torch.distributed GPU comm bypassing FlagCX ─────
+
+
+def _install_dist_traps():
+    """Monkey-patch torch.distributed GPU comm functions to detect leaks.
+
+    When SGLANG_FL_COMM_STRICT=1 and backend=flagcx, any call to
+    torch.distributed collective ops on a GPU (non-Gloo) group
+    will log a warning with a traceback, proving the call bypassed FlagCX.
+
+    CPU group (Gloo) calls are allowed — those are for metadata/object comm.
+
+    NOTE: This is a temporary verification tool. Remove after cross-machine
+    validation is complete. (TODO: delete _install_dist_traps)
+    """
+    import traceback
+
+    import torch.distributed as dist
+
+    # Gloo groups are safe (CPU metadata comm) — only trap NCCL/device groups
+    def _is_gpu_group(group):
+        if group is None:
+            return True  # default group is usually NCCL
+        try:
+            backend = dist.get_backend(group)
+            return backend != "gloo"
+        except Exception:
+            return True  # assume GPU if we can't tell
+
+    _trapped_fns = {}
+
+    def _make_trap(fn_name, original_fn):
+        def _trap(*args, **kwargs):
+            group = kwargs.get("group", None)
+            # For positional: all_reduce(tensor, op, group), broadcast(tensor, src, group)
+            # Try to extract group from common positional patterns
+            if group is None and len(args) >= 3:
+                candidate = args[2] if fn_name in ("send", "recv") else args[-1]
+                if isinstance(candidate, dist.ProcessGroup):
+                    group = candidate
+            if _is_gpu_group(group):
+                stack = "".join(traceback.format_stack(limit=8))
+                msg = (
+                    f"[COMM LEAK] torch.distributed.{fn_name}() called on GPU group! "
+                    f"This should go through FlagCX.\n{stack}"
+                )
+                os.write(2, msg.encode())
+            return original_fn(*args, **kwargs)
+
+        return _trap
+
+    for fn_name in [
+        "all_reduce",
+        "broadcast",
+        "send",
+        "recv",
+        "isend",
+        "irecv",
+        "reduce_scatter_tensor",
+        "all_gather_into_tensor",
+        "all_to_all",
+        "all_to_all_single",
+        "gather",
+    ]:
+        original = getattr(dist, fn_name, None)
+        if original is not None:
+            _trapped_fns[fn_name] = original
+            setattr(dist, fn_name, _make_trap(fn_name, original))
+
+    os.write(2, b"[COMM STRICT] torch.distributed GPU comm traps installed\n")
+
+
 # ─── Communicator AROUND hooks ────────────────────────────────────────────────
 
 
@@ -426,14 +498,23 @@ def _setup_communicator_hooks():
     Auto-activates when the Platform Plugin is OOT. The CommunicatorFL
     transparently routes through FlagCX (if available) or torch.distributed.
 
-    Hooks:
-      - __init__: inject self.fl_communicator after original init
-      - all_reduce, reduce_scatter_tensor, all_gather_into_tensor,
-        reduce_scatterv, all_gatherv, send, recv: delegate to fl_communicator
+    Hooks (12 total):
+      - __init__: inject self.fl_communicator, suppress PyNccl when FlagCX active
+      - all_reduce, _reduce_scatter_tensor, _all_gather_into_tensor,
+        reduce_scatterv, all_gatherv, send, recv, broadcast: delegate to fl_communicator
+      - broadcast_tensor_dict, send_tensor_dict, recv_tensor_dict:
+        full method intercept for FlagCX coverage on composite operations
     """
     from sglang.srt.plugins.hook_registry import HookRegistry, HookType
 
     _GC_TARGET = "sglang.srt.distributed.parallel_state.GroupCoordinator"
+
+    _COMM_DEBUG = os.environ.get("SGLANG_FL_COMM_DEBUG", "0") == "1"
+
+    def _comm_log(msg):
+        """Write debug message directly to fd 2 (stderr), bypassing Python logging/buffering."""
+        if _COMM_DEBUG:
+            os.write(2, f"[pid={os.getpid()}] {msg}\n".encode())
 
     # ── __init__ hook: create and attach CommunicatorFL ──
 
@@ -453,6 +534,19 @@ def _setup_communicator_hooks():
                     rank_in_group=self.rank_in_group,
                     ranks=self.ranks,
                 )
+                # Suppress PyNccl when FlagCX is active to avoid conflicts
+                if (
+                    self.fl_communicator
+                    and self.fl_communicator._flagcx_comm
+                    and hasattr(self, "pynccl_comm")
+                    and self.pynccl_comm is not None
+                ):
+                    self.pynccl_comm.disabled = True
+                    if _COMM_DEBUG:
+                        _comm_log(
+                            f"[Layer3] PyNccl disabled on rank={self.rank_in_group}, "
+                            f"all comm routed through FlagCX"
+                        )
             except Exception as e:
                 logger.warning(f"CommunicatorFL creation failed: {e}")
                 self.fl_communicator = None
@@ -464,6 +558,8 @@ def _setup_communicator_hooks():
     def _all_reduce_hook(original_fn, self, input_):
         comm = getattr(self, "fl_communicator", None)
         if comm is not None and not comm.disabled:
+            if _COMM_DEBUG:
+                _comm_log(f"[FlagCX] all_reduce: shape={input_.shape}")
             return comm.all_reduce(input_)
         return original_fn(self, input_)
 
@@ -472,6 +568,8 @@ def _setup_communicator_hooks():
     def _reduce_scatter_tensor_hook(original_fn, self, output, input_):
         comm = getattr(self, "fl_communicator", None)
         if comm is not None and not comm.disabled:
+            if _COMM_DEBUG:
+                _comm_log(f"[FlagCX] reduce_scatter: shape={input_.shape}")
             comm.reduce_scatter(output, input_)
             return
         return original_fn(self, output, input_)
@@ -481,6 +579,8 @@ def _setup_communicator_hooks():
     def _all_gather_into_tensor_hook(original_fn, self, output, input_):
         comm = getattr(self, "fl_communicator", None)
         if comm is not None and not comm.disabled:
+            if _COMM_DEBUG:
+                _comm_log(f"[FlagCX] all_gather: shape={input_.shape}")
             comm.all_gather(output, input_)
             return
         return original_fn(self, output, input_)
@@ -490,6 +590,8 @@ def _setup_communicator_hooks():
     def _reduce_scatterv_hook(original_fn, self, input_, output=None, sizes=None):
         comm = getattr(self, "fl_communicator", None)
         if comm is not None and not comm.disabled:
+            if _COMM_DEBUG:
+                _comm_log(f"[FlagCX] reduce_scatterv: shape={input_.shape}")
             return comm.reduce_scatterv(input_, output=output, sizes=sizes)
         return original_fn(self, input_, output=output, sizes=sizes)
 
@@ -498,6 +600,8 @@ def _setup_communicator_hooks():
     def _all_gatherv_hook(original_fn, self, input_, sizes=None):
         comm = getattr(self, "fl_communicator", None)
         if comm is not None and not comm.disabled:
+            if _COMM_DEBUG:
+                _comm_log(f"[FlagCX] all_gatherv: sizes={sizes}")
             return comm.all_gatherv(input_, sizes=sizes)
         return original_fn(self, input_, sizes=sizes)
 
@@ -508,6 +612,8 @@ def _setup_communicator_hooks():
         if comm is not None and not comm.disabled:
             if dst is None:
                 dst = (self.rank_in_group + 1) % self.world_size
+            if _COMM_DEBUG:
+                _comm_log(f"[FlagCX] send: dst={dst}, shape={tensor.shape}")
             comm.send(tensor, dst)
             return
         return original_fn(self, tensor, dst=dst)
@@ -519,10 +625,102 @@ def _setup_communicator_hooks():
         if comm is not None and not comm.disabled:
             if src is None:
                 src = (self.rank_in_group - 1) % self.world_size
+            if _COMM_DEBUG:
+                _comm_log(f"[FlagCX] recv: src={src}, size={size}")
             tensor = torch.empty(size, dtype=dtype, device=self.device)
             comm.recv(tensor, src)
             return tensor
         return original_fn(self, size, dtype, src=src)
+
+    # ── broadcast hook ──
+
+    def _broadcast_hook(original_fn, self, input_, src=0):
+        comm = getattr(self, "fl_communicator", None)
+        if comm is not None and not comm.disabled:
+            if _COMM_DEBUG:
+                _comm_log(f"[FlagCX] broadcast: src={src}, shape={input_.shape}")
+            return comm.broadcast(input_, src)
+        return original_fn(self, input_, src)
+
+    # ── broadcast_tensor_dict hook ──
+
+    def _broadcast_tensor_dict_hook(
+        original_fn, self, tensor_dict=None, src=0, group=None, metadata_group=None
+    ):
+        comm = getattr(self, "fl_communicator", None)
+        if comm is not None and not comm.disabled:
+            if not torch.distributed.is_initialized() or self.world_size == 1:
+                return tensor_dict
+            if _COMM_DEBUG:
+                _comm_log(f"[FlagCX] broadcast_tensor_dict: src={src}")
+            return comm.broadcast_tensor_dict(
+                tensor_dict=tensor_dict,
+                src=src,
+                rank_in_group=self.rank_in_group,
+                broadcast_object_fn=self.broadcast_object,
+            )
+        return original_fn(
+            self,
+            tensor_dict=tensor_dict,
+            src=src,
+            group=group,
+            metadata_group=metadata_group,
+        )
+
+    # ── send_tensor_dict hook ──
+
+    def _send_tensor_dict_hook(
+        original_fn,
+        self,
+        tensor_dict,
+        dst=None,
+        all_gather_group=None,
+        async_send=False,
+    ):
+        comm = getattr(self, "fl_communicator", None)
+        if comm is not None and not comm.disabled:
+            if self.world_size == 1:
+                return tensor_dict
+            if dst is None:
+                dst = (self.rank_in_group + 1) % self.world_size
+            if _COMM_DEBUG:
+                _comm_log(f"[FlagCX] send_tensor_dict: dst={dst}")
+            return comm.send_tensor_dict(
+                tensor_dict=tensor_dict,
+                dst=dst,
+                send_object_fn=self.send_object,
+                all_gather_group=all_gather_group,
+            )
+        return original_fn(
+            self,
+            tensor_dict,
+            dst=dst,
+            all_gather_group=all_gather_group,
+            async_send=async_send,
+        )
+
+    # ── recv_tensor_dict hook ──
+
+    def _recv_tensor_dict_hook(
+        original_fn,
+        self,
+        src=None,
+        all_gather_group=None,
+    ):
+        comm = getattr(self, "fl_communicator", None)
+        if comm is not None and not comm.disabled:
+            if not torch.distributed.is_initialized() or self.world_size == 1:
+                return None
+            if src is None:
+                src = (self.rank_in_group - 1) % self.world_size
+            if _COMM_DEBUG:
+                _comm_log(f"[FlagCX] recv_tensor_dict: src={src}")
+            return comm.recv_tensor_dict(
+                src=src,
+                recv_object_fn=self.recv_object,
+                all_gather_group=all_gather_group,
+            )
+        return original_fn(self, src=src, all_gather_group=all_gather_group)
 
     # ── Register all hooks ──
 
@@ -546,8 +744,28 @@ def _setup_communicator_hooks():
     )
     HookRegistry.register(f"{_GC_TARGET}.send", _send_hook, HookType.AROUND)
     HookRegistry.register(f"{_GC_TARGET}.recv", _recv_hook, HookType.AROUND)
+    HookRegistry.register(f"{_GC_TARGET}.broadcast", _broadcast_hook, HookType.AROUND)
+    HookRegistry.register(
+        f"{_GC_TARGET}.broadcast_tensor_dict",
+        _broadcast_tensor_dict_hook,
+        HookType.AROUND,
+    )
+    HookRegistry.register(
+        f"{_GC_TARGET}.send_tensor_dict", _send_tensor_dict_hook, HookType.AROUND
+    )
+    HookRegistry.register(
+        f"{_GC_TARGET}.recv_tensor_dict", _recv_tensor_dict_hook, HookType.AROUND
+    )
 
-    logger.info("CommunicatorFL AROUND hooks registered on GroupCoordinator")
+    logger.info(
+        "CommunicatorFL AROUND hooks registered on GroupCoordinator "
+        "(12 hooks: init + 8 collectives + broadcast_tensor_dict + send/recv_tensor_dict)"
+    )
+
+    # ── Strict mode: trap any torch.distributed GPU comm that bypasses FlagCX ──
+    _COMM_STRICT = os.environ.get("SGLANG_FL_COMM_STRICT", "0") == "1"
+    if _COMM_STRICT and os.environ.get("SGLANG_FL_DIST_BACKEND", "") == "flagcx":
+        _install_dist_traps()
 
 
 # ─── Platform Plugin entry point ─────────────────────────────────────────────

--- a/sglang_fl/distributed/communicator.py
+++ b/sglang_fl/distributed/communicator.py
@@ -7,11 +7,14 @@ Adapted from vllm-plugin-FL's CommunicatorFL pattern.
 """
 
 import logging
+from collections import namedtuple
 from typing import List, Optional, Union
 
 import torch
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
+
+TensorMetadata = namedtuple("TensorMetadata", ["device", "dtype", "size"])
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +59,9 @@ class CommunicatorFL:
         self._flagcx_comm = None
         if self._dist_backend == "flagcx" and world_size > 1:
             try:
-                from sglang_fl.distributed.device_communicators.flagcx import FlagCXCommunicator
+                from sglang_fl.distributed.device_communicators.flagcx import (
+                    FlagCXCommunicator,
+                )
 
                 self._flagcx_comm = FlagCXCommunicator(
                     group=cpu_group,
@@ -186,14 +191,10 @@ class CommunicatorFL:
 
         if self._flagcx_comm and not self._flagcx_comm.disabled:
             output_list = []
-            self._flagcx_comm.flagcx.flagcxGroupStart() if hasattr(
-                self._flagcx_comm, "flagcx"
-            ) else None
+            self._flagcx_comm.group_start()
             for inp in input_:
                 output_list.append(_all_gather_single(inp, sizes=sizes))
-            self._flagcx_comm.flagcx.flagcxGroupEnd() if hasattr(
-                self._flagcx_comm, "flagcx"
-            ) else None
+            self._flagcx_comm.group_end()
             return output_list
         else:
             output_list = []
@@ -218,3 +219,256 @@ class CommunicatorFL:
             self._flagcx_comm.recv(tensor, src)
             return
         dist.recv(tensor, self.ranks[src], self.device_group)
+
+    # ─── broadcast ───────────────────────────────────────────────────────────
+
+    def broadcast(self, input_: torch.Tensor, src: int = 0) -> torch.Tensor:
+        """Broadcast tensor from src rank (in-place)."""
+        if self._flagcx_comm and not self._flagcx_comm.disabled:
+            self._flagcx_comm.broadcast(input_, src)
+            return input_
+        dist.broadcast(input_, src=self.ranks[src], group=self.device_group)
+        return input_
+
+    # ─── broadcast_tensor_dict ───────────────────────────────────────────────
+
+    def broadcast_tensor_dict(
+        self,
+        tensor_dict,
+        src: int,
+        rank_in_group: int,
+        broadcast_object_fn,
+    ):
+        """Broadcast a tensor dict. GPU tensors go via FlagCX, metadata via CPU.
+
+        Args:
+            tensor_dict: Dict to broadcast (only valid on src rank).
+            src: Source rank (local rank in group).
+            rank_in_group: This rank's position in the group.
+            broadcast_object_fn: Callable to broadcast Python objects (CPU group).
+        """
+        if rank_in_group == src:
+            # Sender: split dict into metadata + tensors, broadcast metadata
+            metadata_list = []
+            tensor_list = []
+            for key, value in tensor_dict.items():
+                if isinstance(value, torch.Tensor):
+                    metadata_list.append(
+                        (
+                            key,
+                            TensorMetadata(
+                                value.device.type, value.dtype, value.size()
+                            ),
+                        )
+                    )
+                    tensor_list.append(value)
+                else:
+                    metadata_list.append((key, value))
+
+            broadcast_object_fn(metadata_list, src=src)
+
+            # Broadcast each tensor via FlagCX
+            if self._flagcx_comm and not self._flagcx_comm.disabled:
+                for tensor in tensor_list:
+                    if tensor.numel() == 0:
+                        continue
+                    if not tensor.is_cpu:
+                        self._flagcx_comm.broadcast(tensor, src)
+                    else:
+                        dist.broadcast(
+                            tensor, src=self.ranks[src], group=self.cpu_group
+                        )
+            else:
+                for tensor in tensor_list:
+                    if tensor.numel() == 0:
+                        continue
+                    if tensor.is_cpu:
+                        dist.broadcast(
+                            tensor, src=self.ranks[src], group=self.cpu_group
+                        )
+                    else:
+                        dist.broadcast(
+                            tensor, src=self.ranks[src], group=self.device_group
+                        )
+            return tensor_dict
+        else:
+            # Receiver: get metadata, allocate tensors, receive broadcasts
+            metadata_list = broadcast_object_fn(None, src=src)
+            tensor_dict = {}
+
+            gpu_tensors = []
+            for key, value in metadata_list:
+                if isinstance(value, TensorMetadata):
+                    tensor = torch.empty(
+                        value.size, dtype=value.dtype, device=value.device
+                    )
+                    tensor_dict[key] = tensor
+                    if tensor.numel() == 0:
+                        continue
+                    gpu_tensors.append((tensor, value.device != "cpu"))
+                else:
+                    tensor_dict[key] = value
+
+            if self._flagcx_comm and not self._flagcx_comm.disabled:
+                for tensor, is_gpu in gpu_tensors:
+                    if is_gpu:
+                        self._flagcx_comm.broadcast(tensor, src)
+                    else:
+                        dist.broadcast(
+                            tensor, src=self.ranks[src], group=self.cpu_group
+                        )
+            else:
+                for tensor, is_gpu in gpu_tensors:
+                    if is_gpu:
+                        dist.broadcast(
+                            tensor, src=self.ranks[src], group=self.device_group
+                        )
+                    else:
+                        dist.broadcast(
+                            tensor, src=self.ranks[src], group=self.cpu_group
+                        )
+            return tensor_dict
+
+    # ─── send_tensor_dict ────────────────────────────────────────────────────
+
+    def send_tensor_dict(
+        self,
+        tensor_dict,
+        dst: int,
+        send_object_fn,
+        all_gather_group=None,
+    ):
+        """Send a tensor dict. GPU tensors go via FlagCX, metadata via CPU.
+
+        Args:
+            tensor_dict: Dict of tensors/values to send.
+            dst: Destination rank (local rank in group).
+            send_object_fn: Callable to send Python objects (CPU group).
+            all_gather_group: Optional group for send-allgather optimization.
+        """
+        all_gather_size = 1 if all_gather_group is None else all_gather_group.world_size
+        all_gather_rank = (
+            0 if all_gather_group is None else all_gather_group.rank_in_group
+        )
+
+        metadata_list = []
+        tensor_list = []
+        for key, value in tensor_dict.items():
+            if isinstance(value, torch.Tensor):
+                metadata_list.append(
+                    (key, TensorMetadata(value.device.type, value.dtype, value.size()))
+                )
+                tensor_list.append(value)
+            else:
+                metadata_list.append((key, value))
+
+        # Use async_send=True to avoid deadlock: in PP mode both ranks may
+        # call send_tensor_dict before either calls recv_tensor_dict.
+        # Synchronous Gloo send would block waiting for a matching recv.
+        p2p_works = send_object_fn(metadata_list, dst=dst, async_send=True)
+
+        if self._flagcx_comm and not self._flagcx_comm.disabled:
+            for tensor in tensor_list:
+                if tensor.numel() == 0:
+                    continue
+                t = tensor
+                if (
+                    all_gather_group is not None
+                    and tensor.numel() % all_gather_size == 0
+                ):
+                    t = tensor.reshape(all_gather_size, -1)[all_gather_rank]
+                if not t.is_cpu:
+                    self._flagcx_comm.send(t, dst)
+                else:
+                    dist.send(t, self.ranks[dst], self.cpu_group)
+        else:
+            for tensor in tensor_list:
+                if tensor.numel() == 0:
+                    continue
+                t = tensor
+                if (
+                    all_gather_group is not None
+                    and tensor.numel() % all_gather_size == 0
+                ):
+                    t = tensor.reshape(all_gather_size, -1)[all_gather_rank]
+                if t.is_cpu:
+                    dist.send(t, self.ranks[dst], self.cpu_group)
+                else:
+                    dist.send(t, self.ranks[dst], self.device_group)
+
+        # Return metadata p2p_works so PP mixin can manage their lifecycle.
+        # Do NOT wait here — the peer may not have posted recv yet (PP sends
+        # before recv, so waiting would deadlock on Gloo isend).
+        return p2p_works if p2p_works else []
+
+    # ─── recv_tensor_dict ────────────────────────────────────────────────────
+
+    def recv_tensor_dict(
+        self,
+        src: int,
+        recv_object_fn,
+        all_gather_group=None,
+    ):
+        """Receive a tensor dict. GPU tensors come via FlagCX, metadata via CPU.
+
+        Args:
+            src: Source rank (local rank in group).
+            recv_object_fn: Callable to receive Python objects (CPU group).
+            all_gather_group: Optional group for send-allgather optimization.
+        """
+        all_gather_size = 1 if all_gather_group is None else all_gather_group.world_size
+        all_gather_rank = (
+            0 if all_gather_group is None else all_gather_group.rank_in_group
+        )
+
+        recv_metadata_list = recv_object_fn(src=src)
+        tensor_dict = {}
+
+        recv_ops = []  # (key, tensor, is_gpu, use_all_gather, orig_shape)
+        for key, value in recv_metadata_list:
+            if isinstance(value, TensorMetadata):
+                tensor = torch.empty(value.size, dtype=value.dtype, device=value.device)
+                if tensor.numel() == 0:
+                    tensor_dict[key] = tensor
+                    continue
+
+                use_all_gather = (
+                    all_gather_group is not None
+                    and tensor.numel() % all_gather_size == 0
+                )
+                orig_shape = tensor.shape
+                if use_all_gather:
+                    tensor = tensor.reshape(all_gather_size, -1)[all_gather_rank]
+
+                is_gpu = not tensor.is_cpu
+                recv_ops.append((key, tensor, is_gpu, use_all_gather, orig_shape))
+            else:
+                tensor_dict[key] = value
+
+        if self._flagcx_comm and not self._flagcx_comm.disabled:
+            for key, tensor, is_gpu, use_all_gather, orig_shape in recv_ops:
+                if is_gpu:
+                    self._flagcx_comm.recv(tensor, src)
+                else:
+                    dist.recv(tensor, self.ranks[src], self.cpu_group)
+        else:
+            for key, tensor, is_gpu, use_all_gather, orig_shape in recv_ops:
+                if is_gpu:
+                    work = dist.irecv(tensor, self.ranks[src], self.device_group)
+                    work.wait()
+                else:
+                    work = dist.irecv(tensor, self.ranks[src], self.cpu_group)
+                    work.wait()
+
+        for key, tensor, is_gpu, use_all_gather, orig_shape in recv_ops:
+            if use_all_gather:
+                # all_gather on the TP group (not PP group) — use the hooked
+                # GroupCoordinator._all_gather_into_tensor via all_gather_group
+                full_tensor = torch.empty(
+                    orig_shape, dtype=tensor.dtype, device=tensor.device
+                )
+                all_gather_group._all_gather_into_tensor(full_tensor, tensor)
+                tensor = full_tensor
+            tensor_dict[key] = tensor
+
+        return tensor_dict

--- a/sglang_fl/distributed/communicator.py
+++ b/sglang_fl/distributed/communicator.py
@@ -3,7 +3,13 @@
 Wraps FlagCX (when available) or falls back to torch.distributed.
 Created per GroupCoordinator via AROUND hook on __init__.
 
-Adapted from vllm-plugin-FL's CommunicatorFL pattern.
+Why AROUND hooks instead of injecting flagcx as torch.distributed backend:
+  vLLM lets plugins override platform.dist_backend → passed to init_process_group.
+  SGLang SRT picks backend from a hardcoded dict in parallel_state.py (cuda→nccl);
+  model_runner.py calls get_default_distributed_backend(device) — a plain dict lookup
+  that never consults the platform interface. device_mixin.py defines
+  get_torch_distributed_backend_str() as [Planned] and the SRT path does not call it.
+  So we hook communication methods at the application layer instead.
 """
 
 import logging

--- a/sglang_fl/distributed/device_communicators/flagcx.py
+++ b/sglang_fl/distributed/device_communicators/flagcx.py
@@ -334,10 +334,6 @@ class FlagCXCommunicator:
         assert tensor.device == self.device, (
             f"FlagCX communicator on {self.device}, but tensor on {tensor.device}"
         )
-        os.write(
-            2,
-            f"[FlagCX P2P] send start: rank={self.rank}->dst={dst}, shape={tensor.shape}, numel={tensor.numel()}\n".encode(),
-        )
         flagcx_stream = self._get_stream()
         self.flagcx.flagcxSend(
             self._buffer_type(tensor.data_ptr()),
@@ -348,7 +344,6 @@ class FlagCXCommunicator:
             flagcx_stream,
         )
         self._free_stream(flagcx_stream)
-        os.write(2, f"[FlagCX P2P] send done: rank={self.rank}->dst={dst}\n".encode())
 
     def recv(self, tensor: torch.Tensor, src: int):
         """Receive tensor from source rank using FlagCX."""
@@ -357,10 +352,6 @@ class FlagCXCommunicator:
 
         assert tensor.device == self.device, (
             f"FlagCX communicator on {self.device}, but tensor on {tensor.device}"
-        )
-        os.write(
-            2,
-            f"[FlagCX P2P] recv start: src={src}->rank={self.rank}, shape={tensor.shape}, numel={tensor.numel()}\n".encode(),
         )
         flagcx_stream = self._get_stream()
         self.flagcx.flagcxRecv(
@@ -372,7 +363,6 @@ class FlagCXCommunicator:
             flagcx_stream,
         )
         self._free_stream(flagcx_stream)
-        os.write(2, f"[FlagCX P2P] recv done: src={src}->rank={self.rank}\n".encode())
 
     def group_start(self):
         """Start a group of collective operations."""

--- a/sglang_fl/distributed/device_communicators/flagcx.py
+++ b/sglang_fl/distributed/device_communicators/flagcx.py
@@ -16,6 +16,7 @@ Usage:
       python -m sglang.launch_server --tp 2 ...
 """
 
+import contextlib
 import ctypes
 import logging
 import os
@@ -132,7 +133,13 @@ class FlagCXCommunicator:
         self.device = device
 
         # Initialize FlagCX communicator
-        device_ctx = torch.cuda.device(self.device)
+        device_str = str(self.device)
+        if "musa" in device_str:
+            device_ctx = torch.musa.device(self.device)
+        elif "npu" in device_str:
+            device_ctx = contextlib.nullcontext()
+        else:
+            device_ctx = torch.cuda.device(self.device)
         with device_ctx:
             self.comm = self.flagcx.flagcxCommInitRank(
                 self.world_size, ctypes.byref(self.unique_id), self.rank
@@ -243,7 +250,7 @@ class FlagCXCommunicator:
             f"FlagCX communicator on {self.device}, but tensor on {input_.device}"
         )
         flagcx_stream = self._get_stream()
-        self.flagcx.flagcxGroupStart()
+        self.flagcx.flagcxGroupStart(self.comm)
         split_offset = 0
         for root, split_size in enumerate(sizes):
             chunk = input_[split_offset : split_offset + split_size, ...]
@@ -258,7 +265,7 @@ class FlagCXCommunicator:
                 flagcx_stream,
             )
             split_offset += split_size
-        self.flagcx.flagcxGroupEnd()
+        self.flagcx.flagcxGroupEnd(self.comm)
         self._free_stream(flagcx_stream)
 
     def all_gatherv(
@@ -276,7 +283,7 @@ class FlagCXCommunicator:
         )
         assert output.shape[0] == sum(sizes)
         flagcx_stream = self._get_stream()
-        self.flagcx.flagcxGroupStart()
+        self.flagcx.flagcxGroupStart(self.comm)
         split_offset = 0
         for root, split_size in enumerate(sizes):
             dst_slice = output[split_offset : split_offset + split_size]
@@ -290,7 +297,7 @@ class FlagCXCommunicator:
                 flagcx_stream,
             )
             split_offset += split_size
-        self.flagcx.flagcxGroupEnd()
+        self.flagcx.flagcxGroupEnd(self.comm)
         self._free_stream(flagcx_stream)
 
     def broadcast(self, tensor: torch.Tensor, src: int):
@@ -319,13 +326,72 @@ class FlagCXCommunicator:
         )
         self._free_stream(flagcx_stream)
 
+    def send(self, tensor: torch.Tensor, dst: int):
+        """Send tensor to destination rank using FlagCX."""
+        if self.disabled:
+            return
+
+        assert tensor.device == self.device, (
+            f"FlagCX communicator on {self.device}, but tensor on {tensor.device}"
+        )
+        os.write(
+            2,
+            f"[FlagCX P2P] send start: rank={self.rank}->dst={dst}, shape={tensor.shape}, numel={tensor.numel()}\n".encode(),
+        )
+        flagcx_stream = self._get_stream()
+        self.flagcx.flagcxSend(
+            self._buffer_type(tensor.data_ptr()),
+            tensor.numel(),
+            self._dtype_enum.from_torch(tensor.dtype),
+            dst,
+            self.comm,
+            flagcx_stream,
+        )
+        self._free_stream(flagcx_stream)
+        os.write(2, f"[FlagCX P2P] send done: rank={self.rank}->dst={dst}\n".encode())
+
+    def recv(self, tensor: torch.Tensor, src: int):
+        """Receive tensor from source rank using FlagCX."""
+        if self.disabled:
+            return
+
+        assert tensor.device == self.device, (
+            f"FlagCX communicator on {self.device}, but tensor on {tensor.device}"
+        )
+        os.write(
+            2,
+            f"[FlagCX P2P] recv start: src={src}->rank={self.rank}, shape={tensor.shape}, numel={tensor.numel()}\n".encode(),
+        )
+        flagcx_stream = self._get_stream()
+        self.flagcx.flagcxRecv(
+            self._buffer_type(tensor.data_ptr()),
+            tensor.numel(),
+            self._dtype_enum.from_torch(tensor.dtype),
+            src,
+            self.comm,
+            flagcx_stream,
+        )
+        self._free_stream(flagcx_stream)
+        os.write(2, f"[FlagCX P2P] recv done: src={src}->rank={self.rank}\n".encode())
+
     def group_start(self):
         """Start a group of collective operations."""
-        self.flagcx.flagcxGroupStart()
+        self.flagcx.flagcxGroupStart(self.comm)
 
     def group_end(self):
         """End a group of collective operations."""
-        self.flagcx.flagcxGroupEnd()
+        self.flagcx.flagcxGroupEnd(self.comm)
+
+    def destroy(self):
+        """Destroy FlagCX communicator and free resources."""
+        if hasattr(self, "comm") and self.comm is not None:
+            try:
+                self.flagcx.flagcxCommDestroy(self.comm)
+            except Exception as e:
+                logger.warning(f"FlagCX comm destroy failed: {e}")
+            self.comm = None
+            self.available = False
+            self.disabled = True
 
 
 def create_flagcx_communicator(group, device) -> FlagCXCommunicator:


### PR DESCRIPTION
## Summary

- Complete Layer 3 FlagCX replacement: add sing hooks (broadcast, broadcast_tensor_dict, send/recv_tensor_dict) + PP tensor dict implementation
- Fix PP deadlock caused by synchronous Gloo md under send_first mode
- Add COMM_STRICT verification mechanism (0 GPU comm leaks across 12000+ operations)
- Add P2P send/recv to FlagCXCommunicator, fix FlagCX v0.13.0 GroupStart/GroupEnd API
- Enhance multinode examples with high-concurrency tests

## Changes

| File | Description |
|------|-------------|
| `sglang_fl/__init__.py` | +3 hooks (broadcast, broadcast_tensor_dict, send/recv_tensor_dict), COMM_STRICT traps, PyNccl suppression |
| `sglang_fl/distributed/communicator.py` | PP tensor dict send/recv implementation, async metadata fix |
| `sglang_fl/distributed/device_communicators/flagcx.py` | P2P send()/recv(), GroupStart/GroupEnd comm param fix |
| `examples/qwen3_6_27b_multinode.py` |oncurrency tests (Text x32, VL x8) |
| `examples/qwen3_6_35b_a3b_multinode.py` | High-concurrency tests (Text x32, VL x8) |

## Test plan

- [x] Qwen3.6-27B (Dense) 2 nodes TP=2 PP=2: 11/11 PASSED
- [x] Qwen3.6-35B-A3B (MoE) 2 nodes TP=2 PP=2: 10/11 PASSED
- [x] High-concurrency text x32: PASSED
- [x] High-concurrency VL x8: PASSED
- [x] COMM_STRICT: 0 GPU comm leaks on both nodes (12272 FlagCX calls total)