### PR TITLE
fix: compat with FlagGems 5.3.0-rc2 DeviceDetector path change (#29)

### DIFF
--- a/sglang_fl/__init__.py
+++ b/sglang_fl/__init__.py
@@ -560,7 +560,12 @@ def activate_platform() -> str | None:
     or None if FlagGems DeviceDetector fails (no supported hardware).
     """
     try:
-        from flag_gems.runtime.backend.device import DeviceDetector
+        try:
+            # FlagGems<=5.0.2: DeviceDetector lives in device.
+            from flag_gems.runtime.backend.device import DeviceDetector
+        except ImportError:
+            # FlagGems>5.0.2: DeviceDetector lives in device_finder.
+            from flag_gems.runtime.backend.device_finder import DeviceDetector
 
         detector = DeviceDetector()
         logger.info(

--- a/sglang_fl/platform.py
+++ b/sglang_fl/platform.py
@@ -38,7 +38,12 @@ _DIST_BACKEND_MAP = {
 
 def _get_device_detector():
     """Lazy import DeviceDetector to avoid import errors when flag_gems not installed."""
-    from flag_gems.runtime.backend.device import DeviceDetector
+    try:
+        # FlagGems<=5.0.2: DeviceDetector lives in device.
+        from flag_gems.runtime.backend.device import DeviceDetector
+    except ImportError:
+        # FlagGems>5.0.2: DeviceDetector lives in device_finder.
+        from flag_gems.runtime.backend.device_finder import DeviceDetector
 
     return DeviceDetector()
 


### PR DESCRIPTION
FlagGems 5.3.0-rc2 moved DeviceDetector from
flag_gems.runtime.backend.device to
flag_gems.runtime.backend.device_finder.

Use try/except import to support both old (<= 5.0.2) and new (> 5.0.2) FlagGems versions.

Closes #29