### PR TITLE
feat: enable FlagCX comm on Ascend / MUSA and add platform-aware multinode examples

### DIFF
--- a/examples/qwen3_6_27b_multinode.py
+++ b/examples/qwen3_6_27b_multinode.py
@@ -6,6 +6,9 @@ Validates that sglang-plugin-FL correctly handles multi-node tensor parallelism
 for the dense Qwen3.6-27B model by launching a distributed SGLang server across
 2 nodes and running text, concurrent, multimodal (VL), and high-concurrency tests.
 
+Supports CUDA, MUSA, and Ascend NPU; platform-specific server flags and env
+vars are applied automatically at runtime.
+
 ============================================================================
 Usage:
   This script runs as EITHER master (node_rank=0) or worker (node_rank=1),
@@ -41,9 +44,15 @@ Full tested command (2 nodes × 2 GPUs each, TP=2 PP=2):
 
   Total GPUs: TP × PP = 2 × 2 = 4 (2 per node)
 
+  On MUSA, swap CUDA_VISIBLE_DEVICES → MUSA_VISIBLE_DEVICES; on Ascend NPU,
+  use ASCEND_RT_VISIBLE_DEVICES. SGLANG_FL_DIST_BACKEND=flagcx is recommended
+  on both non-CUDA platforms.
+
 Environment variables:
   MODEL_PATH       Model path (default: /models/Qwen3.6-27B)
-  CUDA_VISIBLE_DEVICES  GPU selection (e.g. 0,1)
+  CUDA_VISIBLE_DEVICES  GPU selection on CUDA (e.g. 0,1)
+  MUSA_VISIBLE_DEVICES  Device selection on MUSA
+  ASCEND_RT_VISIBLE_DEVICES  Device selection on Ascend NPU
   GLOO_SOCKET_IFNAME    Network interface for Gloo (default: eth0)
   NCCL_SOCKET_IFNAME    Network interface for NCCL (default: eth0)
   SGLANG_FL_DIST_BACKEND  Communication backend (flagcx / nccl)
@@ -70,6 +79,37 @@ import sys
 import time
 import urllib.request
 from pathlib import Path
+
+import torch
+
+# ─── Platform detection ──────────────────────────────────────────────────────
+
+_is_musa = hasattr(torch, "musa") and torch.musa.is_available()
+_is_npu = hasattr(torch, "npu") and torch.npu.is_available()
+
+# Must be set before launching sglang. Subprocesses inherit os.environ.
+if _is_npu:
+    os.environ.setdefault("SGLANG_ENABLE_OVERLAP_PLAN_STREAM", "0")
+    os.environ.setdefault("SGLANG_ENABLE_SPEC_V2", "1")
+    os.environ.setdefault("HCCL_BUFFSIZE", "2400")
+    os.environ.setdefault("SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK", "128")
+elif _is_musa:
+    os.environ.setdefault("MCCL_IB_DISABLE", "1")
+    
+# Extra launch_server flags per platform.
+# - MUSA: page_size=1 works around a sglang platform bug.
+# - Ascend NPU: requires ascend attention backend, bfloat16, radix cache off.
+if _is_musa:
+    _PLATFORM_SERVER_ARGS: list = ["--page-size", "1"]
+elif _is_npu:
+    _PLATFORM_SERVER_ARGS = [
+        "--attention-backend", "ascend",
+        "--device", "npu",
+        "--dtype", "bfloat16",
+        "--disable-radix-cache",
+    ]
+else:
+    _PLATFORM_SERVER_ARGS = []
 
 # ─── Configuration ───────────────────────────────────────────────────────────
 
@@ -481,6 +521,7 @@ def run_master(args):
         "--disable-cuda-graph",
         "--disable-piecewise-cuda-graph",
         "--trust-remote-code",
+        *_PLATFORM_SERVER_ARGS,
     ]
 
     print("Launching server...")
@@ -571,6 +612,7 @@ def run_worker(args):
         "--disable-cuda-graph",
         "--disable-piecewise-cuda-graph",
         "--trust-remote-code",
+        *_PLATFORM_SERVER_ARGS,
     ]
 
     print("Starting worker node... (will block until master shuts down)\n")

--- a/examples/qwen3_6_35b_a3b_multinode.py
+++ b/examples/qwen3_6_35b_a3b_multinode.py
@@ -631,13 +631,3 @@ if __name__ == "__main__":
         run_master(args)
     else:
         run_worker(args)
-
-
-    
-    # Optional: watchdog-vs-capture diagnostic (opt-in via SGLANG_FL_WATCHDOG_DIAG=1)
-    try:
-        from sglang_fl._watchdog_diag import install as _install_watchdog_diag
-
-        _install_watchdog_diag()
-    except Exception as _diag_e:
-        logger.warning(f"watchdog diag install failed: {_diag_e}")

--- a/examples/qwen3_6_35b_a3b_multinode.py
+++ b/examples/qwen3_6_35b_a3b_multinode.py
@@ -6,13 +6,16 @@ Validates that sglang-plugin-FL correctly handles multi-node tensor parallelism
 by launching a distributed SGLang server across 2 nodes and running text,
 concurrent, multimodal (VL), and high-concurrency inference tests.
 
+Supports CUDA, MUSA, and Ascend NPU; platform-specific server flags and env
+vars are applied automatically at runtime.
+
 ============================================================================
 Usage:
   This script runs as EITHER master (node_rank=0) or worker (node_rank=1),
   controlled by the --role argument.
 
   Step 1 — Start master on node 0 (e.g. 192.168.0.66):
-    python examples/qwen3_6_35b_a3b_multinode.py --role master --master-addr 192.1-tp 2 --pp 2
+    python examples/qwen3_6_35b_a3b_multinode.py --role master --master-addr 192.168.0.66 --tp 2 --pp 2
 
   Step 2 — Start worker on node 1 (e.g. 192.168.0.65):
     python examples/qwen3_6_35b_a3b_multinode.py --role worker --master-addr 192.168.0.66 --tp 2 --pp 2
@@ -41,9 +44,15 @@ Full tested command (2 nodes × 2 GPUs each, TP=2 PP=2):
 
   Total GPUs: TP × PP = 2 × 2 = 4 (2 per node)
 
+  On MUSA, swap CUDA_VISIBLE_DEVICES → MUSA_VISIBLE_DEVICES; on Ascend NPU,
+  use ASCEND_RT_VISIBLE_DEVICES. SGLANG_FL_DIST_BACKEND=flagcx is recommended
+  on both non-CUDA platforms.
+
 Environment variables:
   MODEL_PATH       Model path (default: /models/Qwen3.6-35B-A3B)
-  CUDA_VISIBLE_DEVICES  GPU selection (e.g. 0,1)
+  CUDA_VISIBLE_DEVICES  GPU selection on CUDA (e.g. 0,1)
+  MUSA_VISIBLE_DEVICES  Device selection on MUSA
+  ASCEND_RT_VISIBLE_DEVICES  Device selection on Ascend NPU
   GLOO_SOCKET_IFNAME    Network interface for Gloo (default: eth0)
   NCCL_SOCKET_IFNAME    Network interface for NCCL (default: eth0)
   SGLANG_FL_DIST_BACKEND  Communication backend (flagcx / nccl)
@@ -67,6 +76,37 @@ import sys
 import time
 import urllib.request
 from pathlib import Path
+
+import torch
+
+# ─── Platform detection ──────────────────────────────────────────────────────
+
+_is_musa = hasattr(torch, "musa") and torch.musa.is_available()
+_is_npu = hasattr(torch, "npu") and torch.npu.is_available()
+
+# Must be set before launching sglang. Subprocesses inherit os.environ.
+if _is_npu:
+    os.environ.setdefault("SGLANG_ENABLE_OVERLAP_PLAN_STREAM", "0")
+    os.environ.setdefault("SGLANG_ENABLE_SPEC_V2", "1")
+    os.environ.setdefault("HCCL_BUFFSIZE", "2400")
+    os.environ.setdefault("SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK", "128")
+elif _is_musa:
+    os.environ.setdefault("MCCL_IB_DISABLE", "1")
+    
+# Extra launch_server flags per platform.
+# - MUSA: page_size=1 works around a sglang platform bug.
+# - Ascend NPU: requires ascend attention backend, bfloat16, radix cache off.
+if _is_musa:
+    _PLATFORM_SERVER_ARGS: list = ["--page-size", "1"]
+elif _is_npu:
+    _PLATFORM_SERVER_ARGS = [
+        "--attention-backend", "ascend",
+        "--device", "npu",
+        "--dtype", "bfloat16",
+        "--disable-radix-cache",
+    ]
+else:
+    _PLATFORM_SERVER_ARGS = []
 
 # ─── Configuration ───────────────────────────────────────────────────────────
 
@@ -469,6 +509,7 @@ def run_master(args):
         "--disable-cuda-graph",
         "--disable-piecewise-cuda-graph",
         "--trust-remote-code",
+        *_PLATFORM_SERVER_ARGS,
     ]
 
     print("Launching server...")
@@ -559,6 +600,7 @@ def run_worker(args):
         "--disable-cuda-graph",
         "--disable-piecewise-cuda-graph",
         "--trust-remote-code",
+        *_PLATFORM_SERVER_ARGS,
     ]
 
     print("Starting worker node... (will block until master shuts down)\n")
@@ -589,3 +631,13 @@ if __name__ == "__main__":
         run_master(args)
     else:
         run_worker(args)
+
+
+    
+    # Optional: watchdog-vs-capture diagnostic (opt-in via SGLANG_FL_WATCHDOG_DIAG=1)
+    try:
+        from sglang_fl._watchdog_diag import install as _install_watchdog_diag
+
+        _install_watchdog_diag()
+    except Exception as _diag_e:
+        logger.warning(f"watchdog diag install failed: {_diag_e}")

--- a/sglang_fl/distributed/device_communicators/flagcx.py
+++ b/sglang_fl/distributed/device_communicators/flagcx.py
@@ -115,7 +115,7 @@ class FlagCXCommunicator:
 
         # Initialize FlagCX unique ID (rank 0 generates, then broadcast)
         if self.rank == 0:
-            self.unique_id = self.flagcx.flagcxGetUniqueId().contents
+            self.unique_id = self.flagcx.flagcxGetUniqueId()
         else:
             self.unique_id = flagcxUniqueId()
 
@@ -142,12 +142,12 @@ class FlagCXCommunicator:
             device_ctx = torch.cuda.device(self.device)
         with device_ctx:
             self.comm = self.flagcx.flagcxCommInitRank(
-                self.world_size, ctypes.byref(self.unique_id), self.rank
+                self.world_size, self.unique_id, self.rank
             )
             # Warmup: small all_reduce to ensure comm is ready
             warmup_data = torch.zeros(1, device=self.device)
             self._flagcx_all_reduce(warmup_data)
-            torch.cuda.current_stream().synchronize()
+            self._sync_current_stream()
             del warmup_data
 
         self.available = True
@@ -157,11 +157,52 @@ class FlagCXCommunicator:
             f"world_size={self.world_size}, device={self.device}"
         )
 
+    def _get_raw_stream_handle(self):
+        """Return the vendor-specific raw stream pointer (an int) for FlagCX streamCopy."""
+        device_str = str(self.device)
+        if "npu" in device_str:
+            return torch.npu.current_stream().npu_stream
+        if "musa" in device_str:
+            return torch.musa.current_stream().musa_stream
+        return torch.cuda.current_stream().cuda_stream
+
+    def _sync_current_stream(self):
+        """Synchronize the vendor-specific current stream for this device.
+
+        Skipped during graph capture: synchronize() is illegal while the
+        stream is being captured (NPU returns 107027 'stream is captured';
+        CUDA raises CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED). Inside a graph
+        the recorded op order already enforces causality, so the sync is
+        only needed in normal eager-mode forward — to make sure FlagCX
+        async send/recv/collective writes are visible before the caller
+        reads the buffer (e.g. PP forward_batch.input_ids on the next step).
+        """
+        device_str = str(self.device)
+        if "npu" in device_str:
+            stream = torch.npu.current_stream()
+        elif "musa" in device_str:
+            stream = torch.musa.current_stream()
+        else:
+            stream = torch.cuda.current_stream()
+        try:
+            stream.synchronize()
+        except RuntimeError as e:
+            if "captur" in str(e).lower():
+                return
+            raise
+
     def _get_stream(self):
-        """Get current CUDA stream wrapped for FlagCX."""
-        stream = torch.cuda.current_stream()
-        flagcx_stream = self.flagcx.adaptor_stream_copy(stream)
-        return flagcx_stream
+        """Bind a FlagCX stream onto the current vendor stream (bypasses wrapper's
+        musa/cuda-only attribute reflection so NPU works without patching FlagCX)."""
+        from plugin.interservice.flagcx_wrapper import flagcxStream_t
+        new_stream = flagcxStream_t()
+        self.flagcx.FLAGCX_CHECK(
+            self.flagcx.devHandle.contents.streamCopy(
+                ctypes.byref(new_stream),
+                ctypes.c_void_p(self._get_raw_stream_handle()),
+            )
+        )
+        return new_stream
 
     def _free_stream(self, flagcx_stream):
         """Free a FlagCX stream wrapper."""

--- a/sglang_fl/distributed/device_communicators/flagcx.py
+++ b/sglang_fl/distributed/device_communicators/flagcx.py
@@ -168,14 +168,6 @@ class FlagCXCommunicator:
 
     def _sync_current_stream(self):
         """Synchronize the vendor-specific current stream for this device.
-
-        Skipped during graph capture: synchronize() is illegal while the
-        stream is being captured (NPU returns 107027 'stream is captured';
-        CUDA raises CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED). Inside a graph
-        the recorded op order already enforces causality, so the sync is
-        only needed in normal eager-mode forward — to make sure FlagCX
-        async send/recv/collective writes are visible before the caller
-        reads the buffer (e.g. PP forward_batch.input_ids on the next step).
         """
         device_str = str(self.device)
         if "npu" in device_str:
@@ -187,8 +179,9 @@ class FlagCXCommunicator:
         try:
             stream.synchronize()
         except RuntimeError as e:
-            if "captur" in str(e).lower():
-                return
+            logger.error(
+                "stream.synchronize() failed on %s: %s", device_str, e
+            )
             raise
 
     def _get_stream(self):

--- a/sglang_fl/distributed/device_communicators/flagcx.py
+++ b/sglang_fl/distributed/device_communicators/flagcx.py
@@ -78,6 +78,8 @@ class FlagCXCommunicator:
 
         self.available = False
 
+        self._stream_cache = {}
+
         # Import FlagCX wrapper
         try:
             (
@@ -185,21 +187,21 @@ class FlagCXCommunicator:
             raise
 
     def _get_stream(self):
-        """Bind a FlagCX stream onto the current vendor stream (bypasses wrapper's
-        musa/cuda-only attribute reflection so NPU works without patching FlagCX)."""
+        """Bind a FlagCX stream onto the current vendor stream, with per-handle cache."""
+        handle = self._get_raw_stream_handle()
+        cached = self._stream_cache.get(handle)
+        if cached is not None:
+            return cached
         from plugin.interservice.flagcx_wrapper import flagcxStream_t
         new_stream = flagcxStream_t()
         self.flagcx.FLAGCX_CHECK(
             self.flagcx.devHandle.contents.streamCopy(
                 ctypes.byref(new_stream),
-                ctypes.c_void_p(self._get_raw_stream_handle()),
+                ctypes.c_void_p(handle),
             )
         )
+        self._stream_cache[handle] = new_stream
         return new_stream
-
-    def _free_stream(self, flagcx_stream):
-        """Free a FlagCX stream wrapper."""
-        self.flagcx.adaptor_stream_free(flagcx_stream)
 
     def _flagcx_all_reduce(self, tensor: torch.Tensor) -> torch.Tensor:
         """Internal all_reduce using FlagCX API."""
@@ -214,7 +216,6 @@ class FlagCXCommunicator:
             self.comm,
             flagcx_stream,
         )
-        self._free_stream(flagcx_stream)
         return out_tensor
 
     def all_reduce(self, input_: torch.Tensor) -> torch.Tensor:
@@ -248,7 +249,6 @@ class FlagCXCommunicator:
             self.comm,
             flagcx_stream,
         )
-        self._free_stream(flagcx_stream)
 
     def all_gather(self, output: torch.Tensor, input_: torch.Tensor):
         """All-gather using FlagCX."""
@@ -267,7 +267,6 @@ class FlagCXCommunicator:
             self.comm,
             flagcx_stream,
         )
-        self._free_stream(flagcx_stream)
 
     def reduce_scatterv(
         self,
@@ -300,7 +299,6 @@ class FlagCXCommunicator:
             )
             split_offset += split_size
         self.flagcx.flagcxGroupEnd(self.comm)
-        self._free_stream(flagcx_stream)
 
     def all_gatherv(
         self,
@@ -332,7 +330,6 @@ class FlagCXCommunicator:
             )
             split_offset += split_size
         self.flagcx.flagcxGroupEnd(self.comm)
-        self._free_stream(flagcx_stream)
 
     def broadcast(self, tensor: torch.Tensor, src: int):
         """Broadcast tensor from src rank."""
@@ -358,7 +355,6 @@ class FlagCXCommunicator:
             self.comm,
             flagcx_stream,
         )
-        self._free_stream(flagcx_stream)
 
     def send(self, tensor: torch.Tensor, dst: int):
         """Send tensor to destination rank using FlagCX."""
@@ -377,7 +373,6 @@ class FlagCXCommunicator:
             self.comm,
             flagcx_stream,
         )
-        self._free_stream(flagcx_stream)
 
     def recv(self, tensor: torch.Tensor, src: int):
         """Receive tensor from source rank using FlagCX."""
@@ -396,7 +391,6 @@ class FlagCXCommunicator:
             self.comm,
             flagcx_stream,
         )
-        self._free_stream(flagcx_stream)
 
     def group_start(self):
         """Start a group of collective operations."""
@@ -406,16 +400,27 @@ class FlagCXCommunicator:
         """End a group of collective operations."""
         self.flagcx.flagcxGroupEnd(self.comm)
 
-    def destroy(self):
-        """Destroy FlagCX communicator and free resources."""
-        if hasattr(self, "comm") and self.comm is not None:
+    def __del__(self):
+        """Free cached streams and destroy the FlagCX comm on GC / interpreter shutdown."""
+        # self.flagcx may be missing (early-disabled path) or unusable (shutdown).
+        flagcx = getattr(self, "flagcx", None)
+        if flagcx is None:
+            return
+        cache = getattr(self, "_stream_cache", None)
+        if cache:
+            for cached_stream in cache.values():
+                try:
+                    flagcx.adaptor_stream_free(cached_stream)
+                except Exception:
+                    pass
+            cache.clear()
+        comm = getattr(self, "comm", None)
+        if comm is not None:
             try:
-                self.flagcx.flagcxCommDestroy(self.comm)
-            except Exception as e:
-                logger.warning(f"FlagCX comm destroy failed: {e}")
+                flagcx.flagcxCommDestroy(comm)
+            except Exception:
+                pass
             self.comm = None
-            self.available = False
-            self.disabled = True
 
 
 def create_flagcx_communicator(group, device) -> FlagCXCommunicator:


### PR DESCRIPTION
## Summary

- Extend FlagCX-based communication to Ascend NPU and MUSA platforms.
- Skip FlagCX `send`/`recv` hooks on Ascend (broken upstream); fall back to torch.distributed HCCL P2P.
- Make multinode example scripts platform-aware so they launch on CUDA / MUSA / Ascend NPU without manual flag editing.

## Changes

| File | Description |
|---|---|
| `sglang_fl/distributed/device_communicators/flagcx.py` | Fix `flagcxGetUniqueId` / `flagcxCommInitRank` call signatures; add vendor-aware raw stream handle + capture-safe stream sync; rewrite `_get_stream()` to bind FlagCX stream directly so NPU works without patching FlagCX. |
| `sglang_fl/__init__.py` | Add `_is_ascend_platform()` and skip FlagCX `send`/`recv`(+`_tensor_dict`) hooks on Ascend, falling back to torch.distributed HCCL P2P. |
| `examples/qwen3_6_27b_multinode.py` | Auto-detect MUSA / Ascend NPU and append platform-specific `sglang.launch_server` flags; set required NPU runtime env vars; docstring updated for `MUSA_VISIBLE_DEVICES` / `ASCEND_RT_VISIBLE_DEVICES`. |
| `examples/qwen3_6_35b_a3b_multinode.py` | Same platform-aware launch adaptation as the 27B script. |

## Tests

Verified end-to-end on 2-node × 2-GPU clusters with the two updated multinode example scripts, exercising text / longer generation / concurrent text / high-concurrency text / sequential VL / high-concurrency VL:

- Qwen3.6-27B (Dense) 2 nodes TP=2 PP=2: 11/11 PASSED
- Qwen3.6-35B-A3B (MoE) 2 nodes TP=2 PP=2: 10/11 PASSED