### PR TITLE
[CICD] Add cuda CICD test

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,570 @@
+# Tests
+
+Platform-agnostic test suite for the sglang-plugin-FL project. All tests are designed to run on NVIDIA CUDA (and future Ascend NPU) without modification.
+
+## Architecture Overview
+
+```
+                          ┌──────────────┐
+                          │  tests/run.py │  ← Unified entry point
+                          └──────┬───────┘
+                                 │
+          ┌──────────────────┬───┴───────────────┬──────────────────┐
+          │                  │                   │                  │
+    ┌─────▼─────┐   ┌───────▼───────┐   ┌────────▼────────┐   ┌──────▼──────┐
+    │ Unit Tests │   │  Functional   │   │   E2E Tests     │   │ Benchmarks  │
+    │ (no GPU)   │   │  (GPU, no     │   │ (GPU + models)  │   │ (GPU + dummy│
+    │            │   │   models)     │   │                 │   │  weights)   │
+    └────────────┘   └───────────────┘   └────────┬────────┘   └─────────────┘
+                                                           │
+                                          ┌────────────────┼────────────────┐
+                                          │                │                │
+                                    ┌─────▼────┐    ┌──────▼─────┐   ┌──────▼─────┐
+                                    │Inference │    │  Serving   │   │ Concurrent │
+                                    │(Engine)  │    │ (HTTP API) │   │(async gen) │
+                                    └──────────┘    └────────────┘   └────────────┘
+```
+
+**Key design principles:**
+
+- **YAML-driven E2E tests**: Model configs in `tests/models/` drive inference,
+  serving, and concurrent smoke tests — no per-model test files needed.
+- **Platform-aware orchestration**: Platform YAML configs (`tests/platforms/`)
+  control which tests run on which hardware, inject tolerance, and set env
+  defaults.
+- **Process isolation**: Each E2E case runs in its own subprocess via `run.py`,
+  so device state is fresh between cases.
+- **Benchmark smoke tests**: `tests/benchmarks/configs/smoke.yaml` drives tiny
+  health checks over `sglang.bench_offline_throughput` / `bench_one_batch` /
+  `bench_serving`, using `load_format: dummy` so no real weights are needed.
+
+## Directory Structure
+
+```
+tests/
+├── run.py                          # Unified test runner (wraps pytest)
+├── conftest.py                     # Root: custom marker registration
+├── validate.sh                     # Precision alignment: baseline vs plugin
+├── test_precision_align.py         # baseline/plugin/compare subcommands
+├── test_e2e_config.py              # Env-var & YAML config e2e validation
+│
+├── models/                         # Model YAML configs (drive E2E tests)
+│   ├── qwen3/
+│   │   ├── 4b_tp2.yaml
+│   │   └── 06b_tp1.yaml
+│   └── qwen3_6/
+│       ├── 27b_tp2_nograph.yaml            (+ _vl / _old variants)
+│       └── 35b_a3b_tp2_nograph.yaml        (+ _vl / _old variants)
+│
+├── platforms/                      # Platform-specific test configs
+│   ├── cuda.yaml                   # NVIDIA GPU: device types, tolerance, matrix
+│   └── template.yaml               # Template for adding new platforms
+│
+├── e2e_tests/                      # End-to-end tests (require GPU + model files)
+│   ├── inference/
+│   │   └── test_inference_smoke.py # Unified inference test (YAML-driven)
+│   ├── serving/
+│   │   ├── test_serving_smoke.py   # Unified serving test (YAML-driven)
+│   │   └── server_helper.py        # SGLangServer lifecycle manager
+│   └── concurrent/
+│       └── test_concurrent_smoke.py# N-way async generation (text/vl/mixed)
+│
+├── functional_tests/               # Component-level GPU tests (no model files)
+│   ├── conftest.py                 # `device` fixture (cuda, skip if absent)
+│   ├── ops/
+│   │   └── test_ops_correctness.py # dispatch.call_op vs reference backend
+│   ├── compilation/
+│   │   └── test_graph_capture.py   # Graph capture & replay
+│   └── distributed/
+│       └── test_collective_ops.py  # Collective ops (all_reduce, etc.)
+│
+├── unit_tests/                     # Fast isolated tests (no GPU required)
+│   ├── conftest.py                 # (per-subpackage conftests)
+│   ├── dispatch/                   # Op dispatch system
+│   │   ├── test_call_op.py
+│   │   ├── test_registry.py
+│   │   ├── test_manager.py
+│   │   ├── test_policy.py
+│   │   ├── test_types.py
+│   │   ├── test_env_policy.py
+│   │   ├── test_cuda_compat_vendors.py
+│   │   ├── test_fork_safety.py
+│   │   ├── backends/test_reference_ops.py
+│   │   └── bridge/                  # Operator bridge unit tests
+│   │       ├── test_silu_and_mul.py
+│   │       ├── test_rms_norm.py
+│   │       ├── test_gemma_rms_norm.py
+│   │       ├── test_rotary_embedding.py
+│   │       ├── test_mrotary_embedding.py
+│   │       ├── test_fla_ops.py
+│   │       ├── test_fused_moe.py
+│   │       └── test_topk.py
+│   ├── distributed/                # Distributed communication
+│   │   ├── test_communicator.py
+│   │   └── test_flagcx.py
+│   ├── platform/                    # Plugin platform/backend loading
+│   │   ├── test_load_plugin.py
+│   │   ├── test_init_backend.py
+│   │   └── test_apply_vendor_patches.py
+│   └── flaggems/                    # FlagGems integration
+│       └── test_setup_flaggems.py
+│
+├── benchmarks/                     # Benchmark smoke tests (dummy weights)
+│   ├── configs/smoke.yaml          # throughput / latency / serve cases
+│   ├── test_benchmark_throughput.py
+│   ├── test_benchmark_latency.py
+│   ├── test_benchmark_serve.py
+│   └── utils.py                    # CLI-arg builder, JSONL reader, env passthrough
+│
+└── utils/                          # Shared test utilities
+    ├── model_config.py             # YAML model config loader (SGLang names)
+    └── platform_config.py          # Platform YAML config loader
+```
+
+## Running Tests
+
+### Prerequisites
+
+```bash
+# Editable install of the plugin (provides setuptools entry_points auto-discovery)
+pip install -e .
+
+# Optional but recommended
+pip install pytest pyyaml requests openai
+```
+
+For E2E / benchmark tests that load real weights, point model YAMLs at local
+model paths (the `llm.model` field in each `tests/models/<m>/<c>.yaml`). Cases
+whose model path does not exist are auto-skipped with a clear message, so a
+missing model never fails the run.
+
+### Via `run.py` (recommended for CI and full runs)
+
+`run.py` is the unified entry point: it resolves the platform config, applies
+env defaults, injects tolerance, discovers test cases, and runs each in a
+subprocess. `--platform` accepts either a platform name (`cuda`) or a device
+alias (`a100`) — aliases are resolved against the `device_types` keys of each
+platform YAML.
+
+```bash
+# Run everything for a platform/device
+python tests/run.py --platform cuda --device a100
+
+# Run only unit tests (no GPU required)
+python tests/run.py --platform cuda --device a100 --scope unit
+
+# Run only functional tests (ops, compilation, distributed)
+python tests/run.py --platform cuda --device a100 --scope functional
+
+# Run only E2E tests (inference + serving + concurrent)
+python tests/run.py --platform cuda --device a100 --scope e2e
+
+# Run only benchmark smoke tests
+python tests/run.py --platform cuda --device a100 --scope benchmark
+
+# Run a specific E2E task/model/case
+python tests/run.py --platform cuda --device a100 \
+    --scope e2e --task inference --model qwen3_6 --case 27b_tp2_nograph
+
+# Run a specific benchmark type
+python tests/run.py --platform cuda --device a100 \
+    --scope benchmark --benchmark latency
+
+# Pass extra pytest args after '--'
+python tests/run.py --platform cuda --device a100 --scope unit -- -x -v
+
+# Device alias instead of explicit platform/device
+python tests/run.py --platform a100 --scope unit
+```
+
+### Via `pytest` directly (for development)
+
+```bash
+# Unit tests (no GPU required)
+pytest tests/unit_tests/ -v
+
+# Functional tests (requires GPU)
+pytest tests/functional_tests/ -v -s
+
+# Single E2E inference test (env vars injected by run.py, but settable by hand)
+FL_TEST_MODEL=qwen3 FL_TEST_CASE=06b_tp1 \
+    pytest tests/e2e_tests/inference/test_inference_smoke.py -v -s
+
+# Single E2E serving test
+FL_TEST_MODEL=qwen3_6 FL_TEST_CASE=27b_tp2_nograph \
+    pytest tests/e2e_tests/serving/test_serving_smoke.py -v -s
+
+# Single E2E concurrent test
+FL_TEST_MODEL=qwen3_6 FL_TEST_CASE=27b_tp2_nograph \
+    pytest tests/e2e_tests/concurrent/test_concurrent_smoke.py -v -s
+
+# Benchmark smoke tests are env-driven too (FL_BENCHMARK_CASE is a JSON blob
+# assembled by run.py — prefer going through run.py for these)
+python tests/run.py --platform cuda --device a100 --scope benchmark --benchmark latency
+```
+
+### Filter by markers
+
+```bash
+pytest -m gpu            # Only GPU tests
+pytest -m functional     # Only functional tests
+pytest -m e2e            # Only E2E tests
+pytest -m benchmark       # Only benchmark tests
+pytest -m "not slow"
+```
+
+### Precision alignment via `validate.sh`
+
+`tests/validate.sh` is a standalone acceptance script comparing original SGLang
+(no plugin) against sglang-plugin-FL (FlagGems + OOT dispatch), with an optional
+mock-vendor mode. It runs `test_precision_align.py` subcommands and writes logs
+to `/tmp/` plus `precision_results[_tpN].json` next to the script.
+
+```bash
+MODEL_PATH=/path/to/Qwen2.5-0.5B-Instruct bash tests/validate.sh all
+
+# Multi-GPU
+TP_SIZE=8 MODEL_PATH=/path/to/14B bash tests/validate.sh full   # incl. vendor mode
+
+# Subcommands
+MODEL_PATH=... bash tests/validate.sh clean     # remove previous logs
+MODEL_PATH=... bash tests/validate.sh baseline  # original SGLang, no plugin
+MODEL_PATH=... bash tests/validate.sh plugin   # sglang-plugin-FL (flagos)
+MODEL_PATH=... bash tests/validate.sh vendor   # mock_npu vendor backend
+MODEL_PATH=... bash tests/validate.sh compare   # precision + dispatch diff
+```
+
+### Config / env-var validation via `test_e2e_config.py`
+
+A self-contained script that boots an SGLang server per env-var/YAML-config
+combination and verifies dispatch logging, backend selection, and inference
+output.
+
+```bash
+MODEL_PATH=/path/to/model python tests/test_e2e_config.py          # all cases
+MODEL_PATH=/path/to/model python tests/test_e2e_config.py --list   # list cases
+MODEL_PATH=/path/to/model python tests/test_e2e_config.py --case 3 # one case
+```
+
+## Model YAML Config Format
+
+E2E tests are driven by YAML configs under `tests/models/<model>/<case>.yaml`.
+A single case can drive multiple e2e tasks (inference, serving, concurrent)
+simultaneously. Parameter names are SGLang-native.
+
+### Text model example
+
+```yaml
+# tests/models/qwen3/06b_tp1.yaml
+llm:
+  model: "/data/models/Qwen/Qwen3-0.6B"
+  context_length: 8192
+  mem_fraction_static: 0.7
+  trust_remote_code: true
+
+generate:
+  prompts:
+    - text: "How many states are there in the United States?"
+      expected: "50"                    # Optional: substring must appear in output
+    - text: "The capital of France is"
+      expected: "Paris"
+  sampling:
+    max_new_tokens: 16
+    temperature: 0.0
+  parametrize:                          # List of explicit engine-param overrides
+    - disable_cuda_graph: true
+      disable_piecewise_cuda_graph: true
+      dtype: "bfloat16"
+```
+
+### Multimodal (image) model example
+
+```yaml
+# tests/models/qwen3_6/35b_a3b_tp2_nograph_vl.yaml
+llm:
+  model: "/data/models/Qwen/Qwen3.6-35B-A3B"
+  tp_size: 2
+  context_length: 8192
+  mem_fraction_static: 0.95
+  disable_cuda_graph: true
+  disable_piecewise_cuda_graph: true
+  trust_remote_code: true
+
+generate:
+  modality: image                       # text (default) | audio | image | video
+  prompts:
+    - image: "examples/test_images/red_square.jpg"
+      question: "What color is shown in this image? Answer with one word."
+      expected: ["red"]
+  sampling:
+    max_new_tokens: 64
+    temperature: 0.0
+```
+
+### Concurrent / serving in the same case
+
+A case YAML may also carry `serve:` and `concurrent:` sections so that one file
+drives inference, serving, and concurrent tasks.
+
+```yaml
+serve:
+  served_model_name: "qwen"
+  endpoints: ["chat"]                   # completion | chat | embedding
+  stream: false
+  max_tokens: 256
+  chat_messages:
+    - role: "user"
+      content: "Introduce yourself,please"
+  sampling:
+    temperature: 0.0
+
+concurrent:
+  modes: ["text", "vl", "mixed"]        # subsets of: text / vl / mixed
+  concurrent_n: 4
+  text:
+    prompts:
+      - text: "How many states are there in the United States?"
+        expected: ["50"]
+  vl:
+    cases:
+      - image: "examples/test_images/cat.jpg"
+        question: "What animal is in this image? Answer with one word."
+        expected: ["cat"]
+  sampling:
+    text: { max_new_tokens: 256, temperature: 0.0 }
+    vl:   { max_new_tokens: 64,  temperature: 0.0 }
+```
+
+### Config fields reference
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `llm.model` | str | Yes | Model path (case auto-skips if not found) |
+| `llm.*` | dict | Yes | SGLang Engine kwargs (`tp_size`, `context_length`, `mem_fraction_static`, `disable_cuda_graph`, `trust_remote_code`, …) |
+| `generate.modality` | str | No | `text` (default), `audio`, `image`, `video` |
+| `generate.prompts` | list | Yes | Strings or dicts with `text`/`expected` (text) or `image`/`question`/`expected` (VL) |
+| `generate.sampling` | dict | Yes | SGLang sampling params (`max_new_tokens`, `temperature`, …) |
+| `generate.parametrize` | list | No | Explicit engine-param override combos (one Engine per combo) |
+| `serve.endpoints` | list | No | `completion`, `chat`, `embedding` |
+| `serve.stream` | bool | No | Use OpenAI SDK streaming for chat (default `false`) |
+| `serve.served_model_name` | str | No | Override `--served-model-name` |
+| `serve.api_key` | str | No | API key for authenticated endpoints |
+| `serve.max_tokens` | int | No | Max tokens for serving requests (default 50) |
+| `serve.chat_messages` | list | No | Messages for `/v1/chat/completions` |
+| `serve.completion_prompt` | str | No | Prompt for `/v1/completions` |
+| `serve.extra_engine` | dict | No | Engine param overrides for serving only |
+| `serve.extra_body` | dict | No | Extra body fields merged into chat payload |
+| `concurrent.modes` | list | No | `text`, `vl`, `mixed` |
+| `concurrent.concurrent_n` | int | No | Async request count (default 4) |
+| `concurrent.text.prompts` | list | No | Text cases with `text`/`expected` |
+| `concurrent.vl.cases` | list | No | VL cases with `image`/`question`/`expected` |
+
+## Platform Config Format
+
+Platform configs (`tests/platforms/<platform>.yaml`) define device types,
+tolerance, env defaults, and the per-device test matrix.
+
+```yaml
+# tests/platforms/cuda.yaml
+platform: cuda
+vendor: nvidia
+
+device_types:
+  a100: { compute_capability: "8.0", memory_gb: 80, tags: [ampere, bf16] }
+  a800: { compute_capability: "8.0", memory_gb: 80, tags: [ampere, bf16, china-variant] }
+  h100: { compute_capability: "9.0", memory_gb: 80, tags: [hopper, fp8, bf16] }
+
+# Tolerance resolution: device_overrides -> platform default -> built-in default
+tolerance:
+  inference:
+    default: {exact: true}
+device_overrides:
+  h100:
+    tolerance:
+      inference:
+        default: {rtol: 1e-4, atol: 1e-7}
+
+# Model names containing any token here are skipped.
+unsupported_features: []
+
+# Applied via os.environ.setdefault before pytest (existing env wins).
+env_defaults:
+  CUDA_DEVICE_MAX_CONNECTIONS: "1"
+  NCCL_ALGO: "Ring"
+
+# Per-device test matrix. Top-level key must match a device_types entry.
+a100:
+  name: "a100"
+  tests:
+    e2e:
+      concurrent:
+        qwen3_6: ["35b_a3b_tp2_nograph", "27b_tp2_nograph"]
+      inference:
+        qwen3_6: ["35b_a3b_tp2_nograph", "27b_tp2_nograph"]
+      serving:
+        qwen3:   ["4b_tp2"]
+        qwen3_6: ["35b_a3b_tp2_nograph", "27b_tp2_nograph"]
+    functional: { include: "*", exclude: [] }
+    unit:       { include: "*", exclude: [] }
+    benchmark:
+      enabled: true
+      smoke: ["throughput", "latency", "serve"]
+```
+
+## Benchmark Smoke Config Format
+
+`tests/benchmarks/configs/smoke.yaml` lists one or more cases per benchmark
+type. Parameters use SGLang CLI flag names (snake_case → `--kebab-case`).
+
+```yaml
+throughput:
+  - name: throughput_smoke_dummy
+    model: qwen3            # refers to tests/models/qwen3/<case>.yaml
+    case: 06b_tp1
+    parameters:            # merged over the model's engine params
+      dataset_name: random
+      random_input_len: 32
+      random_output_len: 1
+      num_prompts: 4
+      disable_cuda_graph: true
+      disable_piecewise_cuda_graph: true
+      load_format: dummy   # no real weights needed
+
+latency:
+  - name: latency_smoke_dummy
+    model: qwen3
+    case: 06b_tp1
+    parameters:
+      input_len: 32
+      output_len: 1
+      batch_size: 1
+      disable_cuda_graph: true
+      disable_piecewise_cuda_graph: true
+      load_format: dummy
+
+serve:
+  - name: serve_smoke_dummy
+    model: qwen3
+    case: 06b_tp1
+    server_parameters:      # merged over model engine params; pops host/port/tp_size/served_model_name
+      served_model_name: smoke-model
+      tp_size: 1
+      context_length: 1024
+      disable_cuda_graph: true
+      load_format: dummy
+    client_parameters:      # passed to sglang.bench_serving
+      model: smoke-model
+      backend: sglang-oai-chat
+      dataset_name: random
+      random_input_len: 32
+      random_output_len: 4
+      num_prompts: 5
+```
+
+## Writing New Tests
+
+### Adding a new E2E model test
+
+1. Create a YAML config: `tests/models/<model>/<case>.yaml` (add `generate`,
+   `serve`, and/or `concurrent` sections as needed).
+2. Register it in the platform config: `tests/platforms/cuda.yaml` under
+   `tests.e2e.<task>.<model>`.
+3. Done — no Python code needed. The unified smoke tests handle the rest.
+
+### Adding a unit test
+
+Unit tests should be fast, isolated, and not require GPU or model weights.
+
+```python
+# tests/unit_tests/dispatch/test_my_op.py
+import pytest
+from sglang_fl.dispatch import call_op
+
+class TestMyOp:
+    def test_basic(self):
+        result = call_op("my.op", *args)
+        assert result == expected
+```
+
+### Adding a functional test
+
+Functional tests validate component correctness on real hardware. They require
+GPU but not model files. Use the `device` fixture and mark `functional` + `gpu`.
+
+```python
+# tests/functional_tests/ops/test_my_kernel.py
+import pytest
+import torch
+
+pytestmark = [pytest.mark.functional, pytest.mark.gpu]
+
+def test_my_kernel(device):
+    x = torch.randn(16, 256, device=device)
+    result = call_op("my.kernel", x)
+    reference = reference_impl(x)
+    assert torch.allclose(result.float(), reference.float(), rtol=1e-3, atol=1e-3)
+```
+
+### Adding a benchmark smoke case
+
+1. Append a case under the relevant type in
+   `tests/benchmarks/configs/smoke.yaml`.
+2. Reference an existing `model`/`case` so `run.py` can merge engine params from
+   the model YAML, or supply a full `model`/`case` of your own.
+
+### Adding a new platform
+
+1. Copy `tests/platforms/template.yaml` to `tests/platforms/<platform>.yaml`.
+2. Fill in `device_types`, `tolerance`, `env_defaults`, and the per-device
+   `tests` matrix.
+3. Run: `python tests/run.py --platform <platform> --device <device>`.
+
+## Test Scopes
+
+| Scope | Directory | GPU | Models | Runs via |
+|---|---|---|---|---|
+| `unit` | `tests/unit_tests/` | No | No | `pytest` directly |
+| `functional` | `tests/functional_tests/` | Yes | No | `pytest` directly |
+| `e2e` | `tests/e2e_tests/` | Yes | Yes | Subprocess per case (via `run.py`) |
+| `benchmark` | `tests/benchmarks/` | Yes | Dummy only | Subprocess per case (via `run.py`) |
+
+## Available Markers
+
+| Marker | Description |
+|---|---|
+| `@pytest.mark.gpu` | Requires a GPU/accelerator |
+| `@pytest.mark.functional` | Functional correctness test |
+| `@pytest.mark.e2e` | End-to-end smoke test |
+| `@pytest.mark.benchmark` | Benchmark smoke test |
+
+(Markers are auto-registered in `tests/conftest.py`.)
+
+## Environment Variables
+
+| Variable | Set by | Purpose |
+|---|---|---|
+| `FL_TEST_PLATFORM` / `FL_TEST_DEVICE` | `run.py` | Active platform/device for the subprocess |
+| `FL_TEST_MODEL` / `FL_TEST_CASE` | `run.py` (e2e) | Selects `tests/models/<model>/<case>.yaml` |
+| `FL_BENCHMARK_CASE` | `run.py` (benchmark) | JSON blob of merged benchmark case params |
+| `FL_CONCURRENT_MODES` | user | Override concurrent modes: `text,vl,mixed` or `all` |
+| `FL_CONCURRENT_N` | user | Override async request count |
+| `FL_CONCURRENT_MAX_TOKENS` / `FL_CONCURRENT_VL_MAX_TOKENS` | user | Override text/vl `max_new_tokens` |
+| `FL_CONCURRENT_STRICT_TEXT` | user | `1` to enforce `expected` checks in text mode |
+| `IMAGE_DIR` | user | Directory for concurrent VL test images |
+| `MODEL_PATH` / `TP_SIZE` | user | Used by `validate.sh` and `test_*_align.py` |
+| `SGLANG_PLUGINS` | user/`validate.sh` | `__none__` disables plugin in baseline runs |
+| `SGLANG_FL_DISPATCH_LOG` | user/`validate.sh` | File path for OOT dispatch op log |
+| `SGLANG_FL_PER_OP` | user/`validate.sh` | Per-op backend overrides, e.g. `silu_and_mul=vendor:mock_npu` |
+| `SGLANG_FLAGGEMS_*` | user/`validate.sh` | FlagGems recording/log controls |
+
+## Shared Fixtures
+
+| Fixture | Scope | Source | Description |
+|---|---|---|---|
+| `device` | session | `tests/functional_tests/conftest.py` | `torch.device("cuda")`, skips if CUDA unavailable |
+| `registry` | function | `tests/unit_tests/dispatch/conftest.py` | Fresh `OpRegistry` |
+| `make_impl` | function | `tests/unit_tests/dispatch/conftest.py` | Factory for `OpImpl` instances |
+| `dummy_fn` | function | `tests/unit_tests/dispatch/conftest.py` | Simple callable for `OpImpl` |
+| `sglang_fl_module` | function | `tests/unit_tests/flaggems/conftest.py` | Imported `sglang_fl` module |
+| `fake_flag_gems` | function | `tests/unit_tests/flaggems/conftest.py` | Mock `flag_gems` module with call capture |
+| `clean_flaggems_env` | autouse | `tests/unit_tests/flaggems/conftest.py` | Clears FlagGems env vars per test |

--- a/tests/benchmarks/__init__.py
+++ b/tests/benchmarks/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+"""Benchmark smoke tests for sglang-plugin-FL."""

--- a/tests/benchmarks/configs/smoke.yaml
+++ b/tests/benchmarks/configs/smoke.yaml
@@ -1,0 +1,45 @@
+throughput:
+  - name: throughput_smoke_dummy
+    model: qwen3
+    case: 06b_tp1
+    parameters:
+      dataset_name: random
+      random_input_len: 32
+      random_output_len: 1
+      num_prompts: 4
+      disable_cuda_graph: true
+      disable_piecewise_cuda_graph: true
+      load_format: dummy
+
+latency:
+  - name: latency_smoke_dummy
+    model: qwen3
+    case: 06b_tp1
+    parameters:
+      input_len: 32
+      output_len: 1
+      batch_size: 1
+      disable_cuda_graph: true
+      disable_piecewise_cuda_graph: true
+      load_format: dummy
+
+serve:
+  - name: serve_smoke_dummy
+    model: qwen3
+    case: 06b_tp1
+    server_parameters:
+      served_model_name: smoke-model
+      tp_size: 1
+      context_length: 1024
+      max_total_tokens: 1024
+      disable_cuda_graph: true
+      disable_piecewise_cuda_graph: true
+      load_format: dummy
+    client_parameters:
+      model: smoke-model
+      backend: sglang-oai-chat
+      dataset_name: random
+      random_input_len: 32
+      random_output_len: 4
+      num_prompts: 5
+

--- a/tests/benchmarks/test_benchmark_latency.py
+++ b/tests/benchmarks/test_benchmark_latency.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Smoke test for SGLang one-batch latency benchmark."""
+
+import sys
+
+import pytest
+
+from tests.benchmarks.utils import load_benchmark_case, read_last_jsonl, run_command, to_cli_args
+
+
+@pytest.mark.benchmark
+def test_benchmark_latency(tmp_path):
+    case = load_benchmark_case()
+    params = dict(case.get("parameters", {}))
+
+    result_file = tmp_path / "latency_result.jsonl"
+    command = [sys.executable, "-m", "sglang.bench_one_batch"]
+    command.extend(to_cli_args(params))
+    command.extend(["--result-filename", str(result_file)])
+
+    result = run_command(command)
+    assert result.returncode == 0, result.stderr
+    assert result_file.exists()
+
+    data = read_last_jsonl(result_file)
+    assert data.get("prefill_latency", 0) > 0
+    assert data.get("total_latency", 0) > 0
+    assert data.get("overall_throughput", 0) > 0

--- a/tests/benchmarks/test_benchmark_serve.py
+++ b/tests/benchmarks/test_benchmark_serve.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Smoke test for SGLang serving benchmark."""
+
+import sys
+
+import pytest
+
+from tests.benchmarks.utils import (
+    load_benchmark_case,
+    read_last_jsonl,
+    run_command,
+    to_cli_args,
+)
+from tests.e2e_tests.serving.server_helper import SGLangServer
+
+
+@pytest.mark.benchmark
+def test_benchmark_serve(tmp_path):
+    case = load_benchmark_case()
+    
+    server_params = dict(case.get("server_parameters", {}))
+    client_params = dict(case.get("client_parameters", {}))
+
+    model_path = server_params.pop("model_path")
+    served_model_name = server_params.pop("served_model_name", "smoke-model")
+    client_params.setdefault("model", served_model_name)
+    client_params.setdefault("served_model_name", served_model_name)
+    client_params.setdefault("tokenizer", model_path)
+    tp_size = int(server_params.pop("tp_size", server_params.pop("tensor_parallel_size", 1)))
+    host = server_params.pop("host", "127.0.0.1")
+    port = int(server_params.pop("port", 0) or 0)
+    server_extra_args = to_cli_args(server_params)
+
+    result_file = tmp_path / "serve_result.jsonl"
+
+    with SGLangServer(
+        model_path=model_path,
+        tp_size=tp_size,
+        served_model_name=served_model_name,
+        host=host,
+        port=port or None,
+        extra_args=server_extra_args,
+    ) as server:
+        command = [
+            sys.executable,
+            "-m",
+            "sglang.bench_serving",
+            "--host",
+            server.host,
+            "--port",
+            str(server.port),
+        ]
+        command.extend(to_cli_args(client_params))
+        command.extend(["--output-file", str(result_file), "--output-details"])
+
+        result = run_command(command)
+
+    assert result.returncode == 0, result.stderr
+    assert result_file.exists()
+
+    data = read_last_jsonl(result_file)
+    expected = int(client_params.get("num_prompts", 0))
+    assert data.get("completed", 0) > 0
+    if expected:
+        assert data.get("completed", 0) == expected
+    errors = [err for err in data.get("errors", []) if err]
+    assert not errors
+
+

--- a/tests/benchmarks/test_benchmark_throughput.py
+++ b/tests/benchmarks/test_benchmark_throughput.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Smoke test for SGLang offline throughput benchmark."""
+
+import sys
+
+import pytest
+
+from tests.benchmarks.utils import load_benchmark_case, read_last_jsonl, run_command, to_cli_args
+
+
+@pytest.mark.benchmark
+def test_benchmark_throughput(tmp_path):
+    case = load_benchmark_case()
+    params = dict(case.get("parameters", {}))
+
+    result_file = tmp_path / "throughput_result.jsonl"
+    command = [sys.executable, "-m", "sglang.bench_offline_throughput"]
+    command.extend(to_cli_args(params))
+    command.extend(["--result-filename", str(result_file)])
+
+    result = run_command(command)
+    assert result.returncode == 0, result.stderr
+    assert result_file.exists()
+
+    data = read_last_jsonl(result_file)
+    assert data.get("successful_requests", 0) > 0
+    assert data.get("output_throughput", data.get("total_throughput", 0)) > 0

--- a/tests/benchmarks/utils.py
+++ b/tests/benchmarks/utils.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Helpers for SGLang benchmark smoke tests."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+def load_benchmark_case() -> dict[str, Any]:
+    """Load benchmark case config injected by tests/run.py."""
+    raw = os.environ.get("FL_BENCHMARK_CASE")
+    if not raw:
+        raise RuntimeError("FL_BENCHMARK_CASE is not set")
+    return json.loads(raw)
+
+
+def to_cli_args(params: dict[str, Any], skip: set[str] | None = None) -> list[str]:
+    """Convert snake_case parameter mapping to CLI args."""
+    
+    skip = skip or set()
+    args: list[str] = []
+    
+    for key, value in params.items():
+        if key in skip or value is None or value is False:
+            continue
+        
+        flag = "--" + key.replace("_", "-")
+        if value is True or value == "":
+            args.append(flag)
+        else:
+            args.extend([flag, str(value)])
+            
+    return args
+
+
+def run_command(command: list[str], timeout: int | None = None) -> subprocess.CompletedProcess[str]:
+    print("[benchmark] Command:", " ".join(command))
+    
+    env = os.environ.copy()
+    local_no_proxy = "127.0.0.1,localhost,::1"
+    for key in ("NO_PROXY", "no_proxy"):
+        current = env.get(key, "")
+        env[key] = ",".join(filter(None, [current, local_no_proxy]))
+
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+    )
+    print(result.stdout)
+    print(result.stderr)
+    return result
+
+def read_last_jsonl(path: Path) -> dict[str, Any]:
+    lines = [line.strip() for line in path.read_text(encoding="utf-8").splitlines()]
+    lines = [line for line in lines if line]
+    if not lines:
+        raise AssertionError(f"No JSONL records found in {path}")
+    return json.loads(lines[-1])
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""
+Global pytest fixtures and configuration for all tests.
+
+This root-level conftest is loaded by pytest before any sub-package conftest.
+It provides:
+  - Custom markers auto-registration
+"""
+
+
+def pytest_configure(config):
+    """Register all custom markers in a single place."""
+    for line in [
+        "benchmark: marks tests as benchmark smoke tests",
+        "e2e: marks tests as end-to-end smoke tests",
+        "functional: marks tests as functional correctness tests",
+        "gpu: marks tests that require a GPU",
+    ]:
+        config.addinivalue_line("markers", line)

--- a/tests/e2e_tests/concurrent/test_concurrent_smoke.py
+++ b/tests/e2e_tests/concurrent/test_concurrent_smoke.py
@@ -1,0 +1,419 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Concurrent inference smoke test driven by model YAML configs.
+
+This test mirrors the concurrent examples in ``examples/`` and runs one or more
+N-way async generation modes against a single SGLang Engine instance.
+
+The default mode is intentionally small for CI:
+- text model configs run text concurrency
+- image model configs run VL concurrency
+
+Set ``FL_CONCURRENT_MODES=text,vl,mixed`` or ``FL_CONCURRENT_MODES=all`` to run
+more modes without changing the YAML files.
+"""
+
+import asyncio
+import os
+import statistics
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from sglang import Engine
+from tests.utils.model_config import ModelConfig
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_IMAGE_DIR = Path(os.environ.get("IMAGE_DIR", _REPO_ROOT / "examples" / "test_images"))
+
+_MODEL = os.environ.get("FL_TEST_MODEL", "")
+_CASE = os.environ.get("FL_TEST_CASE", "")
+
+if not _MODEL or not _CASE:
+    pytest.skip(
+        "FL_TEST_MODEL and FL_TEST_CASE must be set (injected by run.py)",
+        allow_module_level=True,
+    )
+
+_CFG = ModelConfig.load(_MODEL, _CASE)
+
+if not os.path.exists(_CFG.model):
+    pytest.fail(f"Model not found: {_CFG.model}", pytrace=False)
+
+_DEFAULT_TEXT_CASES = [
+    {
+        "text": "How many states are there in the United States?",
+        "expected": ["50"],
+    },
+    {"text": "The capital of France is", "expected": ["paris"]},
+    {
+        "text": "What is the largest planet in the solar system?",
+        "expected": ["jupiter"],
+    },
+    {
+        "text": "Who wrote the play Romeo and Juliet?",
+        "expected": ["shakespeare"],
+    },
+    {"text": "What is 17 multiplied by 13?", "expected": ["221"]},
+    {
+        "text": "Name the three primary colors of light.",
+        "expected": ["red", "green", "blue"],
+    },
+    {"text": "What year did World War II end?", "expected": ["1945"]},
+    {
+        "text": "Explain the concept of gravity in one sentence.",
+        "expected": ["mass", "force", "attract"],
+    },
+]
+
+_DEFAULT_VL_CASES = [
+    {
+        "image": "red_square.jpg",
+        "question": "What color is shown in this image? Answer with one word.",
+        "expected": ["red"],
+    },
+    {
+        "image": "cat.jpg",
+        "question": "What animal is in this image? Answer with one word.",
+        "expected": ["cat"],
+    },
+    {
+        "image": "stop_sign.png",
+        "question": "What is the color of this sign? Answer with one word.",
+        "expected": ["red"],
+    },
+    {
+        "image": "digit_seven.png",
+        "question": "What digit is shown in this image? Answer with one digit.",
+        "expected": ["7"],
+    },
+]
+
+
+def _normalize_text_cases(raw_cases: list[Any]) -> list[dict[str, Any]]:
+    if not raw_cases:
+        return _DEFAULT_TEXT_CASES
+
+    cases = []
+    for item in raw_cases:
+        if isinstance(item, str):
+            cases.append({"text": item, "expected": []})
+            continue
+        expected = item.get("expected", [])
+        if isinstance(expected, str):
+            expected = [expected]
+        cases.append({"text": item["text"], "expected": expected})
+    return cases
+
+
+_TEXT_CASES = _normalize_text_cases(_CFG.concurrent.text_prompts)
+TEXT_PROMPTS = [case["text"] for case in _TEXT_CASES]
+TEXT_EXPECTED = {
+    case["text"]: case["expected"] for case in _TEXT_CASES if case.get("expected")
+}
+VL_CASES = _CFG.concurrent.vl_cases or _DEFAULT_VL_CASES
+
+ALL_MODES = ["text", "vl", "mixed"]
+CONCURRENT_N = int(
+    os.environ.get(
+        "FL_CONCURRENT_N",
+        os.environ.get("CONCURRENT_N", str(_CFG.concurrent.concurrent_n)),
+    )
+)
+_TEXT_SAMPLING = {"max_new_tokens": 64, "temperature": 0}
+_TEXT_SAMPLING.update(_CFG.concurrent.text_sampling)
+_TEXT_SAMPLING["max_new_tokens"] = int(
+    os.environ.get("FL_CONCURRENT_MAX_TOKENS", _TEXT_SAMPLING["max_new_tokens"])
+)
+
+_VL_SAMPLING = {"max_new_tokens": 64, "temperature": 0}
+_VL_SAMPLING.update(_CFG.concurrent.vl_sampling)
+_VL_SAMPLING["max_new_tokens"] = int(
+    os.environ.get("FL_CONCURRENT_VL_MAX_TOKENS", _VL_SAMPLING["max_new_tokens"])
+)
+
+_tokenizer = None
+_processor = None
+
+
+def _selected_modes() -> list[str]:
+    raw = os.environ.get("FL_CONCURRENT_MODES", "").strip()
+    if raw:
+        modes = ALL_MODES if raw == "all" else [m.strip() for m in raw.split(",")]
+        invalid = [m for m in modes if m not in ALL_MODES]
+        assert not invalid, f"Unsupported FL_CONCURRENT_MODES values: {invalid}"
+        return [m for m in modes if m]
+    if _CFG.concurrent.modes:
+        return _CFG.concurrent.modes
+    return ["vl"] if _CFG.generate.modality == "image" else ["text"]
+
+
+def _get_tokenizer():
+    global _tokenizer
+    if _tokenizer is None:
+        from transformers import AutoTokenizer
+
+        _tokenizer = AutoTokenizer.from_pretrained(_CFG.model, trust_remote_code=True)
+    return _tokenizer
+
+
+def _get_processor():
+    global _processor
+    if _processor is None:
+        from transformers import AutoProcessor
+
+        _processor = AutoProcessor.from_pretrained(_CFG.model, trust_remote_code=True)
+    return _processor
+
+
+def _apply_chat_template(template_owner, messages: list[dict[str, Any]]) -> str:
+    kwargs = {
+        "tokenize": False,
+        "add_generation_prompt": True,
+        "enable_thinking": False,
+    }
+    try:
+        return template_owner.apply_chat_template(messages, **kwargs)
+    except TypeError:
+        kwargs.pop("enable_thinking")
+        return template_owner.apply_chat_template(messages, **kwargs)
+
+
+def _text_prompt(question: str) -> str:
+    messages = [{"role": "user", "content": question}]
+    return _apply_chat_template(_get_tokenizer(), messages)
+
+
+def _image_uri(name: str) -> str:
+    path = Path(name)
+    if not path.is_absolute():
+        repo_relative = (_REPO_ROOT / path).resolve()
+        image_relative = (_IMAGE_DIR / path).resolve()
+        path = repo_relative if repo_relative.is_file() else image_relative
+    assert path.is_file(), f"Missing test image: {path}"
+    return f"file://{path.resolve()}"
+
+
+def _vl_prompt(question: str, image_uri: str) -> str:
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": image_uri}},
+                {"type": "text", "text": question},
+            ],
+        }
+    ]
+    return _apply_chat_template(_get_processor(), messages)
+
+
+def _output_text(output: Any) -> str:
+    if isinstance(output, dict):
+        return str(output.get("text", ""))
+    return str(getattr(output, "text", ""))
+
+
+def _completion_tokens(output: Any) -> int:
+    if not isinstance(output, dict):
+        return 0
+    return int(output.get("meta_info", {}).get("completion_tokens", 0) or 0)
+
+
+def _percentile(values: list[float], p: float) -> float:
+    if not values:
+        return 0.0
+    sorted_values = sorted(values)
+    index = (len(sorted_values) - 1) * p
+    floor = int(index)
+    ceil = min(floor + 1, len(sorted_values) - 1)
+    return sorted_values[floor] + (sorted_values[ceil] - sorted_values[floor]) * (index - floor)
+
+
+def _report(label: str, n_req: int, elapsed: float, latencies: list[float], total_tokens: int) -> None:
+    mean = statistics.fmean(latencies) if latencies else 0.0
+    p50 = _percentile(latencies, 0.50)
+    p99 = _percentile(latencies, 0.99)
+    print(
+        f"\n[{label}] {n_req} req | wall {elapsed:.2f}s | "
+        f"{n_req / elapsed:.2f} req/s | {total_tokens / elapsed:.1f} tok/s | "
+        f"latency mean {mean:.2f}s P50 {p50:.2f}s P99 {p99:.2f}s"
+    )
+
+
+def _assert_expected(text: str, expected: list[str], label: str) -> None:
+    assert text.strip(), f"Empty output for {label}"
+    lower = text.lower()
+    matched = any(item.lower() in lower for item in expected)
+    assert matched, f"Expected one of {expected!r} in output for {label}, got: {text!r}"
+
+
+def _validate_text(pairs: list[tuple[str, str]]) -> None:
+    for prompt, text in pairs:
+        assert text.strip(), f"Empty output for {prompt}"
+        expected = TEXT_EXPECTED.get(prompt, [])
+        if expected:
+            _assert_expected(text, expected, prompt)
+    print("  text validation passed.")
+
+
+def _validate_vl(pairs: list[tuple[dict[str, Any], str]]) -> None:
+    for case, text in pairs:
+        _assert_expected(text, case["expected"], case["image"])
+    print("  vl validation passed.")
+
+
+def _check_images() -> None:
+    missing = []
+    for case in VL_CASES:
+        try:
+            _image_uri(case["image"])
+        except AssertionError:
+            missing.append(case["image"])
+    assert not missing, "Missing test images: " + ", ".join(missing)
+
+
+def _engine_kwargs() -> dict[str, Any]:
+    kwargs = _CFG.engine_kwargs()
+    kwargs.setdefault("disable_cuda_graph", True)
+    kwargs.setdefault("disable_piecewise_cuda_graph", True)
+    return kwargs
+
+
+def _run_text_concurrent(engine: Engine) -> list[tuple[str, str]]:
+    base = [(prompt, _text_prompt(prompt)) for prompt in TEXT_PROMPTS]
+    items = [base[i % len(base)] for i in range(CONCURRENT_N)]
+
+    async def one(prompt_text: str):
+        start = time.perf_counter()
+        output = await engine.async_generate(prompt=prompt_text, sampling_params=_TEXT_SAMPLING)
+        return time.perf_counter() - start, output
+
+    async def run():
+        start = time.perf_counter()
+        results = await asyncio.gather(*(one(prompt_text) for _, prompt_text in items))
+        return time.perf_counter() - start, results
+
+    elapsed, results = engine.loop.run_until_complete(run())
+    latencies = [latency for latency, _ in results]
+    total_tokens = sum(_completion_tokens(output) for _, output in results)
+
+    for (label, _), (_, output) in zip(items[: min(len(items), len(base))], results):
+        print(f"  {label!r}\n    -> {_output_text(output)!r}")
+
+    _report("text-concurrent", CONCURRENT_N, elapsed, latencies, total_tokens)
+    return [(label, _output_text(output)) for (label, _), (_, output) in zip(items, results)]
+
+
+def _run_vl_concurrent(engine: Engine) -> list[tuple[dict[str, Any], str]]:
+    _check_images()
+    base = []
+    for case in VL_CASES:
+        uri = _image_uri(case["image"])
+        base.append((case, _vl_prompt(case["question"], uri), uri))
+    items = [base[i % len(base)] for i in range(CONCURRENT_N)]
+
+    async def one(prompt_text: str, image_uri: str):
+        start = time.perf_counter()
+        output = await engine.async_generate(
+            prompt=prompt_text,
+            image_data=[image_uri],
+            sampling_params=_VL_SAMPLING,
+        )
+        return time.perf_counter() - start, output
+
+    async def run():
+        start = time.perf_counter()
+        results = await asyncio.gather(*(one(prompt_text, uri) for _, prompt_text, uri in items))
+        return time.perf_counter() - start, results
+
+    elapsed, results = engine.loop.run_until_complete(run())
+    latencies = [latency for latency, _ in results]
+    total_tokens = sum(_completion_tokens(output) for _, output in results)
+
+    for (case, _, _), (_, output) in zip(items[: min(len(items), len(base))], results):
+        print(f"  [{case['image']}] {case['question']}\n    -> {_output_text(output)!r}")
+
+    _report("vl-concurrent", CONCURRENT_N, elapsed, latencies, total_tokens)
+    return [(case, _output_text(output)) for (case, _, _), (_, output) in zip(items, results)]
+
+
+def _run_mixed_concurrent(engine: Engine) -> tuple[list[tuple[str, str]], list[tuple[dict[str, Any], str]]]:
+    _check_images()
+    n_text = CONCURRENT_N // 2
+    n_vl = CONCURRENT_N - n_text
+
+    text_base = [(prompt, _text_prompt(prompt)) for prompt in TEXT_PROMPTS]
+    text_items = [text_base[i % len(text_base)] for i in range(n_text)]
+
+    vl_base = []
+    for case in VL_CASES:
+        uri = _image_uri(case["image"])
+        vl_base.append((case, _vl_prompt(case["question"], uri), uri))
+    vl_items = [vl_base[i % len(vl_base)] for i in range(n_vl)]
+
+    async def text_one(prompt_text: str):
+        start = time.perf_counter()
+        output = await engine.async_generate(prompt=prompt_text, sampling_params=_TEXT_SAMPLING)
+        return time.perf_counter() - start, output
+
+    async def vl_one(prompt_text: str, image_uri: str):
+        start = time.perf_counter()
+        output = await engine.async_generate(
+            prompt=prompt_text,
+            image_data=[image_uri],
+            sampling_params=_VL_SAMPLING,
+        )
+        return time.perf_counter() - start, output
+
+    async def run():
+        start = time.perf_counter()
+        outputs = await asyncio.gather(
+            *(text_one(prompt_text) for _, prompt_text in text_items),
+            *(vl_one(prompt_text, uri) for _, prompt_text, uri in vl_items),
+        )
+        return time.perf_counter() - start, outputs[:n_text], outputs[n_text:]
+
+    elapsed, text_results, vl_results = engine.loop.run_until_complete(run())
+    latencies = [latency for latency, _ in text_results] + [latency for latency, _ in vl_results]
+    total_tokens = sum(_completion_tokens(output) for _, output in [*text_results, *vl_results])
+
+    _report("mixed-concurrent", CONCURRENT_N, elapsed, latencies, total_tokens)
+    text_pairs = [(label, _output_text(output)) for (label, _), (_, output) in zip(text_items, text_results)]
+    vl_pairs = [(case, _output_text(output)) for (case, _, _), (_, output) in zip(vl_items, vl_results)]
+    return text_pairs, vl_pairs
+
+
+@pytest.mark.e2e
+def test_concurrent() -> None:
+    """Smoke test: run concurrent async generation and validate outputs."""
+    modes = _selected_modes()
+    print(f"\n[{_MODEL}/{_CASE}] concurrent modes: {modes}")
+    print(f"[{_MODEL}/{_CASE}] model: {_CFG.model}")
+    print(f"[{_MODEL}/{_CASE}] concurrent_n: {CONCURRENT_N}")
+
+    engine = Engine(**_engine_kwargs())
+    try:
+        for index, mode in enumerate(modes):
+            if index > 0 and hasattr(engine, "flush_cache"):
+                engine.flush_cache()
+            print(f"\n=== concurrent mode: {mode} ===")
+            if mode == "text":
+                _validate_text(_run_text_concurrent(engine))
+            elif mode == "vl":
+                _validate_vl(_run_vl_concurrent(engine))
+            elif mode == "mixed":
+                text_pairs, vl_pairs = _run_mixed_concurrent(engine)
+                _validate_text(text_pairs)
+                _validate_vl(vl_pairs)
+            else:
+                raise AssertionError(f"Unsupported concurrent mode: {mode}")
+    finally:
+        engine.shutdown()
+
+
+
+
+
+

--- a/tests/e2e_tests/inference/test_inference_smoke.py
+++ b/tests/e2e_tests/inference/test_inference_smoke.py
@@ -1,0 +1,366 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""
+Unified inference smoke test auto-generated from model YAML configs.
+
+This test file is driven by two environment variables set by ``tests/run.py``:
+
+- ``FL_TEST_MODEL``: Model family (e.g. ``qwen3``, ``minicpm``)
+- ``FL_TEST_CASE``:  Case name within the family (e.g. ``06b_tp1``, ``o45_tp2``)
+
+It loads ``tests/models/<model>/<case>.yaml``, constructs the SGLang Engine,
+runs generation for each prompt (with optional parametrize combos), and
+asserts that outputs are non-empty.
+
+Supports both text-only and multimodal (audio/image/video) models via the
+``generate.modality`` field in the YAML config.
+"""
+
+from pathlib import Path
+import os
+
+import pytest
+
+from tests.utils.model_config import ModelConfig
+from sglang import Engine
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# ---------------------------------------------------------------------------
+# Load config from environment (injected by run.py)
+# ---------------------------------------------------------------------------
+
+_MODEL = os.environ.get("FL_TEST_MODEL", "")
+_CASE = os.environ.get("FL_TEST_CASE", "")
+
+if not _MODEL or not _CASE:
+    pytest.skip(
+        "FL_TEST_MODEL and FL_TEST_CASE must be set (injected by run.py)",
+        allow_module_level=True,
+    )
+
+_CFG = ModelConfig.load(_MODEL, _CASE)
+
+if not os.path.exists(_CFG.model):
+    pytest.fail(
+        f"Model not found: {_CFG.model}",
+        pytrace=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Multimodal helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_asset_uri(asset: str) -> str:
+    """Resolve a local asset path or URL into a SGLang image/video/audio input."""
+    if asset.startswith(("http://", "https://", "file://", "data:")):
+        return asset
+
+    path = Path(asset)
+    if not path.is_absolute():
+        path = _REPO_ROOT / path
+    assert path.is_file(), f"Multimodal asset not found: {path}"
+    return f"file://{path.resolve()}"
+
+
+def _load_assets(modality: str, asset_names: list[str], count: int) -> dict:
+    """Load multimodal assets for SGLang Engine input.
+
+    Args:
+        modality: One of ``audio``, ``image``, ``video``.
+        asset_names: Pool of asset paths or URLs from YAML config.
+        count: Number of assets to include (0 returns empty dict).
+
+    Returns:
+        Dict suitable for SGLang ``generate`` keyword arguments.
+    """
+    if count <= 0:
+        return {}
+
+    selected = [_resolve_asset_uri(asset) for asset in asset_names[:count]]
+    key_map = {
+        "audio": "audio_data",
+        "image": "image_data",
+        "video": "video_data",
+    }
+    if modality not in key_map:
+        raise ValueError(f"Unsupported modality: {modality}")
+    return {key_map[modality]: selected}
+
+
+def _build_multimodal_prompt(
+    tokenizer,
+    question: str,
+    modality: str,
+    asset_count: int,
+) -> str:
+    """Build a chat prompt with multimodal placeholders.
+
+    Uses the tokenizer's ``apply_chat_template`` to format the prompt.
+    The placeholder format is determined by modality.
+    """
+    placeholder_map = {
+        "audio": "(<audio>./</audio>)",
+        "image": "(<image>./</image>)",
+        "video": "(<video>./</video>)",
+    }
+    placeholder = placeholder_map.get(modality, "")
+    content = (
+        f"{placeholder * asset_count}\n{question}" if asset_count > 0 else question
+    )
+
+    messages = [{"role": "user", "content": content}]
+    return tokenizer.apply_chat_template(
+        messages,
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+
+
+def _build_image_prompt(processor, question: str, image_uri: str) -> str:
+    """Build an image prompt using the Qwen-style processor chat template."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": image_uri}},
+                {"type": "text", "text": question},
+            ],
+        }
+    ]
+    return processor.apply_chat_template(
+        messages,
+        tokenize=False,
+        add_generation_prompt=True,
+        enable_thinking=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test function
+# ---------------------------------------------------------------------------
+
+
+def _get_max_asset_count() -> int:
+    """Return the maximum asset_count across all multimodal prompts."""
+    gen = _CFG.generate
+    if gen.modality == "text":
+        return 0
+    return max(
+        (p.get("asset_count", 0) for p in gen.prompts if isinstance(p, dict)),
+        default=0,
+    )
+
+
+def _output_text(output) -> str:
+    """Extract generated text from a SGLang Engine output object."""
+    if isinstance(output, dict):
+        return str(output.get("text", ""))
+    return str(getattr(output, "text", ""))
+
+
+def _assert_expected(text: str, expected, label: str) -> None:
+    """Assert an optional string/list expected value appears in the output."""
+    if not expected:
+        return
+    values = expected if isinstance(expected, list) else [expected]
+    lower = text.lower()
+    matched = any(str(item).lower() in lower for item in values)
+    assert matched, f"Expected one of {values!r} in output for {label}, got: {text!r}"
+
+
+def _run_text_test(llm: Engine, sampling_params: dict) -> None:
+    """Run text-only generation test.
+
+    Prompts can be plain strings or dicts with ``text`` and optional
+    ``expected`` (substring that must appear in the output).
+    """
+    gen = _CFG.generate
+    raw_prompts = gen.prompts
+    assert len(raw_prompts) > 0, "No prompts defined in YAML config"
+
+    # Normalize: str -> {"text": str}, dict stays as-is
+    prompt_cfgs = []
+    for p in raw_prompts:
+        if isinstance(p, str):
+            prompt_cfgs.append({"text": p})
+        else:
+            prompt_cfgs.append(p)
+
+    prompt_texts = [p["text"] for p in prompt_cfgs]
+    outputs = llm.generate(prompt_texts, sampling_params)
+    assert len(outputs) == len(prompt_cfgs), (
+        f"Expected {len(prompt_cfgs)} outputs, got {len(outputs)}"
+    )
+
+    for i, output in enumerate(outputs):
+        text = _output_text(output)
+        prompt = prompt_cfgs[i]["text"]
+        expected = prompt_cfgs[i].get("expected")
+
+        assert len(text) > 0, f"Empty output for prompt[{i}]: {prompt}"
+        print(f"  prompt[{i}]: {prompt!r}")
+        print(f"  output[{i}]: {text!r}")
+        _assert_expected(text, expected, f"prompt[{i}]")
+
+
+def _run_multimodal_test(llm: Engine, sampling_params: dict) -> None:
+    """Run multimodal generation test."""
+    gen = _CFG.generate
+
+    if gen.modality == "image":
+        from transformers import AutoProcessor
+
+        processor = AutoProcessor.from_pretrained(_CFG.model, trust_remote_code=True)
+        for i, prompt_cfg in enumerate(gen.prompts):
+            assert isinstance(prompt_cfg, dict), (
+                f"Image prompts must be dicts, got: {type(prompt_cfg)}"
+            )
+            question = prompt_cfg["question"]
+            image_uri = _resolve_asset_uri(prompt_cfg["image"])
+            prompt_text = _build_image_prompt(processor, question, image_uri)
+            output = llm.generate(
+                prompt=prompt_text,
+                image_data=[image_uri],
+                sampling_params=sampling_params,
+            )
+
+            text = _output_text(output)
+            assert len(text) > 0, f"Empty output for image prompt[{i}]"
+            print(f"  [image] {prompt_cfg['image']}: {question}")
+            print(f"  Output: {text!r}")
+            _assert_expected(text, prompt_cfg.get("expected"), f"image prompt[{i}]")
+        return
+
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        _CFG.model,
+        trust_remote_code=True,
+    )
+
+    stop_tokens = ["<|im_end|>", "<|endoftext|>"]
+    stop_ids = []
+    for t in stop_tokens:
+        token_id = tokenizer.convert_tokens_to_ids(t)
+        if isinstance(token_id, int) and token_id != tokenizer.unk_token_id:
+            stop_ids.append(token_id)
+
+    if stop_ids:
+        sampling_params = _CFG.sampling_kwargs(stop_token_ids=stop_ids)
+
+    for i, prompt_cfg in enumerate(gen.prompts):
+        assert isinstance(prompt_cfg, dict), (
+            f"Multimodal prompts must be dicts, got: {type(prompt_cfg)}"
+        )
+        question = prompt_cfg["question"]
+        asset_count = prompt_cfg.get("asset_count", 0)
+
+        prompt_text = _build_multimodal_prompt(
+            tokenizer,
+            question,
+            gen.modality,
+            asset_count,
+        )
+        mm_kwargs = _load_assets(gen.modality, gen.assets, asset_count)
+
+        output = llm.generate(
+            prompt=prompt_text,
+            sampling_params=sampling_params,
+            **mm_kwargs,
+        )
+
+        text = _output_text(output)
+        assert isinstance(text, str), f"Output is not str for prompt[{i}]"
+        assert len(text) > 0, f"Empty output for prompt[{i}]"
+
+        print(f"  [{gen.modality} count={asset_count}] Q: {question}")
+        print(f"  Output: {text!r}")
+        _assert_expected(text, prompt_cfg.get("expected"), f"prompt[{i}]")
+
+
+def _run_configured_vl_test(llm: Engine) -> None:
+    """Run optional image cases from generate.vl."""
+    vl = _CFG.generate.vl
+    cases = vl.get("cases", [])
+    if not cases:
+        return
+
+    print("\n=== generate.vl inference ===")
+
+    from transformers import AutoProcessor
+
+    processor = AutoProcessor.from_pretrained(_CFG.model, trust_remote_code=True)
+    sampling_params = dict(_CFG.generate.sampling)
+    sampling_params.update(vl.get("sampling", {}))
+
+    for i, case in enumerate(cases):
+        image_uri = _resolve_asset_uri(case["image"])
+        prompt_text = _build_image_prompt(processor, case["question"], image_uri)
+        output = llm.generate(
+            prompt=prompt_text,
+            image_data=[image_uri],
+            sampling_params=sampling_params,
+        )
+        text = _output_text(output)
+
+        assert text.strip(), f"Empty output for generate.vl case[{i}]"
+        _assert_expected(text, case.get("expected"), f"generate.vl case[{i}]")
+        print(f"  [generate.vl/{i}] {case['image']}: {case['question']}")
+        print(f"  output[{i}]: {text!r}")
+
+
+# ---------------------------------------------------------------------------
+# Parametrized test entry point
+# ---------------------------------------------------------------------------
+
+
+_COMBOS = _CFG.generate.get_parametrize_combos()
+_COMBO_IDS = [
+    "-".join(f"{k}={v}" for k, v in combo.items()) or "default" for combo in _COMBOS
+]
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("combo", _COMBOS, ids=_COMBO_IDS)
+def test_inference(combo: dict) -> None:
+    """Smoke test: load model, generate, assert non-empty output.
+
+    Each parametrize combo overrides engine params from the YAML config.
+    """
+    gen = _CFG.generate
+
+    # Build Engine kwargs with parametrize overrides
+    llm_kwargs = _CFG.engine_kwargs(**combo)
+
+    # For multimodal: inject limit_mm_per_prompt
+    max_assets = _get_max_asset_count()
+    if gen.modality != "text" and max_assets > 0:
+        llm_kwargs.setdefault(
+            "limit_mm_per_prompt",
+            {
+                "image": 0,
+                "video": 0,
+                "audio": 0,
+                gen.modality: max_assets,
+            },
+        )
+
+    combo_desc = ", ".join(f"{k}={v}" for k, v in combo.items()) or "default"
+    print(f"\n[{_MODEL}/{_CASE}] combo: {combo_desc}")
+    print(f"[{_MODEL}/{_CASE}] model: {_CFG.model}")
+
+    llm = Engine(**llm_kwargs)
+    try:
+        sampling_params = _CFG.sampling_kwargs()
+
+        if gen.modality == "text":
+            _run_text_test(llm, sampling_params)
+        else:
+            _run_multimodal_test(llm, sampling_params)
+
+        _run_configured_vl_test(llm)
+    finally:
+        llm.shutdown()

--- a/tests/e2e_tests/serving/server_helper.py
+++ b/tests/e2e_tests/serving/server_helper.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""
+Shared SGLang server lifecycle helper for serving E2E tests.
+
+Provides ``SGLangServer`` — a context manager that starts an SGLang server
+process, waits for readiness, and tears it down on exit.
+
+Usage in test fixtures::
+
+    @pytest.fixture(scope="module")
+    def sglang_server():
+        with SGLangServer(model_path=MODEL_PATH, tp_size=8) as srv:
+            yield srv
+
+
+    def test_completion(sglang_server):
+        resp = requests.post(f"{sglang_server.base_url}/v1/completions", ...)
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass, field
+
+import pytest
+import requests
+
+# Bypass HTTP proxies for local server connections.
+_NO_PROXY = {"http": None, "https": None}
+
+
+def _get_free_port() -> int:
+    # SGLang derives an internal gRPC port from the HTTP port. Keep the HTTP
+    # port low enough so derived ports stay within the valid 1-65535 range.
+    for port in range(30000, 55536):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            try:
+                sock.bind(("127.0.0.1", port))
+            except OSError:
+                continue
+            return port
+    raise RuntimeError("No free port found in range 30000-55535")
+
+
+def _append_no_proxy(env: dict[str, str]) -> dict[str, str]:
+    local_no_proxy = "127.0.0.1,localhost,::1"
+    for key in ("NO_PROXY", "no_proxy"):
+        current = env.get(key, "")
+        env[key] = ",".join(filter(None, [current, local_no_proxy]))
+    return env
+
+
+@dataclass
+class SGLangServer:
+    """Manages an SGLang serving process lifecycle."""
+
+    model_path: str
+    tp_size: int = 1
+    extra_args: list[str] = field(default_factory=list)
+    host: str = "127.0.0.1"
+    api_key: str = ""
+    served_model_name: str = ""
+    max_retries: int = 60
+    poll_interval: int = 10
+
+    # Set after start
+    port: int = 0
+    base_url: str = ""
+    _process: subprocess.Popen | None = None
+    _log_file: tempfile._TemporaryFileWrapper | None = None
+
+    def start(self) -> None:
+        if not self.port:
+            self.port = _get_free_port()
+        self.base_url = f"http://{self.host}:{self.port}/v1"
+
+        cmd = [
+            sys.executable,
+            "-m",
+            "sglang.launch_server",
+            "--model-path",
+            self.model_path,
+            "--tp-size",
+            str(self.tp_size),
+            "--host",
+            self.host,
+            "--port",
+            str(self.port),
+        ]
+        if self.api_key:
+            cmd.extend(["--api-key", self.api_key])
+        if self.served_model_name:
+            cmd.extend(["--served-model-name", self.served_model_name])
+        cmd.extend(self.extra_args)
+
+        model_short = os.path.basename(self.model_path)
+        print(f"\n[Setup] Starting SGLang ({model_short}, TP={self.tp_size})")
+        print(f"[Setup] Command: {' '.join(cmd)}")
+
+        self._log_file = tempfile.NamedTemporaryFile(  # noqa: SIM115
+            prefix=f"sglang_{model_short}_",
+            suffix=".log",
+            delete=False,
+        )
+        self._process = subprocess.Popen(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=self._log_file,
+            stderr=subprocess.STDOUT,
+            env=_append_no_proxy(os.environ.copy()),
+        )
+        self._wait_ready()
+
+    def stop(self) -> None:
+        if self._process is None:
+            return
+        print("\n[Teardown] Shutting down SGLang service...")
+        try:
+            self._process.terminate()
+            self._process.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            self._process.kill()
+            self._process.wait(timeout=10)
+        except Exception:
+            self._process.kill()
+        finally:
+            if self._log_file:
+                self._log_file.close()
+                if getattr(self, "_keep_log", False):
+                    print(f"[Teardown] Log preserved: {self._log_file.name}")
+                else:
+                    os.unlink(self._log_file.name)
+            self._process = None
+
+    def __enter__(self) -> "SGLangServer":
+        self.start()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.stop()
+
+    def _wait_ready(self) -> None:
+        headers = {}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        # Use /health for readiness check. It returns 200 once the HTTP server
+        # is accepting connections and the engine process is ready to serve.
+        health_url = f"http://{self.host}:{self.port}/health"
+        print(f"[Setup] Waiting for service to be ready (polling {health_url})...")
+        for i in range(self.max_retries):
+            if self._process and self._process.poll() is not None:
+                self._fail_with_logs(
+                    "SGLang process exited unexpectedly "
+                    f"(code={self._process.returncode})"
+                )
+
+            try:
+                resp = requests.get(
+                    health_url, headers=headers, timeout=10, proxies=_NO_PROXY
+                )
+                if resp.status_code == 200:
+                    print(f"[Setup] SGLang service ready (port={self.port})")
+                    return
+                detail = ""
+                with contextlib.suppress(Exception):
+                    detail = f" body={resp.text[:200]}"
+                print(
+                    f"[Setup] Waiting ({i + 1}/{self.max_retries})"
+                    f" status={resp.status_code}{detail}"
+                )
+            except requests.exceptions.RequestException as exc:
+                print(
+                    f"[Setup] Waiting ({i + 1}/{self.max_retries}) {type(exc).__name__}"
+                )
+
+            time.sleep(self.poll_interval)
+
+        self._fail_with_logs("SGLang service startup timed out")
+
+    def _fail_with_logs(self, message: str) -> None:
+        logs = ""
+        log_path = ""
+        if self._log_file:
+            self._log_file.flush()
+            log_path = self._log_file.name
+            with open(log_path, encoding="utf-8", errors="replace") as f:
+                logs = f.read()
+        # Keep log file for post-mortem inspection.
+        self._keep_log = True
+        self.stop()
+        tail = logs[-16000:] if len(logs) > 16000 else logs
+        extra = f"\nFull log: {log_path}" if log_path else ""
+        pytest.fail(
+            f"{message}.{extra}\nLogs ({len(logs)} chars, showing tail):\n{tail}"
+        )
+

--- a/tests/e2e_tests/serving/test_serving_smoke.py
+++ b/tests/e2e_tests/serving/test_serving_smoke.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""
+Unified SGLang serving smoke test driven by model YAML configs.
+
+Driven by environment variables set by ``tests/run.py``:
+
+- ``FL_TEST_MODEL``: Model family (e.g. ``qwen3``, ``qwen3_6``)
+- ``FL_TEST_CASE``:  Case name within the family (e.g. ``06b_tp1``,
+  ``35b_a3b_tp2_nograph``)
+
+Loads ``tests/models/<model>/<case>.yaml``, starts an SGLang server with the
+engine config, and validates configured endpoints (completion, chat, embedding).
+
+Supports both non-streaming (raw requests) and streaming (OpenAI SDK) modes,
+controlled by the ``serve.stream`` flag in the model YAML.
+"""
+
+import os
+
+import pytest
+import requests
+
+from tests.e2e_tests.serving.server_helper import _NO_PROXY, SGLangServer
+from tests.utils.model_config import ModelConfig
+
+# ---------------------------------------------------------------------------
+# Load config from environment (injected by run.py)
+# ---------------------------------------------------------------------------
+
+_MODEL = os.environ.get("FL_TEST_MODEL", "")
+_CASE = os.environ.get("FL_TEST_CASE", "")
+
+if not _MODEL or not _CASE:
+    pytest.skip(
+        "FL_TEST_MODEL and FL_TEST_CASE must be set (injected by run.py)",
+        allow_module_level=True,
+    )
+
+_CFG = ModelConfig.load(_MODEL, _CASE)
+
+if not os.path.exists(_CFG.model):
+    pytest.fail(
+        f"Model not found: {_CFG.model}",
+        pytrace=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Server fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def server():
+    """Start SGLang server with model config and optional serve overrides."""
+    serve = _CFG.serve
+
+    # Build extra_args from engine config + serve-specific overrides.
+    extra_args = _CFG.serve_args(**serve.extra_engine)
+
+    with SGLangServer(
+        model_path=_CFG.model,
+        tp_size=int(_CFG.engine.get("tensor_parallel_size", 1)),
+        api_key=serve.api_key,
+        served_model_name=serve.served_model_name,
+        max_retries=serve.startup_retries,
+        extra_args=extra_args,
+    ) as srv:
+        yield srv
+
+
+@pytest.fixture
+def base_url(server):
+    return server.base_url
+
+
+@pytest.fixture
+def headers():
+    serve = _CFG.serve
+    h: dict[str, str] = {"Content-Type": "application/json"}
+    if serve.api_key:
+        h["Authorization"] = f"Bearer {serve.api_key}"
+    return h
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+_REQUEST_MODEL = _CFG.serve.request_model(_CFG.model)
+
+
+@pytest.mark.e2e
+def test_model_list(base_url, headers):
+    """Service must expose the loaded model in /v1/models."""
+    response = requests.get(f"{base_url}/models", headers=headers, proxies=_NO_PROXY)
+    assert response.status_code == 200
+    models = response.json()["data"]
+    assert any(m["id"] == _REQUEST_MODEL for m in models)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint runners
+# ---------------------------------------------------------------------------
+
+
+def _run_completion(base_url: str, headers: dict[str, str]) -> None:
+    """Validate /v1/completions endpoint."""
+    serve = _CFG.serve
+    payload = {
+        "model": _REQUEST_MODEL,
+        "prompt": serve.completion_prompt,
+        "max_tokens": serve.max_tokens,
+        **serve.sampling,
+    }
+
+    response = requests.post(
+        f"{base_url}/completions",
+        headers=headers,
+        json=payload,
+        proxies=_NO_PROXY,
+    )
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert "choices" in data
+    assert len(data["choices"]) > 0
+
+    generated_text = data["choices"][0]["text"]
+    assert len(generated_text.strip()) > 0, "Generated text is empty"
+    print(f"\nGenerated text: {generated_text}")
+
+
+def _run_chat(base_url: str, headers: dict[str, str]) -> None:
+    """Validate /v1/chat/completions endpoint.
+
+    When ``serve.stream`` is True, uses the OpenAI SDK for streaming.
+    Otherwise, uses a plain requests POST.
+    """
+    serve = _CFG.serve
+    messages = serve.chat_messages or [{"role": "user", "content": "Hello"}]
+
+    if serve.stream:
+        _run_chat_streaming(base_url, serve, messages)
+    else:
+        _run_chat_non_streaming(base_url, headers, serve, messages)
+
+
+def _run_chat_non_streaming(
+    base_url: str,
+    headers: dict[str, str],
+    serve,
+    messages: list[dict],
+) -> None:
+    """Non-streaming chat completions via raw requests."""
+    payload: dict = {
+        "model": _REQUEST_MODEL,
+        "messages": messages,
+        "max_tokens": serve.max_tokens,
+        **serve.sampling,
+    }
+    if serve.extra_body:
+        payload.update(serve.extra_body)
+
+    response = requests.post(
+        f"{base_url}/chat/completions",
+        headers=headers,
+        json=payload,
+        proxies=_NO_PROXY,
+    )
+    assert response.status_code == 200, response.text
+
+    data = response.json()
+    assert "choices" in data
+    assert len(data["choices"]) > 0
+
+    content = data["choices"][0]["message"]["content"]
+    assert len(content.strip()) > 0, "Assistant message is empty"
+    print(f"\nResponse: {content}")
+
+
+def _run_chat_streaming(
+    base_url: str,
+    serve,
+    messages: list[dict],
+) -> None:
+    """Streaming chat completions via OpenAI SDK."""
+    import httpx
+    from openai import OpenAI
+
+    client = OpenAI(
+        api_key=serve.api_key or "EMPTY",
+        base_url=base_url,
+        http_client=httpx.Client(trust_env=False),
+    )
+
+    create_kwargs: dict = {
+        "model": _REQUEST_MODEL,
+        "messages": messages,
+        "max_tokens": serve.max_tokens,
+        "stream": True,
+        **serve.sampling,
+    }
+    if serve.extra_body:
+        create_kwargs["extra_body"] = serve.extra_body
+
+    response = client.chat.completions.create(**create_kwargs)
+
+    text = ""
+    for chunk in response:
+        if chunk.choices and chunk.choices[0].delta.content:
+            text += chunk.choices[0].delta.content
+
+    assert len(text.strip()) > 0, "Streaming response is empty"
+    print(f"\nStreaming response: {text}")
+
+
+def _run_embedding(base_url: str, headers: dict[str, str]) -> None:
+    """Validate /v1/embeddings endpoint."""
+    serve = _CFG.serve
+    payload = {
+        "model": _REQUEST_MODEL,
+        "input": serve.embedding_input or "Hello world",
+    }
+
+    response = requests.post(
+        f"{base_url}/embeddings",
+        headers=headers,
+        json=payload,
+        proxies=_NO_PROXY,
+    )
+    assert response.status_code == 200, response.text
+
+    data = response.json()
+    assert "data" in data
+    assert len(data["data"]) > 0
+    assert len(data["data"][0]["embedding"]) > 0
+    print(f"\nEmbedding dimension: {len(data['data'][0]['embedding'])}")
+
+
+_ENDPOINT_RUNNERS = {
+    "completion": _run_completion,
+    "chat": _run_chat,
+    "embedding": _run_embedding,
+}
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("endpoint", _CFG.serve.endpoints, ids=_CFG.serve.endpoints)
+def test_endpoint(endpoint: str, base_url, headers):
+    """Validate a serving endpoint configured in the model YAML."""
+    runner = _ENDPOINT_RUNNERS.get(endpoint)
+    assert runner is not None, f"Unknown endpoint type: {endpoint}"
+    runner(base_url, headers)

--- a/tests/functional_tests/compilation/test_graph_capture.py
+++ b/tests/functional_tests/compilation/test_graph_capture.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Functional smoke tests for SGLang-FL graph capture integration.
+
+SGLang-FL does not provide its own graph wrapper. It declares graph capability
+through ``PlatformFL`` and lets SGLang choose the native GraphRunner. These tests
+therefore cover platform graph capability, runner selection, basic CUDA graph
+capture/replay, and a small ``call_op`` capture smoke path.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+pytestmark = [pytest.mark.functional]
+
+
+def _platform_for(device_type: str):
+    from sglang_fl.platform import PlatformFL
+
+    platform = PlatformFL.__new__(PlatformFL)
+    platform._device_type = device_type
+    return platform
+
+
+def test_platform_graph_capability_flags() -> None:
+    """Check PlatformFL graph capability declarations by device type."""
+    expected = {
+        "cuda": (True, True),
+        "npu": (True, False),
+        "musa": (True, False),
+        "cpu": (False, False),
+    }
+
+    for device_type, (cuda_graph, piecewise_graph) in expected.items():
+        platform = _platform_for(device_type)
+        assert platform.support_cuda_graph() is cuda_graph
+        assert platform.support_piecewise_cuda_graph() is piecewise_graph
+
+
+def test_cuda_like_platform_uses_sglang_cuda_graph_runner() -> None:
+    """CUDA and MUSA reuse SGLang's native CudaGraphRunner."""
+    from sglang.srt.model_executor.cuda_graph_runner import CudaGraphRunner
+
+    assert _platform_for("cuda").get_graph_runner_cls() is CudaGraphRunner
+    assert _platform_for("musa").get_graph_runner_cls() is CudaGraphRunner
+
+
+def test_npu_platform_uses_sglang_npu_graph_runner() -> None:
+    """NPU selects SGLang's native NPUGraphRunner when the NPU package exists."""
+    try:
+        from sglang.srt.hardware_backend.npu.graph_runner.npu_graph_runner import (
+            NPUGraphRunner,
+        )
+    except Exception as exc:  # pragma: no cover - depends on NPU dependencies
+        pytest.skip(f"SGLang NPUGraphRunner unavailable in this environment: {exc}")
+
+    assert _platform_for("npu").get_graph_runner_cls() is NPUGraphRunner
+
+
+@pytest.mark.gpu
+def test_basic_cuda_graph_capture_and_replay(device) -> None:
+    """Check basic CUDA graph capture/replay works in the functional environment."""
+    if device.type != "cuda":
+        pytest.skip("CUDA graph capture smoke test requires CUDA")
+
+    static_input = torch.randn(4, 8, device=device)
+    static_output = torch.empty_like(static_input)
+
+    def computation(x: torch.Tensor, out: torch.Tensor) -> None:
+        out.copy_(x * 2 + 1)
+
+    computation(static_input, static_output)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        computation(static_input, static_output)
+
+    new_input = torch.ones_like(static_input)
+    static_input.copy_(new_input)
+    graph.replay()
+
+    assert torch.allclose(static_output, new_input * 2 + 1)
+
+
+@pytest.mark.gpu
+def test_call_op_silu_and_mul_cuda_graph_capture(device) -> None:
+    """Check FL dispatch/call_op does not break a small CUDA graph capture."""
+    if device.type != "cuda":
+        pytest.skip("call_op graph capture smoke test requires CUDA")
+
+    from sglang_fl.dispatch import SelectionPolicy, call_op, policy_context
+
+    static_input = torch.randn(4, 16, device=device)
+    static_output = torch.empty(4, 8, device=device)
+    policy = SelectionPolicy.from_dict(prefer="reference", strict=False)
+
+    with policy_context(policy):
+        static_output.copy_(call_op("silu_and_mul", None, static_input))
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with policy_context(policy):
+        with torch.cuda.graph(graph):
+            static_output.copy_(call_op("silu_and_mul", None, static_input))
+
+    new_input = torch.randn_like(static_input)
+    static_input.copy_(new_input)
+    graph.replay()
+
+    half = new_input.shape[-1] // 2
+    expected = F.silu(new_input[..., :half]) * new_input[..., half:]
+    assert torch.allclose(static_output, expected, rtol=1e-3, atol=1e-3)

--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Shared fixtures for SGLang-FL functional tests."""
+
+import pytest
+import torch
+
+
+@pytest.fixture(scope="session")
+def device():
+    """Return a CUDA device for functional operator tests."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    return torch.device("cuda")

--- a/tests/functional_tests/distributed/test_collective_ops.py
+++ b/tests/functional_tests/distributed/test_collective_ops.py
@@ -1,0 +1,493 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Functional smoke tests for SGLang-FL distributed collectives.
+
+These tests use lightweight mocks instead of initializing a real distributed
+process group. The goal is to validate importability, routing decisions, and
+basic tensor/metadata semantics in ``CommunicatorFL``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+pytestmark = [pytest.mark.functional]
+
+
+class _FakePlatform:
+    def __init__(self, backend: str = "nccl") -> None:
+        self._dist_backend = backend
+
+
+class _FakeFlagCX:
+    disabled = False
+    available = True
+
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    def all_reduce(self, tensor: torch.Tensor) -> torch.Tensor:
+        self.calls.append(("all_reduce", tensor.clone()))
+        return tensor + 1
+
+    def reduce_scatter(self, output: torch.Tensor, input_: torch.Tensor) -> None:
+        self.calls.append(("reduce_scatter", tuple(output.shape), tuple(input_.shape)))
+        output.copy_(input_[: output.shape[0]])
+
+    def reduce_scatterv(self, output: torch.Tensor, input_: torch.Tensor, sizes) -> None:
+        self.calls.append(("reduce_scatterv", list(sizes)))
+        output.copy_(input_[: output.shape[0]])
+
+    def all_gather(self, output: torch.Tensor, input_: torch.Tensor) -> None:
+        self.calls.append(("all_gather", tuple(output.shape), tuple(input_.shape)))
+        output[: input_.shape[0]].copy_(input_)
+
+    def all_gatherv(self, output: torch.Tensor, input_: torch.Tensor, sizes) -> None:
+        self.calls.append(("all_gatherv", list(sizes)))
+        output[: input_.shape[0]].copy_(input_)
+
+    def broadcast(self, tensor: torch.Tensor, src: int) -> None:
+        self.calls.append(("broadcast", src, tuple(tensor.shape)))
+
+    def send(self, tensor: torch.Tensor, dst: int) -> None:
+        self.calls.append(("send", dst, tuple(tensor.shape)))
+
+    def recv(self, tensor: torch.Tensor, src: int) -> None:
+        self.calls.append(("recv", src, tuple(tensor.shape)))
+        tensor.fill_(src)
+
+    def group_start(self) -> None:
+        self.calls.append(("group_start",))
+
+    def group_end(self) -> None:
+        self.calls.append(("group_end",))
+
+
+class _FakeWork:
+    def __init__(self) -> None:
+        self.wait = Mock()
+
+
+def _make_comm(*, world_size: int = 2, rank: int = 0, flagcx=None):
+    from sglang_fl.distributed.communicator import CommunicatorFL
+
+    comm = CommunicatorFL.__new__(CommunicatorFL)
+    comm.cpu_group = "cpu-group"
+    comm.device = torch.device("cpu")
+    comm.device_group = "device-group"
+    comm.world_size = world_size
+    comm.rank_in_group = rank
+    comm.ranks = list(range(10, 10 + world_size))
+    comm._dist_backend = "flagcx" if flagcx else "nccl"
+    comm._flagcx_comm = flagcx
+    return comm
+
+
+def test_communicator_fl_import() -> None:
+    from sglang_fl.distributed.communicator import CommunicatorFL, TensorMetadata
+
+    assert CommunicatorFL.__name__ == "CommunicatorFL"
+    assert TensorMetadata("cpu", torch.float32, torch.Size([1])).device == "cpu"
+
+
+def test_flagcx_communicator_import() -> None:
+    from sglang_fl.distributed.device_communicators.flagcx import FlagCXCommunicator
+
+    assert FlagCXCommunicator.__name__ == "FlagCXCommunicator"
+
+
+def test_world_size_one_skips_flagcx_creation(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+    import sglang_fl.platform as platform_mod
+    import sglang_fl.distributed.device_communicators.flagcx as flagcx_mod
+
+    monkeypatch.setattr(platform_mod, "PlatformFL", lambda: _FakePlatform("flagcx"))
+    fake_ctor = Mock(return_value=_FakeFlagCX())
+    monkeypatch.setattr(flagcx_mod, "FlagCXCommunicator", fake_ctor)
+
+    comm = comm_mod.CommunicatorFL(
+        cpu_group="cpu-group",
+        device=torch.device("cpu"),
+        device_group="device-group",
+        world_size=1,
+        rank_in_group=0,
+        ranks=[0],
+    )
+
+    assert comm._dist_backend == "flagcx"
+    assert comm._flagcx_comm is None
+    fake_ctor.assert_not_called()
+
+
+def test_flagcx_creation_failure_falls_back(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+    import sglang_fl.platform as platform_mod
+    import sglang_fl.distributed.device_communicators.flagcx as flagcx_mod
+
+    monkeypatch.setattr(platform_mod, "PlatformFL", lambda: _FakePlatform("flagcx"))
+    monkeypatch.setattr(
+        flagcx_mod,
+        "FlagCXCommunicator",
+        Mock(side_effect=RuntimeError("flagcx unavailable")),
+    )
+
+    comm = comm_mod.CommunicatorFL(
+        cpu_group="cpu-group",
+        device=torch.device("cpu"),
+        device_group="device-group",
+        world_size=2,
+        rank_in_group=0,
+        ranks=[0, 1],
+    )
+
+    assert comm._dist_backend == "flagcx"
+    assert comm._flagcx_comm is None
+
+
+def test_flagcx_backend_creates_communicator(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+    import sglang_fl.platform as platform_mod
+    import sglang_fl.distributed.device_communicators.flagcx as flagcx_mod
+
+    fake_flagcx = _FakeFlagCX()
+    fake_ctor = Mock(return_value=fake_flagcx)
+    monkeypatch.setattr(platform_mod, "PlatformFL", lambda: _FakePlatform("flagcx"))
+    monkeypatch.setattr(flagcx_mod, "FlagCXCommunicator", fake_ctor)
+
+    comm = comm_mod.CommunicatorFL(
+        cpu_group="cpu-group",
+        device=torch.device("cpu"),
+        device_group="device-group",
+        world_size=2,
+        rank_in_group=0,
+        ranks=[0, 1],
+    )
+
+    assert comm._flagcx_comm is fake_flagcx
+    fake_ctor.assert_called_once_with(group="cpu-group", device=torch.device("cpu"))
+
+
+def test_all_reduce_routes_to_flagcx_and_copies_back(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+
+    monkeypatch.setattr(comm_mod.dist, "all_reduce", Mock())
+    flagcx = _FakeFlagCX()
+    comm = _make_comm(flagcx=flagcx)
+    tensor = torch.tensor([1.0, 2.0])
+
+    out = comm.all_reduce(tensor)
+
+    assert out is tensor
+    assert torch.equal(tensor, torch.tensor([2.0, 3.0]))
+    assert flagcx.calls[0][0] == "all_reduce"
+    comm_mod.dist.all_reduce.assert_not_called()
+
+
+def test_all_reduce_falls_back_to_torch_when_flagcx_disabled(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+
+    flagcx = _FakeFlagCX()
+    flagcx.disabled = True
+    dist_all_reduce = Mock()
+    monkeypatch.setattr(comm_mod.dist, "all_reduce", dist_all_reduce)
+    comm = _make_comm(flagcx=flagcx)
+    tensor = torch.tensor([1.0])
+
+    assert comm.all_reduce(tensor) is tensor
+    dist_all_reduce.assert_called_once_with(tensor, group="device-group")
+    assert flagcx.calls == []
+
+
+def test_reduce_scatter_routes_to_flagcx(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+
+    monkeypatch.setattr(comm_mod.dist, "reduce_scatter_tensor", Mock())
+    flagcx = _FakeFlagCX()
+    comm = _make_comm(flagcx=flagcx)
+    input_ = torch.arange(4.0)
+    output = torch.empty(2)
+
+    comm.reduce_scatter(output, input_)
+
+    assert torch.equal(output, torch.tensor([0.0, 1.0]))
+    assert flagcx.calls[0][0] == "reduce_scatter"
+    comm_mod.dist.reduce_scatter_tensor.assert_not_called()
+
+
+def test_reduce_scatter_falls_back_to_torch(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+
+    dist_reduce_scatter = Mock()
+    monkeypatch.setattr(comm_mod.dist, "reduce_scatter_tensor", dist_reduce_scatter)
+    comm = _make_comm()
+    input_ = torch.arange(4.0)
+    output = torch.empty(2)
+
+    comm.reduce_scatter(output, input_)
+
+    dist_reduce_scatter.assert_called_once_with(output, input_, group="device-group")
+
+
+def test_all_gather_routes_to_flagcx(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+
+    monkeypatch.setattr(comm_mod.dist, "all_gather_into_tensor", Mock())
+    flagcx = _FakeFlagCX()
+    comm = _make_comm(flagcx=flagcx)
+    input_ = torch.tensor([3.0, 4.0])
+    output = torch.empty(4)
+
+    comm.all_gather(output, input_)
+
+    assert torch.equal(output[:2], input_)
+    assert flagcx.calls[0][0] == "all_gather"
+    comm_mod.dist.all_gather_into_tensor.assert_not_called()
+
+
+def test_all_gather_falls_back_to_torch(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+
+    dist_all_gather = Mock()
+    monkeypatch.setattr(comm_mod.dist, "all_gather_into_tensor", dist_all_gather)
+    comm = _make_comm()
+    input_ = torch.tensor([3.0, 4.0])
+    output = torch.empty(4)
+
+    comm.all_gather(output, input_)
+
+    dist_all_gather.assert_called_once_with(output, input_, group="device-group")
+
+
+def test_send_recv_route_to_flagcx(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+
+    monkeypatch.setattr(comm_mod.dist, "send", Mock())
+    monkeypatch.setattr(comm_mod.dist, "recv", Mock())
+    flagcx = _FakeFlagCX()
+    comm = _make_comm(flagcx=flagcx)
+    send_tensor = torch.ones(2)
+    recv_tensor = torch.empty(2)
+
+    comm.send(send_tensor, dst=1)
+    comm.recv(recv_tensor, src=1)
+
+    assert ("send", 1, (2,)) in flagcx.calls
+    assert ("recv", 1, (2,)) in flagcx.calls
+    assert torch.equal(recv_tensor, torch.tensor([1.0, 1.0]))
+    comm_mod.dist.send.assert_not_called()
+    comm_mod.dist.recv.assert_not_called()
+
+
+def test_send_recv_fallback_uses_global_ranks(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+
+    dist_send = Mock()
+    dist_recv = Mock()
+    monkeypatch.setattr(comm_mod.dist, "send", dist_send)
+    monkeypatch.setattr(comm_mod.dist, "recv", dist_recv)
+    comm = _make_comm(world_size=2, rank=0)
+    tensor = torch.ones(2)
+
+    comm.send(tensor, dst=1)
+    comm.recv(tensor, src=1)
+
+    dist_send.assert_called_once_with(tensor, 11, "device-group")
+    dist_recv.assert_called_once_with(tensor, 11, "device-group")
+
+
+def test_broadcast_fallback_uses_global_src_rank(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+
+    dist_broadcast = Mock()
+    monkeypatch.setattr(comm_mod.dist, "broadcast", dist_broadcast)
+    comm = _make_comm(world_size=2, rank=0)
+    tensor = torch.ones(2)
+
+    assert comm.broadcast(tensor, src=1) is tensor
+    dist_broadcast.assert_called_once_with(tensor, src=11, group="device-group")
+
+
+def test_reduce_scatterv_sizes_select_rank_chunk(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+
+    monkeypatch.setattr(
+        comm_mod.dist,
+        "reduce_scatter_tensor",
+        lambda output, input_, group=None: output.copy_(input_[: output.shape[0]]),
+    )
+    input_ = torch.arange(10.0).reshape(5, 2)
+
+    rank0 = _make_comm(world_size=2, rank=0).reduce_scatterv(input_, sizes=[2, 3])
+    rank1 = _make_comm(world_size=2, rank=1).reduce_scatterv(input_, sizes=[2, 3])
+
+    assert rank0.shape == (2, 2)
+    assert rank1.shape == (3, 2)
+
+
+def test_reduce_scatterv_invalid_sizes_asserts() -> None:
+    comm = _make_comm(world_size=2, rank=0)
+    with pytest.raises(AssertionError):
+        comm.reduce_scatterv(torch.arange(8.0).reshape(4, 2), sizes=[2, 3])
+
+
+def test_all_gatherv_output_shape_and_torch_path(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+
+    calls = []
+
+    def fake_all_gather(output, input_, group=None):
+        calls.append((tuple(output.shape), tuple(input_.shape), group))
+        output[: input_.shape[0]].copy_(input_)
+
+    monkeypatch.setattr(comm_mod.dist, "all_gather_into_tensor", fake_all_gather)
+    comm = _make_comm(world_size=2, rank=1)
+    input_ = torch.ones(3, 2)
+
+    outputs = comm.all_gatherv(input_, sizes=[2, 3])
+
+    assert isinstance(outputs, list)
+    assert outputs[0].shape == (5, 2)
+    assert calls == [((5, 2), (3, 2), "device-group")]
+
+
+def test_all_gatherv_equal_sizes_uses_regular_all_gather(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+
+    dist_all_gather = Mock(side_effect=lambda output, input_, group=None: output.zero_())
+    monkeypatch.setattr(comm_mod.dist, "all_gather_into_tensor", dist_all_gather)
+    comm = _make_comm(world_size=2, rank=0)
+
+    outputs = comm.all_gatherv(torch.ones(2, 2), sizes=[2, 2])
+
+    assert outputs[0].shape == (4, 2)
+    dist_all_gather.assert_called_once()
+
+
+def test_broadcast_tensor_dict_sender_metadata_and_tensor_route(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+    from sglang_fl.distributed.communicator import TensorMetadata
+
+    dist_broadcast = Mock()
+    monkeypatch.setattr(comm_mod.dist, "broadcast", dist_broadcast)
+    comm = _make_comm(world_size=2, rank=0)
+    tensor_dict = {
+        "tensor": torch.ones(2),
+        "empty": torch.empty(0),
+        "value": "metadata-only",
+    }
+    sent_objects = []
+
+    def broadcast_object_fn(obj, src):
+        sent_objects.append((obj, src))
+        return obj
+
+    out = comm.broadcast_tensor_dict(tensor_dict, src=0, rank_in_group=0, broadcast_object_fn=broadcast_object_fn)
+
+    assert out is tensor_dict
+    metadata = sent_objects[0][0]
+    assert metadata[0][0] == "tensor"
+    assert isinstance(metadata[0][1], TensorMetadata)
+    assert metadata[1][0] == "empty"
+    assert isinstance(metadata[1][1], TensorMetadata)
+    assert metadata[2] == ("value", "metadata-only")
+    dist_broadcast.assert_called_once_with(tensor_dict["tensor"], src=10, group="cpu-group")
+
+
+def test_broadcast_tensor_dict_receiver_allocates_from_metadata(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+    from sglang_fl.distributed.communicator import TensorMetadata
+
+    dist_broadcast = Mock()
+    monkeypatch.setattr(comm_mod.dist, "broadcast", dist_broadcast)
+    comm = _make_comm(world_size=2, rank=1)
+    metadata = [
+        ("tensor", TensorMetadata("cpu", torch.float32, torch.Size([2]))),
+        ("empty", TensorMetadata("cpu", torch.float32, torch.Size([0]))),
+        ("value", 123),
+    ]
+
+    out = comm.broadcast_tensor_dict(None, src=0, rank_in_group=1, broadcast_object_fn=lambda obj, src: metadata)
+
+    assert out["tensor"].shape == (2,)
+    assert out["empty"].shape == (0,)
+    assert out["value"] == 123
+    dist_broadcast.assert_called_once()
+
+
+def test_send_tensor_dict_metadata_async_and_skips_empty(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+    from sglang_fl.distributed.communicator import TensorMetadata
+
+    dist_send = Mock()
+    monkeypatch.setattr(comm_mod.dist, "send", dist_send)
+    comm = _make_comm(world_size=2, rank=0)
+    works = [object()]
+    sent = []
+
+    def send_object_fn(metadata, dst, async_send=False):
+        sent.append((metadata, dst, async_send))
+        return works
+
+    result = comm.send_tensor_dict(
+        {"tensor": torch.ones(2), "empty": torch.empty(0), "value": "x"},
+        dst=1,
+        send_object_fn=send_object_fn,
+    )
+
+    assert result is works
+    metadata = sent[0][0]
+    assert sent[0][1:] == (1, True)
+    assert isinstance(metadata[0][1], TensorMetadata)
+    assert isinstance(metadata[1][1], TensorMetadata)
+    assert metadata[2] == ("value", "x")
+    dist_send.assert_called_once()
+
+
+def test_recv_tensor_dict_allocates_and_waits(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+    from sglang_fl.distributed.communicator import TensorMetadata
+
+    work = _FakeWork()
+    irecv = Mock(return_value=work)
+    monkeypatch.setattr(comm_mod.dist, "irecv", irecv)
+    comm = _make_comm(world_size=2, rank=1)
+    metadata = [
+        ("tensor", TensorMetadata("cpu", torch.float32, torch.Size([2]))),
+        ("empty", TensorMetadata("cpu", torch.float32, torch.Size([0]))),
+        ("value", "x"),
+    ]
+
+    out = comm.recv_tensor_dict(src=0, recv_object_fn=lambda src: metadata)
+
+    assert out["tensor"].shape == (2,)
+    assert out["empty"].shape == (0,)
+    assert out["value"] == "x"
+    irecv.assert_called_once()
+    work.wait.assert_called_once()
+
+
+def test_recv_tensor_dict_all_gather_restores_full_tensor(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+    from sglang_fl.distributed.communicator import TensorMetadata
+
+    monkeypatch.setattr(comm_mod.dist, "irecv", Mock(return_value=_FakeWork()))
+    comm = _make_comm(world_size=2, rank=1)
+    metadata = [("tensor", TensorMetadata("cpu", torch.float32, torch.Size([4])))]
+    all_gather_group = SimpleNamespace(
+        world_size=2,
+        rank_in_group=1,
+        _all_gather_into_tensor=Mock(side_effect=lambda full, part: full.fill_(7)),
+    )
+
+    out = comm.recv_tensor_dict(
+        src=0,
+        recv_object_fn=lambda src: metadata,
+        all_gather_group=all_gather_group,
+    )
+
+    assert torch.equal(out["tensor"], torch.full((4,), 7.0))
+    all_gather_group._all_gather_into_tensor.assert_called_once()

--- a/tests/functional_tests/ops/test_ops_correctness.py
+++ b/tests/functional_tests/ops/test_ops_correctness.py
@@ -1,0 +1,402 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Functional correctness tests for SGLang-FL dispatch operators.
+
+These tests execute real ``sglang_fl.dispatch.call_op`` paths on GPU and compare
+basic operator outputs against the reference backend where numerical comparison
+is stable. They are intentionally smaller than e2e model tests and focus on the
+foundational bridge/dispatch operators used by SGLang models.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from sglang_fl.dispatch import SelectionPolicy, call_op, policy_context
+
+pytestmark = [pytest.mark.functional, pytest.mark.gpu]
+
+
+_RTOL = 1e-3
+_ATOL = 1e-3
+_HALF_TOL = 2e-2
+
+
+def _allclose(actual: torch.Tensor, expected: torch.Tensor, *, dtype: torch.dtype) -> bool:
+    tol = _HALF_TOL if dtype in (torch.float16, torch.bfloat16) else _ATOL
+    return torch.allclose(actual.float(), expected.float(), rtol=tol, atol=tol)
+
+
+def _selected_prefer() -> str:
+    prefer = os.environ.get("SGLANG_FL_PREFER", "flagos").strip().lower()
+    return prefer if prefer in {"flagos", "vendor", "reference"} else "flagos"
+
+
+def _call_reference(op_name: str, *args, **kwargs):
+    policy = SelectionPolicy.from_dict(prefer="reference", strict=False)
+    with policy_context(policy):
+        return call_op(op_name, *args, **kwargs)
+
+
+def _call_selected(op_name: str, *args, **kwargs):
+    # Functional tests should validate the preferred implementation when it is
+    # available, while still allowing fallback so partially wired backends do not
+    # hide the rest of the operator surface.
+    policy = SelectionPolicy.from_dict(prefer=_selected_prefer(), strict=True)
+    with policy_context(policy):
+        return call_op(op_name, *args, **kwargs)
+
+
+def _maybe_skip_unavailable(exc: RuntimeError, op_name: str) -> None:
+    if "No available implementation" in str(exc):
+        pytest.skip(f"{op_name} not available: {exc}")
+    raise exc
+
+
+def _skip_optional_kernel(exc: Exception, op_name: str) -> None:
+    pytest.skip(f"{op_name} kernel unavailable in this environment: {exc}")
+
+
+def _assert_tensor_finite(tensor: torch.Tensor, shape: tuple[int, ...] | None = None) -> None:
+    if shape is not None:
+        assert tensor.shape == shape
+    assert torch.isfinite(tensor.float()).all()
+
+
+def _rms_reference(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    variance = x.float().pow(2).mean(-1, keepdim=True)
+    return (x.float() * torch.rsqrt(variance + eps) * weight.float()).to(x.dtype)
+
+
+def _rotary_cache(max_position: int, rotary_dim: int, device, dtype) -> tuple[torch.Tensor, torch.Tensor]:
+    inv_freq = 1.0 / (
+        10000.0 ** (torch.arange(0, rotary_dim, 2, device=device).float() / rotary_dim)
+    )
+    t = torch.arange(max_position, device=device).float()
+    freqs = torch.outer(t, inv_freq)
+    return freqs.cos().to(dtype), freqs.sin().to(dtype)
+
+
+def test_silu_and_mul_correctness(device) -> None:
+    """Compare silu_and_mul with the PyTorch definition."""
+    shapes = [(1, 128), (8, 256), (32, 512)]
+    for dtype in (torch.float32, torch.float16, torch.bfloat16):
+        for batch, hidden_twice in shapes:
+            x = torch.randn(batch, hidden_twice, device=device, dtype=dtype)
+            half = hidden_twice // 2
+            expected = F.silu(x[..., :half]) * x[..., half:]
+            try:
+                actual = _call_selected("silu_and_mul", None, x)
+            except RuntimeError as exc:
+                _maybe_skip_unavailable(exc, "silu_and_mul")
+            assert actual.shape == expected.shape
+            assert _allclose(actual, expected, dtype=dtype)
+
+
+def test_rms_norm_correctness(device) -> None:
+    """Compare rms_norm with a PyTorch RMSNorm reference."""
+    eps = 1e-6
+    for dtype in (torch.float32, torch.float16, torch.bfloat16):
+        x = torch.randn(4, 16, 128, device=device, dtype=dtype)
+        weight = torch.randn(128, device=device, dtype=dtype)
+        obj = SimpleNamespace(weight=weight, variance_epsilon=eps)
+        expected = _rms_reference(x, weight, eps)
+        try:
+            actual = _call_selected("rms_norm", obj, x)
+        except RuntimeError as exc:
+            _maybe_skip_unavailable(exc, "rms_norm")
+        if isinstance(actual, tuple):
+            actual = actual[0]
+        assert actual.shape == expected.shape
+        assert _allclose(actual, expected, dtype=dtype)
+
+
+def test_rms_norm_with_residual_contract(device) -> None:
+    """Check rms_norm residual mode returns normalized output and updated residual."""
+    eps = 1e-6
+    x = torch.randn(2, 8, 64, device=device, dtype=torch.float16)
+    residual = torch.randn_like(x)
+    weight = torch.randn(64, device=device, dtype=torch.float16)
+    obj = SimpleNamespace(weight=weight, variance_epsilon=eps)
+    try:
+        actual = _call_selected("rms_norm", obj, x, residual)
+    except RuntimeError as exc:
+        _maybe_skip_unavailable(exc, "rms_norm")
+    assert isinstance(actual, tuple)
+    normed, updated_residual = actual
+    assert normed.shape == x.shape
+    assert updated_residual.shape == x.shape
+
+
+def test_gemma_rms_norm_correctness(device) -> None:
+    """Compare gemma_rms_norm with the Gemma weight semantics reference."""
+    eps = 1e-6
+    for dtype in (torch.float32, torch.float16, torch.bfloat16):
+        x = torch.randn(4, 16, 128, device=device, dtype=dtype)
+        weight = torch.randn(128, device=device, dtype=dtype)
+        obj = SimpleNamespace(weight=weight, variance_epsilon=eps)
+        variance = x.float().pow(2).mean(-1, keepdim=True)
+        expected = (x.float() * torch.rsqrt(variance + eps) * (1.0 + weight.float())).to(dtype)
+        try:
+            actual = _call_selected("gemma_rms_norm", obj, x)
+        except RuntimeError as exc:
+            _maybe_skip_unavailable(exc, "gemma_rms_norm")
+        if isinstance(actual, tuple):
+            actual = actual[0]
+        assert actual.shape == expected.shape
+        assert _allclose(actual, expected, dtype=dtype)
+
+
+def test_rotary_embedding_correctness(device) -> None:
+    """Compare rotary_embedding selected path against reference backend."""
+    dtype = torch.float16
+    num_tokens, num_heads, head_size = 16, 4, 64
+    positions = torch.arange(num_tokens, device=device, dtype=torch.long)
+    cos, sin = _rotary_cache(128, head_size, device, dtype)
+    q = torch.randn(num_tokens, num_heads, head_size, device=device, dtype=dtype)
+    k = torch.randn_like(q)
+
+    try:
+        expected_q, expected_k = _call_reference(
+            "rotary_embedding", None, q.clone(), k.clone(), cos, sin, positions, False, False
+        )
+        actual_q, actual_k = _call_selected(
+            "rotary_embedding", None, q.clone(), k.clone(), cos, sin, positions, False, False
+        )
+    except RuntimeError as exc:
+        _maybe_skip_unavailable(exc, "rotary_embedding")
+
+    assert actual_q.shape == expected_q.shape
+    assert actual_k.shape == expected_k.shape
+    assert _allclose(actual_q, expected_q, dtype=dtype)
+    assert _allclose(actual_k, expected_k, dtype=dtype)
+
+
+def test_mrotary_embedding_correctness(device) -> None:
+    """Compare mrotary_embedding selected path against reference backend."""
+    dtype = torch.float16
+    num_tokens, num_heads, head_size, rotary_dim = 12, 4, 64, 64
+    cos, sin = _rotary_cache(128, rotary_dim, device, dtype)
+    cos_sin_cache = torch.cat([cos, sin], dim=-1)
+    positions = torch.arange(num_tokens, device=device, dtype=torch.long)
+    q = torch.randn(num_tokens, num_heads * head_size, device=device, dtype=dtype)
+    k = torch.randn_like(q)
+    obj = SimpleNamespace(
+        head_size=head_size,
+        rotary_dim=rotary_dim,
+        is_neox_style=True,
+        cos_sin_cache=cos_sin_cache,
+        mrope_section=None,
+    )
+
+    try:
+        expected_q, expected_k = _call_reference("mrotary_embedding", obj, positions, q.clone(), k.clone())
+        actual_q, actual_k = _call_selected("mrotary_embedding", obj, positions, q.clone(), k.clone())
+    except RuntimeError as exc:
+        _maybe_skip_unavailable(exc, "mrotary_embedding")
+
+    assert actual_q.shape == expected_q.shape
+    assert actual_k.shape == expected_k.shape
+    assert _allclose(actual_q, expected_q, dtype=dtype)
+    assert _allclose(actual_k, expected_k, dtype=dtype)
+
+
+def test_topk_output_contract(device) -> None:
+    """Check topk returns a valid SGLang StandardTopKOutput-like object."""
+    try:
+        from sglang.srt.layers.moe.topk import TopKConfig
+    except Exception as exc:  # pragma: no cover - depends on installed SGLang
+        pytest.skip(f"SGLang TopKConfig unavailable: {exc}")
+
+    num_tokens, hidden_size, num_experts, top_k = 16, 64, 8, 2
+    hidden_states = torch.randn(num_tokens, hidden_size, device=device, dtype=torch.float16)
+    router_logits = torch.randn(num_tokens, num_experts, device=device, dtype=torch.float32)
+    topk_config = TopKConfig(top_k=top_k, renormalize=True)
+    obj = SimpleNamespace(layer_id=0, topk_config=topk_config)
+
+    try:
+        output = _call_selected("topk", obj, hidden_states, router_logits)
+    except RuntimeError as exc:
+        _maybe_skip_unavailable(exc, "topk")
+
+    assert hasattr(output, "topk_weights")
+    assert hasattr(output, "topk_ids")
+    assert output.topk_weights.shape == (num_tokens, top_k)
+    assert output.topk_ids.shape == (num_tokens, top_k)
+    assert torch.all(output.topk_ids >= 0)
+    assert torch.all(output.topk_ids < num_experts)
+    assert torch.allclose(
+        output.topk_weights.float().sum(dim=-1),
+        torch.ones(num_tokens, device=device),
+        rtol=1e-3,
+        atol=1e-3,
+    )
+
+def test_fused_moe_output_contract(device) -> None:
+    """Check fused_moe dispatches to a MoeRunner-compatible object."""
+    try:
+        from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
+        from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatchOutput
+        from sglang.srt.layers.moe.topk import StandardTopKOutput
+    except Exception as exc:  # pragma: no cover - depends on installed SGLang
+        pytest.skip(f"SGLang MoE dispatcher types unavailable: {exc}")
+
+    class MockRunner:
+        def run(self, dispatch_output, quant_info):
+            assert quant_info.w13_weight is layer.w13_weight
+            assert quant_info.w2_weight is layer.w2_weight
+            weights = dispatch_output.topk_output.topk_weights.to(dispatch_output.hidden_states.dtype)
+            scale = weights.sum(dim=-1, keepdim=True)
+            return StandardCombineInput(hidden_states=dispatch_output.hidden_states * scale)
+
+    num_tokens, hidden_size, num_experts, intermediate_size, top_k = 8, 16, 4, 32, 2
+    hidden_states = torch.randn(num_tokens, hidden_size, device=device, dtype=torch.float16)
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, top_k, device=device, dtype=torch.float32),
+        dim=-1,
+    )
+    topk_ids = torch.randint(0, num_experts, (num_tokens, top_k), device=device, dtype=torch.int32)
+    router_logits = torch.randn(num_tokens, num_experts, device=device, dtype=torch.float32)
+    topk_output = StandardTopKOutput(topk_weights, topk_ids, router_logits)
+    dispatch_output = StandardDispatchOutput(hidden_states, None, topk_output)
+    layer = SimpleNamespace(
+        w13_weight=torch.empty(
+            num_experts,
+            intermediate_size * 2,
+            hidden_size,
+            device=device,
+            dtype=torch.float16,
+        ),
+        w2_weight=torch.empty(
+            num_experts,
+            hidden_size,
+            intermediate_size,
+            device=device,
+            dtype=torch.float16,
+        ),
+    )
+    obj = SimpleNamespace(runner=MockRunner())
+
+    try:
+        output = _call_selected("fused_moe", obj, layer, dispatch_output)
+    except RuntimeError as exc:
+        _maybe_skip_unavailable(exc, "fused_moe")
+
+    assert hasattr(output, "hidden_states")
+    _assert_tensor_finite(output.hidden_states, (num_tokens, hidden_size))
+
+
+def _make_fla_inputs(device, dtype: torch.dtype = torch.float16):
+    batch, seq_len, num_heads, key_dim, value_dim = 1, 4, 2, 16, 16
+    q = torch.randn(batch, seq_len, num_heads, key_dim, device=device, dtype=dtype) * 0.1
+    k = torch.randn_like(q)
+    v = torch.randn(batch, seq_len, num_heads, value_dim, device=device, dtype=dtype) * 0.1
+    g = torch.randn(batch, seq_len, num_heads, device=device, dtype=dtype) * -0.1
+    beta = torch.sigmoid(torch.randn(batch, seq_len, num_heads, device=device, dtype=dtype))
+    scale = key_dim**-0.5
+    return q, k, v, g, beta, scale
+
+
+def test_fla_chunk_gated_delta_rule_contract(device) -> None:
+    """Check FLA chunk_gated_delta_rule returns valid output tensors."""
+    q, k, v, g, beta, scale = _make_fla_inputs(device)
+
+    try:
+        output, _, final_state = _call_selected(
+            "chunk_gated_delta_rule",
+            q,
+            k,
+            v,
+            g,
+            beta,
+            scale,
+            head_first=False,
+        )
+    except RuntimeError as exc:
+        if "No available implementation" in str(exc):
+            _maybe_skip_unavailable(exc, "chunk_gated_delta_rule")
+        _skip_optional_kernel(exc, "chunk_gated_delta_rule")
+    except Exception as exc:
+        _skip_optional_kernel(exc, "chunk_gated_delta_rule")
+
+    _assert_tensor_finite(output, tuple(v.shape))
+    if final_state is not None:
+        _assert_tensor_finite(final_state)
+
+
+def test_fla_fused_recurrent_gated_delta_rule_contract(device) -> None:
+    """Check FLA fused_recurrent_gated_delta_rule returns valid output tensors."""
+    q, k, v, g, beta, scale = _make_fla_inputs(device)
+
+    try:
+        output, final_state = _call_selected(
+            "fused_recurrent_gated_delta_rule",
+            q,
+            k,
+            v,
+            g,
+            beta,
+            scale,
+            output_final_state=True,
+        )
+    except RuntimeError as exc:
+        if "No available implementation" in str(exc):
+            _maybe_skip_unavailable(exc, "fused_recurrent_gated_delta_rule")
+        _skip_optional_kernel(exc, "fused_recurrent_gated_delta_rule")
+    except Exception as exc:
+        _skip_optional_kernel(exc, "fused_recurrent_gated_delta_rule")
+
+    _assert_tensor_finite(output, tuple(v.shape))
+    if final_state is not None:
+        _assert_tensor_finite(final_state)
+
+
+def test_fla_packed_decode_contract(device) -> None:
+    """Check FLA packed decode dispatch returns valid output/state tensors."""
+    batch, num_heads, key_dim, value_dim = 2, 2, 16, 16
+    dtype = torch.float16
+    mixed_qkv = torch.randn(
+        batch,
+        num_heads,
+        key_dim * 2 + value_dim,
+        device=device,
+        dtype=dtype,
+    )
+    a = torch.randn(batch, num_heads, device=device, dtype=dtype)
+    b = torch.randn(batch, num_heads, device=device, dtype=dtype)
+    A_log = torch.randn(num_heads, device=device, dtype=dtype)
+    dt_bias = torch.randn(num_heads, device=device, dtype=dtype)
+    initial_state = torch.randn(batch, num_heads, key_dim, value_dim, device=device, dtype=dtype)
+    out = torch.empty(batch, num_heads, value_dim, device=device, dtype=dtype)
+    ssm_state_indices = torch.arange(batch, device=device, dtype=torch.int32)
+
+    try:
+        output, final_state = _call_selected(
+            "fused_recurrent_gated_delta_rule_packed_decode",
+            mixed_qkv,
+            a,
+            b,
+            A_log,
+            dt_bias,
+            key_dim**-0.5,
+            initial_state,
+            out,
+            ssm_state_indices,
+        )
+    except RuntimeError as exc:
+        if "No available implementation" in str(exc):
+            _maybe_skip_unavailable(exc, "fused_recurrent_gated_delta_rule_packed_decode")
+        _skip_optional_kernel(exc, "fused_recurrent_gated_delta_rule_packed_decode")
+    except Exception as exc:
+        _skip_optional_kernel(exc, "fused_recurrent_gated_delta_rule_packed_decode")
+
+    _assert_tensor_finite(output)
+    _assert_tensor_finite(final_state)
+
+

--- a/tests/models/qwen3/06b_tp1.yaml
+++ b/tests/models/qwen3/06b_tp1.yaml
@@ -1,0 +1,21 @@
+# Qwen3-0.6B model configuration (TP=2 not needed, single GPU)
+
+llm:
+  model: "/data/models/Qwen/Qwen3-0.6B"
+  context_length: 8192
+  mem_fraction_static: 0.7
+  trust_remote_code: true
+
+generate:
+  prompts:
+    - text: "How many states are there in the United States?"
+      expected: "50"
+    - text: "The capital of France is"
+      expected: "Paris"
+  sampling:
+    max_new_tokens: 16
+    temperature: 0.0
+  parametrize:
+  - disable_cuda_graph: true
+    disable_piecewise_cuda_graph: true
+    dtype: "bfloat16"

--- a/tests/models/qwen3/4b_tp2.yaml
+++ b/tests/models/qwen3/4b_tp2.yaml
@@ -1,0 +1,37 @@
+# Qwen3-4B model configuration (TP=2).
+
+llm:
+  model: "/data/models/Qwen/Qwen3-4B"
+  tp_size: 2
+  context_length: 1024
+  mem_fraction_static: 0.8
+  trust_remote_code: true
+  disable_cuda_graph: true
+  disable_piecewise_cuda_graph: true
+
+generate:
+  prompts:
+    - text: "How many states are there in the United States?"
+      expected: "50"
+    - text: "The capital of France is"
+      expected: "Paris"
+  sampling:
+    max_new_tokens: 16
+    temperature: 0.7
+
+serve:
+  served_model_name: "qwen"
+  endpoints: ["chat"]
+  stream: true
+  max_tokens: 256
+  chat_messages:
+    - role: "user"
+      content: "Give me a short introduction to large language models."
+  sampling:
+    temperature: 0.7
+    top_p: 0.8
+    presence_penalty: 1.5
+  extra_body:
+    top_k: 20
+    chat_template_kwargs:
+      enable_thinking: false

--- a/tests/models/qwen3_6/27b_tp2_nograph.yaml
+++ b/tests/models/qwen3_6/27b_tp2_nograph.yaml
@@ -1,0 +1,103 @@
+# Qwen3.6-27B SGLang smoke configuration, TP=2, no CUDA graph.
+#
+# This single case is intended to drive multiple e2e tasks:
+# - inference: uses the generate section and aligns with offline_inference
+# - serving: uses the serve section
+# - concurrent: uses the concurrent section and aligns with concurrent examples
+
+llm:
+  model: "/data/models/Qwen/Qwen3.6-27B"
+  tp_size: 2
+  pp_size: 1
+  context_length: 8192
+  mem_fraction_static: 0.95
+  disable_cuda_graph: true
+  disable_piecewise_cuda_graph: true
+  trust_remote_code: true
+  disable_custom_all_reduce: true
+
+generate:
+  prompts:
+    - text: "How many states are there in the United States?"
+      expected: "50"
+    - text: "The capital of France is"
+      expected: "Paris"
+  sampling:
+    max_new_tokens: 10
+    temperature: 0.0
+
+  vl:
+    sampling:
+      max_new_tokens: 64
+      temperature: 0.0
+    cases:
+      - image: "examples/test_images/red_square.jpg"
+        question: "What color is shown in this image? Answer with one word."
+        expected: ["red"]
+      - image: "examples/test_images/cat.jpg"
+        question: "What animal is in this image? Answer with one word."
+        expected: ["cat"]
+      - image: "examples/test_images/stop_sign.png"
+        question: "What is the color of this sign? Answer with one word."
+        expected: ["red"]
+      - image: "examples/test_images/digit_seven.png"
+        question: "What digit is shown in this image? Answer with one digit."
+        expected: ["7"]
+
+serve:
+  served_model_name: "qwen"
+  startup_retries: 120
+  endpoints: ["chat"]
+  stream: false
+  max_tokens: 256
+  chat_messages:
+    - role: "user"
+      content: "Introduce yourself,please"
+  sampling:
+    temperature: 0.0
+
+concurrent:
+  modes: ["text", "vl", "mixed"]
+  concurrent_n: 16
+
+  text:
+    prompts:
+      - text: "How many states are there in the United States?"
+        expected: ["50"]
+      - text: "The capital of France is"
+        expected: ["paris"]
+      - text: "What is the largest planet in the solar system?"
+        expected: ["jupiter"]
+      - text: "Who wrote the play Romeo and Juliet?"
+        expected: ["shakespeare"]
+      - text: "What is 17 multiplied by 13?"
+        expected: ["221"]
+      - text: "Name the three primary colors of light."
+        expected: ["red", "green", "blue"]
+      - text: "What year did World War II end?"
+        expected: ["1945"]
+      - text: "Explain the concept of gravity in one sentence."
+        expected: ["mass", "force", "attract"]
+
+  vl:
+    cases:
+      - image: "examples/test_images/red_square.jpg"
+        question: "What color is shown in this image? Answer with one word."
+        expected: ["red"]
+      - image: "examples/test_images/cat.jpg"
+        question: "What animal is in this image? Answer with one word."
+        expected: ["cat"]
+      - image: "examples/test_images/stop_sign.png"
+        question: "What is the color of this sign? Answer with one word."
+        expected: ["red"]
+      - image: "examples/test_images/digit_seven.png"
+        question: "What digit is shown in this image? Answer with one digit."
+        expected: ["7"]
+
+  sampling:
+    text:
+      max_new_tokens: 256
+      temperature: 0.0
+    vl:
+      max_new_tokens: 64
+      temperature: 0.0

--- a/tests/models/qwen3_6/35b_a3b_tp2_nograph.yaml
+++ b/tests/models/qwen3_6/35b_a3b_tp2_nograph.yaml
@@ -1,0 +1,104 @@
+# Qwen3.6-35B-A3B SGLang smoke configuration, TP=2, no CUDA graph.
+#
+# This single case is intended to drive multiple e2e tasks:
+# - inference: uses the generate section
+# - serving: uses the serve section
+# - concurrent: uses the concurrent section
+
+llm:
+  model: "/data/models/Qwen/Qwen3.6-35B-A3B"
+  tp_size: 2
+  pp_size: 1
+  context_length: 8192
+  mem_fraction_static: 0.95
+  disable_cuda_graph: true
+  disable_piecewise_cuda_graph: true
+  trust_remote_code: true
+  disable_custom_all_reduce: true
+
+generate:
+  prompts:
+    - text: "How many states are there in the United States?"
+      expected: "50"
+    - text: "The capital of France is"
+      expected: "Paris"
+  sampling:
+    max_new_tokens: 10
+    temperature: 0.0
+
+  vl:
+    sampling:
+      max_new_tokens: 64
+      temperature: 0.0
+    cases:
+      - image: "examples/test_images/red_square.jpg"
+        question: "What color is shown in this image? Answer with one word."
+        expected: ["red"]
+      - image: "examples/test_images/cat.jpg"
+        question: "What animal is in this image? Answer with one word."
+        expected: ["cat"]
+      - image: "examples/test_images/stop_sign.png"
+        question: "What is the color of this sign? Answer with one word."
+        expected: ["red"]
+      - image: "examples/test_images/digit_seven.png"
+        question: "What digit is shown in this image? Answer with one digit."
+        expected: ["7"]
+
+serve:
+  served_model_name: "qwen"
+  startup_retries: 120
+  endpoints: ["chat"]
+  stream: false
+  max_tokens: 256
+  chat_messages:
+    - role: "user"
+      content: "Introduce yourself,please"
+  sampling:
+    temperature: 0.0
+
+concurrent:
+  modes: ["text", "vl", "mixed"]
+  concurrent_n: 16
+
+  text:
+    prompts:
+      - text: "How many states are there in the United States?"
+        expected: ["50"]
+      - text: "The capital of France is"
+        expected: ["paris"]
+      - text: "What is the largest planet in the solar system?"
+        expected: ["jupiter"]
+      - text: "Who wrote the play Romeo and Juliet?"
+        expected: ["shakespeare"]
+      - text: "What is 17 multiplied by 13?"
+        expected: ["221"]
+      - text: "Name the three primary colors of light."
+        expected: ["red", "green", "blue"]
+      - text: "What year did World War II end?"
+        expected: ["1945"]
+      - text: "Explain the concept of gravity in one sentence."
+        expected: ["mass", "force", "attract"]
+
+  vl:
+    cases:
+      - image: "examples/test_images/red_square.jpg"
+        question: "What color is shown in this image? Answer with one word."
+        expected: ["red"]
+      - image: "examples/test_images/cat.jpg"
+        question: "What animal is in this image? Answer with one word."
+        expected: ["cat"]
+      - image: "examples/test_images/stop_sign.png"
+        question: "What is the color of this sign? Answer with one word."
+        expected: ["red"]
+      - image: "examples/test_images/digit_seven.png"
+        question: "What digit is shown in this image? Answer with one digit."
+        expected: ["7"]
+
+  sampling:
+    text:
+      max_new_tokens: 256
+      temperature: 0.0
+    vl:
+      max_new_tokens: 64
+      temperature: 0.0
+

--- a/tests/platforms/cuda.yaml
+++ b/tests/platforms/cuda.yaml
@@ -1,0 +1,83 @@
+# CUDA-Based Platform Configuration
+# Flexible test selection mechanism for NVIDIA GPU environments.
+#
+#
+# Users can modify:
+# - e2e: Add/remove model cases in inference and serving support lists
+# - benchmark: Enable/disable throughput, latency, and serve smoke tests
+# - unit: Add/remove paths in include and exclude lists
+# - tolerance: Adjust numerical comparison tolerance for result validation
+# - unsupported_features: Exclude test cases matching specific feature tags
+# - env_defaults: Set CUDA/NCCL/SGLang environment defaults before tests start
+#
+# ---- Platform-level settings ------------------------------------------------
+platform: cuda
+vendor: nvidia
+
+device_types:
+  a100:
+    compute_capability: "8.0"
+    memory_gb: 80
+    tags: [ampere, fp64, bf16]
+  a800:
+    compute_capability: "8.0"
+    memory_gb: 80
+    tags: [ampere, fp64, bf16, china-variant]
+  h100:
+    compute_capability: "9.0"
+    memory_gb: 80
+    tags: [hopper, fp8, bf16]
+
+# Default numerical tolerance for result comparison.
+tolerance:
+  inference:
+    default: {exact: true}
+
+# Device-level overrides for specific devices or categories.
+device_overrides:
+  h100:
+    tolerance:
+      inference:
+        default: {rtol: 1e-4, atol: 1e-7}
+
+# Features not supported on this platform.
+# Test cases whose model name contains any of these strings will be skipped.
+# Example: ["flaggems"] would skip "qwen3_flaggems" cases.
+unsupported_features: []
+
+# Default environment variables for this platform.
+# tests/run.py applies these before invoking pytest.
+env_defaults:
+  CUDA_DEVICE_MAX_CONNECTIONS: "1"
+  NCCL_ALGO: "Ring"
+
+# ---- Device-specific test configurations ------------------------------------
+a100:
+  name: "a100"
+  tests:
+    e2e:
+      # Add or remove test cases per model.
+      # Each case points to tests/models/<model>/<case>.yaml.
+      concurrent:
+        qwen3_6: ["35b_a3b_tp2_nograph", "27b_tp2_nograph"]
+      inference:
+        qwen3_6: ["35b_a3b_tp2_nograph",  "27b_tp2_nograph"]
+      serving:
+        qwen3: ["4b_tp2"]
+        qwen3_6: ["35b_a3b_tp2_nograph", "27b_tp2_nograph"]
+
+    functional:
+      # Reserved for future tests/functional_tests support.
+      # Current SGLang runner does not consume this section yet.
+      include: "*"
+      exclude: []
+
+    unit:
+      # Include patterns: "*" for all, or list specific paths.
+      include: "*"
+      # Exclude patterns: empty list or list paths to exclude.
+      exclude: []
+
+    benchmark:
+      enabled: true
+      smoke: ["throughput", "latency", "serve"]

--- a/tests/platforms/template.yaml
+++ b/tests/platforms/template.yaml
@@ -1,0 +1,152 @@
+# Platform Configuration Template
+# Copy and customize for your specific hardware platform.
+#
+# To create a new platform configuration:
+# 1. Copy this file: copy tests/platforms/template.yaml tests/platforms/my_platform.yaml
+# 2. Update platform-level settings (tolerance, unsupported_features, env_defaults)
+# 3. Update device_types with your hardware
+# 4. Configure device-specific test settings
+# 5. Run tests: python tests/run.py --platform my_platform --device my_device
+#
+# Existing platforms: cuda.yaml (NVIDIA GPU), ascend.yaml (Huawei NPU)
+#
+# Users can modify:
+# - unit tests: Add/remove paths in include and exclude lists
+# - e2e tests: Add/remove model cases in inference/serving support lists
+# - benchmark tests: Enable/disable throughput, latency, and serve smoke tests
+# - tolerance: Adjust numerical comparison tolerance for result validation
+# - unsupported_features: Exclude test cases matching specific feature tags
+# - env_defaults: Set platform-specific environment variables before pytest starts
+#
+# Notes for SGLang:
+# - Model cases are loaded from tests/models/<model>/<case>.yaml.
+# - Benchmark smoke cases are loaded from tests/benchmarks/configs/smoke.yaml.
+# - tests/run.py currently consumes unit, e2e, and benchmark sections.
+# - functional can be added later if SGLang functional_tests are introduced.
+
+# ---- Platform-level settings ------------------------------------------------
+# Platform name used by: python tests/run.py --platform my_platform
+platform: my_platform
+
+# Vendor name is metadata for reports/logging and future platform-specific logic.
+vendor: my_vendor
+
+# Hardware device descriptors for this platform.
+# The top-level device name is also accepted by run.py as --device.
+# Common optional fields:
+# - memory_gb: approximate device memory, useful for selecting large-model tests
+# - compute_capability: CUDA-style capability when applicable, e.g. "8.0"
+# - tags: free-form labels such as bf16, fp16, ascend, musa, hygon, dcu
+#
+# You can define multiple devices under the same platform:
+#   small_device:
+#     memory_gb: 32
+#     tags: [bf16]
+#   large_device:
+#     memory_gb: 80
+#     tags: [bf16, large-model]
+device_types:
+  my_device:
+    memory_gb: 80
+    tags: [bf16]
+
+# Default numerical tolerance for result comparison.
+# Different chips may produce slightly different numerical results due to
+# hardware precision, kernel implementation, accumulation order, or dtype.
+#
+# Resolution order used by PlatformConfig.get_tolerance():
+# 1. device_overrides[active_device].tolerance[category][dtype]
+# 2. tolerance[category][dtype]
+# 3. tolerance[category]["default"]
+# 4. built-in default: rtol=1e-5, atol=1e-8
+#
+# Typical categories:
+# - inference: model/e2e output numerical checks
+# - ops: functional op correctness checks, if added later
+# - benchmark: benchmark result sanity checks, if numerical tolerance is needed
+#
+# Typical dtype keys:
+# - default
+# - float16
+# - bfloat16
+# - float32
+tolerance:
+  inference:
+    default: {rtol: 1e-5, atol: 1e-8}
+    bfloat16: {rtol: 1e-3, atol: 1e-3}
+
+# Device-level overrides for specific devices or test categories.
+# This is useful when one device under the same platform needs looser or stricter
+# numerical tolerance than the platform default.
+#
+# Example:
+#   my_device:
+#     tolerance:
+#       inference:
+#         bfloat16: {rtol: 2e-3, atol: 2e-3}
+#
+# Keep this as {} if no per-device override is needed.
+device_overrides: {}
+
+# Features not supported on this platform.
+# If a model name contains any token below, tests/run.py skips that model case.
+# Common values may include: ["flaggems", "flashinfer", "triton", "large-model"]
+unsupported_features: []
+
+# Default environment variables for this platform.
+# tests/run.py applies these before invoking pytest, but existing user-provided
+# environment variables are preserved.
+#
+# Examples:
+#   CUDA_DEVICE_MAX_CONNECTIONS: "1"
+#   NCCL_ALGO: "Ring"
+#   SGLANG_FL_CONFIG: "/path/to/config.yaml"
+env_defaults: {}
+
+# ---- Device-specific test configurations ------------------------------------
+# This top-level key must match a name under device_types.
+my_device:
+  name: "my_device"
+  tests:
+    # Unit tests are lightweight and should not require real model files.
+    # Include patterns:
+    # - "*" means run all tests/unit_tests
+    # - a list can narrow pytest selection through -k expressions
+    # Exclude patterns are converted to --ignore tests/unit_tests/<pattern>.
+    unit:
+      include: "*"
+      exclude: []
+
+    # E2E tests require real model files and are slower.
+    # Format: task -> model family -> list of case names.
+    # Each case points to tests/models/<model>/<case>.yaml.
+    # Current structured task names are expected to align with:
+    # - tests/e2e_tests/inference/test_inference_smoke.py
+    # - tests/e2e_tests/serving/test_serving_smoke.py
+    e2e:
+      inference:
+        qwen3: ["06b_tp1"]
+      serving:
+        qwen3: ["4b_tp2"]
+
+    # Benchmark smoke tests are lightweight health checks for SGLang benchmark
+    # commands. The detailed CLI parameters live in:
+    # tests/benchmarks/configs/smoke.yaml
+    #
+    # Supported smoke names:
+    # - throughput -> python -m sglang.bench_offline_throughput
+    # - latency    -> python -m sglang.bench_one_batch
+    # - serve      -> python -m sglang.launch_server + python -m sglang.bench_serving
+    benchmark:
+      enabled: true
+      smoke: ["throughput", "latency", "serve"]
+
+    # Reserved for future SGLang functional tests, if tests/functional_tests is
+    # added later. The current runner does not consume this section yet.
+    # functional:
+    #   include: "*"
+    #   exclude: []
+    functional:
+      # Component tests (ops/compilation/distributed) — run all by default
+      include: "*"
+      exclude: []

--- a/tests/run.py
+++ b/tests/run.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Unified test entry point for sglang-plugin-FL.
+
+- tests/platforms/<platform>.yaml selects scopes/cases per device.
+- tests/models/<model>/<case>.yaml stores model and engine settings.
+- tests/benchmarks/configs/smoke.yaml stores benchmark smoke templates.
+
+Examples:
+    python tests/run.py --platform cuda --device a100 --scope unit
+    python tests/run.py --platform cuda --device a100 --scope functional
+    python tests/run.py --platform cuda --device a100 --scope benchmark
+    python tests/run.py --platform cuda --device a100 --scope functional
+    python tests/run.py --platform cuda --device a100 --scope benchmark --benchmark latency
+    python tests/run.py --platform cuda --device a100 --scope functional
+    python tests/run.py --platform cuda --device a100 --scope benchmark --model qwen3 --case 06b_tp1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_TESTS_DIR = _REPO_ROOT / "tests"
+sys.path.insert(0, str(_REPO_ROOT))
+
+from tests.utils.model_config import ModelConfig
+from tests.utils.platform_config import PlatformConfig
+
+
+def load_structured_config(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8-sig")
+    try:
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(text) or {}
+    except ModuleNotFoundError:
+        data = json.loads(text)
+    return data if isinstance(data, dict) else {}
+
+
+@dataclass
+class TestCase:
+    name: str
+    pytest_path: str
+    task: str
+    model: str = ""
+    case: str = ""
+    extra_args: list[str] = field(default_factory=list)
+    extra_env: dict[str, str] = field(default_factory=dict)
+
+
+class TestRunner:
+    def __init__(
+        self,
+        platform: str,
+        device: str | None,
+        scope: str,
+        task: str | None = None,
+        model: str | None = None,
+        case: str | None = None,
+        benchmark: str | None = None,
+        extra_pytest_args: list[str] | None = None,
+    ) -> None:
+        self.config = PlatformConfig.load(platform, device)
+        self.scope = scope
+        self.task = task
+        self.model = model
+        self.case = case
+        self.benchmark = benchmark
+        self.extra_pytest_args = extra_pytest_args or []
+
+    def run(self) -> int:
+        self.config.apply_env_defaults()
+        os.environ["FL_TEST_PLATFORM"] = self.config.platform
+        os.environ["FL_TEST_DEVICE"] = self.config.device
+
+        cases = self.discover_tests()
+        if not cases:
+            print("[run] No test cases selected.")
+            return 0
+
+        print(f"[run] Platform: {self.config.platform}")
+        print(f"[run] Device:   {self.config.device}")
+        print(f"[run] Scope:    {self.scope}")
+        print(f"[run] Cases:    {len(cases)}")
+        print()
+
+        failed = 0
+        for case in cases:
+            rc = self._run_single(case)
+            if rc != 0:
+                failed += 1
+
+        print()
+        print(f"[run] Passed: {len(cases) - failed}, Failed: {failed}")
+        return 1 if failed else 0
+
+    def discover_tests(self) -> list[TestCase]:
+        cases: list[TestCase] = []
+        if self.scope in ("all", "unit"):
+            cases.extend(self._discover_unit_tests())
+        if self.scope in ("all", "e2e"):
+            cases.extend(self._discover_e2e_tests())
+        if self.scope in ("all", "functional"):
+            cases.extend(self._discover_functional_tests())
+        if self.scope in ("all", "benchmark"):
+            cases.extend(self._discover_benchmark_tests())
+        return cases
+
+    def _discover_unit_tests(self) -> list[TestCase]:
+        unit_filter = self.config.get_unit_filter()
+        extra_args = ["-q", "--tb=short"]
+        for pattern in unit_filter.exclude:
+            extra_args.extend(["--ignore", f"tests/unit_tests/{pattern}"])
+        if unit_filter.include != "*" and isinstance(unit_filter.include, list):
+            extra_args.extend(["-k", " or ".join(unit_filter.include)])
+        return [TestCase(name="unit", pytest_path="tests/unit_tests", task="unit", extra_args=extra_args)]
+
+    def _discover_e2e_tests(self) -> list[TestCase]:
+        cases: list[TestCase] = []
+
+        # Keep existing flat e2e/config tests runnable while the structured e2e tree is added later.
+        for path in ("tests/test_e2e_config.py", "tests/test_precision_align.py"):
+            if (_REPO_ROOT / path).exists() and self.task in (None, "config", "precision"):
+                cases.append(
+                    TestCase(
+                        name=Path(path).stem,
+                        pytest_path=path,
+                        task="e2e",
+                        extra_args=["-v", "--tb=short", "-s"],
+                    )
+                )
+
+        # Future-compatible structured e2e discovery.
+        for item in self.config.get_e2e_tests().get_cases(task=self.task, model=self.model):
+            model_name = item["model"]
+            case_name = item["case"]
+            if self.case and self.case != case_name:
+                continue
+            if self.config.should_skip_model(model_name):
+                print(f"[run] Skipping e2e/{model_name}/{case_name} (unsupported feature)")
+                continue
+            task = item["task"]
+            test_path = f"tests/e2e_tests/{task}/test_{task}_smoke.py"
+            if not (_REPO_ROOT / test_path).exists():
+                print(f"[run] Warning: structured e2e test not found: {test_path}")
+                continue
+            cases.append(
+                TestCase(
+                    name=f"e2e/{task}/{model_name}/{case_name}",
+                    pytest_path=test_path,
+                    task="e2e",
+                    model=model_name,
+                    case=case_name,
+                    extra_args=["-v", "--tb=short", "-s"],
+                    extra_env={"FL_TEST_MODEL": model_name, "FL_TEST_CASE": case_name},
+                )
+            )
+        return cases
+
+    def _discover_functional_tests(self) -> list[TestCase]:
+        functional_filter = self.config.get_functional_filter()
+        extra_args = ["-v", "--tb=short", "-s"]
+        for pattern in functional_filter.exclude:
+            extra_args.extend(["--ignore", f"tests/functional_tests/{pattern}"])
+        if functional_filter.include != "*" and isinstance(functional_filter.include, list):
+            extra_args.extend(["-k", " or ".join(functional_filter.include)])
+
+        root = _REPO_ROOT / "tests" / "functional_tests"
+        if not root.exists():
+            return []
+
+        return [
+            TestCase(
+                name="functional",
+                pytest_path="tests/functional_tests",
+                task="functional",
+                extra_args=extra_args,
+            )
+        ]
+    def _discover_benchmark_tests(self) -> list[TestCase]:
+        benchmark_cfg = self.config.get_benchmark_tests()
+        if not benchmark_cfg.get("enabled", False):
+            return []
+
+        selected = benchmark_cfg.get("smoke", [])
+        if isinstance(selected, str):
+            selected_types = {selected}
+        else:
+            selected_types = set(selected)
+        if self.benchmark:
+            selected_types &= {self.benchmark}
+
+        config_path = _TESTS_DIR / "benchmarks" / "configs" / "smoke.yaml"
+        smoke_config = load_structured_config(config_path)
+
+        cases: list[TestCase] = []
+        for bench_type, case_list in smoke_config.items():
+            if bench_type not in selected_types:
+                continue
+            if not isinstance(case_list, list):
+                continue
+            pytest_path = f"tests/benchmarks/test_benchmark_{bench_type}.py"
+            if not (_REPO_ROOT / pytest_path).exists():
+                print(f"[run] Benchmark test file missing: {pytest_path}")
+                continue
+
+            for raw_case in case_list:
+                runtime_case = dict(raw_case)
+                model_name = runtime_case.pop("model", self.model)
+                case_name = runtime_case.pop("case", self.case)
+                if not model_name or not case_name:
+                    print(
+                        f"[run] Skipping benchmark/{bench_type}: "
+                        "missing model/case in smoke.yaml and no --model/--case provided"
+                    )
+                    continue
+                model_name = str(model_name)
+                case_name = str(case_name)
+                if self.model and self.model != model_name:
+                    continue
+                if self.case and self.case != case_name:
+                    continue
+                if self.config.should_skip_model(model_name):
+                    print(f"[run] Skipping benchmark/{model_name}/{case_name} (unsupported feature)")
+                    continue
+
+                model_cfg = ModelConfig.load(model_name, case_name)
+                self._inject_model_config(runtime_case, model_cfg)
+                name = str(runtime_case.get("name", f"{bench_type}_smoke"))
+                cases.append(
+                    TestCase(
+                        name=f"benchmark/{bench_type}/{model_name}/{case_name}/{name}",
+                        pytest_path=pytest_path,
+                        task="benchmark",
+                        model=model_name,
+                        case=case_name,
+                        extra_args=["-v", "--tb=short", "-s"],
+                        extra_env={
+                            "FL_BENCHMARK_TYPE": bench_type,
+                            "FL_BENCHMARK_CASE": json.dumps(runtime_case),
+                        },
+                    )
+                )
+        return cases
+
+    @staticmethod
+    def _inject_model_config(runtime_case: dict[str, Any], model_cfg: ModelConfig) -> None:
+        if "parameters" in runtime_case:
+            runtime_case["parameters"] = model_cfg.benchmark_parameters(runtime_case.get("parameters", {}))
+        if "server_parameters" in runtime_case:
+            runtime_case["server_parameters"] = model_cfg.server_parameters(runtime_case.get("server_parameters", {}))
+        if "client_parameters" in runtime_case:
+            client_params = dict(runtime_case.get("client_parameters", {}))
+            if model_cfg.serve.served_model_name:
+                client_params.setdefault("model", model_cfg.serve.served_model_name)
+            runtime_case["client_parameters"] = client_params
+
+    def _run_single(self, case: TestCase) -> int:
+        cmd = [sys.executable, "-m", "pytest", case.pytest_path]
+        cmd.extend(case.extra_args)
+        cmd.extend(self.extra_pytest_args)
+
+        print(f"[run] --- {case.name} ---")
+        if case.extra_env:
+            env_text = " ".join(f"{k}={v}" for k, v in case.extra_env.items())
+            print(f"[run] Env:     {env_text}")
+        print(f"[run] Command: {' '.join(cmd)}")
+
+        env = {**os.environ, **case.extra_env}
+        result = subprocess.run(cmd, cwd=str(_REPO_ROOT), env=env)
+        return result.returncode
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--platform", required=True, help="Platform name or device alias, e.g. cuda/a100/ascend/910b")
+    parser.add_argument("--device", default=None, help="Device type within the platform, e.g. a100")
+    parser.add_argument("--scope", choices=["all", "unit", "e2e", "functional", "benchmark"], default="all")
+    parser.add_argument("--task", default=None, help="Task filter, e.g. inference/serving")
+    parser.add_argument("--model", default=None, help="Model family filter, e.g. qwen3")
+    parser.add_argument("--case", default=None, help="Model case filter, e.g. 06b_tp1")
+    parser.add_argument("--benchmark", choices=["throughput", "latency", "serve"], default=None)
+    parser.add_argument("pytest_args", nargs=argparse.REMAINDER, help="Extra pytest args after '--'")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    extra_pytest_args = args.pytest_args
+    if extra_pytest_args and extra_pytest_args[0] == "--":
+        extra_pytest_args = extra_pytest_args[1:]
+
+    runner = TestRunner(
+        platform=args.platform,
+        device=args.device,
+        scope=args.scope,
+        task=args.task,
+        model=args.model,
+        case=args.case,
+        benchmark=args.benchmark,
+        extra_pytest_args=extra_pytest_args,
+    )
+    return runner.run()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+

--- a/tests/unit_tests/dispatch/backends/test_reference_ops.py
+++ b/tests/unit_tests/dispatch/backends/test_reference_ops.py
@@ -1,0 +1,164 @@
+from types import ModuleType, SimpleNamespace
+
+import torch
+import torch.nn.functional as F
+
+from sglang_fl.dispatch.backends.reference.reference import ReferenceBackend
+
+
+def test_reference_silu_and_mul_matches_pytorch_formula() -> None:
+    backend = ReferenceBackend()
+    x = torch.randn(3, 8)
+
+    result = backend.silu_and_mul(None, x)
+    expected = F.silu(x[..., :4]) * x[..., 4:]
+
+    torch.testing.assert_close(result, expected)
+
+
+def test_reference_rms_norm_matches_pytorch_formula() -> None:
+    backend = ReferenceBackend()
+    obj = SimpleNamespace(weight=torch.randn(4), variance_epsilon=1e-6)
+    x = torch.randn(3, 4)
+
+    result = backend.rms_norm(obj, x)
+    expected = obj.weight * x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + 1e-6)
+
+    torch.testing.assert_close(result, expected)
+
+
+def test_reference_rms_norm_with_residual_returns_updated_residual() -> None:
+    backend = ReferenceBackend()
+    obj = SimpleNamespace(weight=torch.randn(4), variance_epsilon=1e-6)
+    x = torch.randn(3, 4)
+    residual = torch.randn(3, 4)
+
+    output, updated_residual = backend.rms_norm(obj, x, residual)
+    expected_residual = x + residual
+    expected_output = (
+        obj.weight
+        * expected_residual
+        * torch.rsqrt(expected_residual.pow(2).mean(-1, keepdim=True) + 1e-6)
+    )
+
+    torch.testing.assert_close(updated_residual, expected_residual)
+    torch.testing.assert_close(output, expected_output)
+
+
+def test_reference_gemma_rms_norm_uses_weight_plus_one() -> None:
+    backend = ReferenceBackend()
+    obj = SimpleNamespace(weight=torch.randn(4), variance_epsilon=1e-6)
+    x = torch.randn(3, 4)
+
+    result = backend.gemma_rms_norm(obj, x)
+    x_float = x.float()
+    expected = x_float * torch.rsqrt(x_float.pow(2).mean(-1, keepdim=True) + 1e-6)
+    expected = (expected * (1.0 + obj.weight.float())).to(x.dtype)
+
+    torch.testing.assert_close(result, expected)
+
+
+def test_reference_rotary_embedding_matches_neox_formula() -> None:
+    backend = ReferenceBackend()
+    query = torch.randn(2, 1, 4)
+    key = torch.randn(2, 1, 4)
+    cos = torch.randn(4, 2)
+    sin = torch.randn(4, 2)
+    position_ids = torch.tensor([0, 2])
+
+    q_out, k_out = backend.rotary_embedding(
+        None,
+        query,
+        key,
+        cos,
+        sin,
+        position_ids,
+        rotary_interleaved=False,
+    )
+
+    cos_full = torch.cat([cos[position_ids], cos[position_ids]], dim=-1).unsqueeze(1)
+    sin_full = torch.cat([sin[position_ids], sin[position_ids]], dim=-1).unsqueeze(1)
+
+    def rotate_half(x):
+        x1 = x[..., : x.shape[-1] // 2]
+        x2 = x[..., x.shape[-1] // 2 :]
+        return torch.cat((-x2, x1), dim=-1)
+
+    torch.testing.assert_close(q_out, query * cos_full + rotate_half(query) * sin_full)
+    torch.testing.assert_close(k_out, key * cos_full + rotate_half(key) * sin_full)
+
+
+def test_reference_rotary_embedding_matches_interleaved_formula() -> None:
+    backend = ReferenceBackend()
+    query = torch.randn(2, 1, 4)
+    key = torch.randn(2, 1, 4)
+    cos = torch.randn(4, 2)
+    sin = torch.randn(4, 2)
+    position_ids = torch.tensor([1, 3])
+
+    q_out, k_out = backend.rotary_embedding(
+        None,
+        query,
+        key,
+        cos,
+        sin,
+        position_ids,
+        rotary_interleaved=True,
+    )
+
+    cos_full = torch.cat([cos[position_ids], cos[position_ids]], dim=-1).unsqueeze(1)
+    sin_full = torch.cat([sin[position_ids], sin[position_ids]], dim=-1).unsqueeze(1)
+
+    def rotate_interleaved(x):
+        x1 = x[..., ::2]
+        x2 = x[..., 1::2]
+        return torch.stack((-x2, x1), dim=-1).flatten(-2)
+
+    torch.testing.assert_close(
+        q_out,
+        query * cos_full + rotate_interleaved(query) * sin_full,
+    )
+    torch.testing.assert_close(
+        k_out,
+        key * cos_full + rotate_interleaved(key) * sin_full,
+    )
+
+
+def test_reference_topk_uses_sglang_select_experts_torch_native(monkeypatch) -> None:
+    calls = []
+
+    def fake_select_experts(**kwargs):
+        calls.append(kwargs)
+        return "topk-output"
+
+    sglang_mod = ModuleType("sglang")
+    srt_mod = ModuleType("sglang.srt")
+    layers_mod = ModuleType("sglang.srt.layers")
+    moe_mod = ModuleType("sglang.srt.layers.moe")
+    topk_mod = ModuleType("sglang.srt.layers.moe.topk")
+    topk_mod.select_experts = fake_select_experts
+
+    monkeypatch.setitem(__import__("sys").modules, "sglang", sglang_mod)
+    monkeypatch.setitem(__import__("sys").modules, "sglang.srt", srt_mod)
+    monkeypatch.setitem(__import__("sys").modules, "sglang.srt.layers", layers_mod)
+    monkeypatch.setitem(__import__("sys").modules, "sglang.srt.layers.moe", moe_mod)
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "sglang.srt.layers.moe.topk",
+        topk_mod,
+    )
+
+    backend = ReferenceBackend()
+    topk_config = SimpleNamespace(torch_native=False)
+    obj = SimpleNamespace(layer_id=7, topk_config=topk_config)
+    hidden_states = torch.randn(2, 4)
+    router_logits = torch.randn(2, 3)
+
+    result = backend.topk(obj, hidden_states, router_logits)
+
+    assert result == "topk-output"
+    assert topk_config.torch_native is True
+    assert calls[0]["hidden_states"] is hidden_states
+    assert calls[0]["layer_id"] == 7
+    assert calls[0]["router_logits"] is router_logits
+    assert calls[0]["topk_config"] is topk_config

--- a/tests/unit_tests/dispatch/bridge/test_fla_ops.py
+++ b/tests/unit_tests/dispatch/bridge/test_fla_ops.py
@@ -1,0 +1,134 @@
+import math
+
+import torch
+
+import sglang_fl.dispatch.bridge.fla_chunk as chunk_bridge
+import sglang_fl.dispatch.bridge.fla_fused_recurrent as recurrent_bridge
+import sglang_fl.dispatch.bridge.fla_packed_decode as packed_bridge
+
+
+def test_chunk_gated_delta_rule_bridge_forwards_default_scale(monkeypatch) -> None:
+    q = torch.randn(1, 2, 3, 4)
+    k = torch.randn(1, 2, 3, 4)
+    v = torch.randn(1, 2, 3, 5)
+    g = torch.randn(1, 2, 3)
+    beta = torch.randn(1, 2, 3)
+    calls = []
+
+    def fake_call_op(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "ok"
+
+    monkeypatch.setattr(chunk_bridge, "call_op", fake_call_op)
+
+    result = chunk_bridge.chunk_gated_delta_rule_bridge(q, k, v, g, beta)
+
+    assert result == "ok"
+    assert calls[0][0] == ("chunk_gated_delta_rule",)
+    kwargs = calls[0][1]
+    assert kwargs["q"] is q
+    assert kwargs["k"] is k
+    assert kwargs["v"] is v
+    assert kwargs["g"] is g
+    assert kwargs["beta"] is beta
+    assert kwargs["scale"] == k.shape[-1] ** -0.5
+    assert kwargs["head_first"] is False
+    assert kwargs["use_qk_l2norm_in_kernel"] is False
+
+
+def test_fused_recurrent_bridge_fills_beta_and_contiguous_inputs(monkeypatch) -> None:
+    q = torch.randn(1, 2, 3, 4)
+    k = torch.randn(1, 2, 3, 4)
+    v = torch.randn(1, 2, 3, 5)
+    g = torch.randn(1, 2, 3).transpose(1, 2)
+    calls = []
+
+    def fake_call_op(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "ok"
+
+    monkeypatch.setattr(recurrent_bridge, "call_op", fake_call_op)
+
+    result = recurrent_bridge.fused_recurrent_gated_delta_rule_bridge(q, k, v, g)
+
+    assert result == "ok"
+    assert calls[0][0] == ("fused_recurrent_gated_delta_rule",)
+    kwargs = calls[0][1]
+    assert kwargs["q"] is q
+    assert kwargs["k"] is k
+    assert kwargs["v"] is v
+    assert kwargs["g"].is_contiguous()
+    assert kwargs["beta"].is_contiguous()
+    torch.testing.assert_close(kwargs["beta"], torch.ones_like(q[..., 0]))
+    assert math.isclose(kwargs["scale"], k.shape[-1] ** -0.5)
+    assert kwargs["output_final_state"] is True
+
+
+def test_fused_recurrent_bridge_keeps_explicit_beta_scale(monkeypatch) -> None:
+    q = torch.randn(1, 2, 3, 4)
+    k = torch.randn(1, 2, 3, 4)
+    v = torch.randn(1, 2, 3, 5)
+    g = torch.randn(1, 2, 3)
+    beta = torch.randn(1, 2, 3)
+    calls = []
+
+    monkeypatch.setattr(
+        recurrent_bridge,
+        "call_op",
+        lambda *args, **kwargs: calls.append((args, kwargs)) or "ok",
+    )
+
+    recurrent_bridge.fused_recurrent_gated_delta_rule_bridge(
+        q,
+        k,
+        v,
+        g,
+        beta=beta,
+        scale=0.25,
+        output_final_state=False,
+    )
+
+    kwargs = calls[0][1]
+    torch.testing.assert_close(kwargs["beta"], beta)
+    assert kwargs["scale"] == 0.25
+    assert kwargs["output_final_state"] is False
+
+
+def test_packed_decode_bridge_forwards_keyword_arguments(monkeypatch) -> None:
+    tensors = [torch.randn(2, 3) for _ in range(7)]
+    mixed_qkv, a, b, A_log, dt_bias, initial_state, out = tensors
+    ssm_state_indices = torch.tensor([0, 1])
+    calls = []
+
+    def fake_call_op(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "ok"
+
+    monkeypatch.setattr(packed_bridge, "call_op", fake_call_op)
+
+    result = packed_bridge.fused_recurrent_gated_delta_rule_packed_decode_bridge(
+        mixed_qkv,
+        a,
+        b,
+        A_log,
+        dt_bias,
+        0.5,
+        initial_state,
+        out,
+        ssm_state_indices,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    assert result == "ok"
+    assert calls[0][0] == ("fused_recurrent_gated_delta_rule_packed_decode",)
+    kwargs = calls[0][1]
+    assert kwargs["mixed_qkv"] is mixed_qkv
+    assert kwargs["a"] is a
+    assert kwargs["b"] is b
+    assert kwargs["A_log"] is A_log
+    assert kwargs["dt_bias"] is dt_bias
+    assert kwargs["scale"] == 0.5
+    assert kwargs["initial_state"] is initial_state
+    assert kwargs["out"] is out
+    assert kwargs["ssm_state_indices"] is ssm_state_indices
+    assert kwargs["use_qk_l2norm_in_kernel"] is True

--- a/tests/unit_tests/dispatch/bridge/test_fused_moe.py
+++ b/tests/unit_tests/dispatch/bridge/test_fused_moe.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+
+import torch
+
+import sglang_fl.dispatch.bridge.fused_moe as bridge
+
+
+def test_fused_moe_bridge_forwards_layer_and_dispatch_output(monkeypatch) -> None:
+    obj = SimpleNamespace()
+    layer = torch.nn.Linear(4, 4)
+    dispatch_output = object()
+    expected = object()
+    calls = []
+
+    def fake_call_op(*args, **kwargs):
+        calls.append((args, kwargs))
+        return expected
+
+    monkeypatch.setattr(bridge, "call_op", fake_call_op)
+
+    result = bridge.fused_moe_bridge(obj, layer, dispatch_output)
+
+    assert result is expected
+    assert calls == [(("fused_moe", obj, layer, dispatch_output), {})]

--- a/tests/unit_tests/dispatch/bridge/test_gemma_rms_norm.py
+++ b/tests/unit_tests/dispatch/bridge/test_gemma_rms_norm.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+
+import torch
+
+import sglang_fl.dispatch.bridge.gemma_rms_norm as bridge
+
+
+def test_gemma_rms_norm_bridge_forwards_to_call_op(monkeypatch) -> None:
+    obj = SimpleNamespace()
+    x = torch.randn(2, 4)
+    residual = torch.randn(2, 4)
+    expected = torch.randn(2, 4)
+    calls = []
+
+    def fake_call_op(*args, **kwargs):
+        calls.append((args, kwargs))
+        return expected
+
+    monkeypatch.setattr(bridge, "call_op", fake_call_op)
+
+    result = bridge.gemma_rms_norm_bridge(obj, x, residual=residual)
+
+    assert result is expected
+    assert calls == [(("gemma_rms_norm", obj, x, residual), {})]
+
+
+def test_gemma_rms_norm_bridge_merges_post_residual_addition(monkeypatch) -> None:
+    obj = SimpleNamespace()
+    x = torch.randn(2, 4)
+    residual = torch.randn(2, 4)
+    post = torch.randn(2, 4)
+    captured = {}
+
+    def fake_call_op(op_name, op_obj, op_x, op_residual):
+        captured["args"] = (op_name, op_obj, op_x, op_residual)
+        return op_x
+
+    monkeypatch.setattr(bridge, "call_op", fake_call_op)
+
+    bridge.gemma_rms_norm_bridge(
+        obj,
+        x,
+        residual=residual,
+        post_residual_addition=post,
+    )
+
+    op_name, op_obj, op_x, op_residual = captured["args"]
+    assert op_name == "gemma_rms_norm"
+    assert op_obj is obj
+    assert op_x is x
+    torch.testing.assert_close(op_residual, residual + post)

--- a/tests/unit_tests/dispatch/bridge/test_mrotary_embedding.py
+++ b/tests/unit_tests/dispatch/bridge/test_mrotary_embedding.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+
+import torch
+
+import sglang_fl.dispatch.bridge.mrotary_embedding as bridge
+
+
+def test_mrotary_embedding_bridge_forwards_to_call_op(monkeypatch) -> None:
+    obj = SimpleNamespace()
+    positions = torch.tensor([[0, 1], [1, 2], [2, 3]])
+    query = torch.randn(2, 8)
+    key = torch.randn(2, 8)
+    expected = (torch.randn(2, 8), torch.randn(2, 8))
+    calls = []
+
+    def fake_call_op(*args, **kwargs):
+        calls.append((args, kwargs))
+        return expected
+
+    monkeypatch.setattr(bridge, "call_op", fake_call_op)
+
+    result = bridge.mrotary_embedding_bridge(obj, positions, query, key)
+
+    assert result is expected
+    assert calls == [(("mrotary_embedding", obj, positions, query, key), {})]
+
+
+def test_mrotary_embedding_bridge_falls_through_for_fused_kv_arg() -> None:
+    expected = (torch.randn(2, 8), torch.randn(2, 8))
+    obj = SimpleNamespace(forward_native=lambda *args: expected)
+
+    result = bridge.mrotary_embedding_bridge(
+        obj,
+        torch.tensor([0, 1]),
+        torch.randn(2, 8),
+        torch.randn(2, 8),
+        fused_set_kv_buffer_arg=object(),
+    )
+
+    assert result is expected

--- a/tests/unit_tests/dispatch/bridge/test_rms_norm.py
+++ b/tests/unit_tests/dispatch/bridge/test_rms_norm.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+
+import torch
+
+import sglang_fl.dispatch.bridge.rms_norm as bridge
+
+
+def test_rms_norm_bridge_forwards_x_and_residual(monkeypatch) -> None:
+    obj = SimpleNamespace()
+    x = torch.randn(2, 4)
+    residual = torch.randn(2, 4)
+    expected = torch.randn(2, 4)
+    calls = []
+
+    def fake_call_op(*args, **kwargs):
+        calls.append((args, kwargs))
+        return expected
+
+    monkeypatch.setattr(bridge, "call_op", fake_call_op)
+
+    result = bridge.rms_norm_bridge(obj, x, residual=residual)
+
+    assert result is expected
+    assert calls == [(("rms_norm", obj, x, residual), {})]
+
+
+def test_rms_norm_bridge_merges_post_residual_addition(monkeypatch) -> None:
+    obj = SimpleNamespace()
+    x = torch.randn(2, 4)
+    residual = torch.randn(2, 4)
+    post = torch.randn(2, 4)
+    captured = {}
+
+    def fake_call_op(op_name, op_obj, op_x, op_residual):
+        captured["args"] = (op_name, op_obj, op_x, op_residual)
+        return op_x
+
+    monkeypatch.setattr(bridge, "call_op", fake_call_op)
+
+    bridge.rms_norm_bridge(
+        obj,
+        x,
+        residual=residual,
+        post_residual_addition=post,
+    )
+
+    op_name, op_obj, op_x, op_residual = captured["args"]
+    assert op_name == "rms_norm"
+    assert op_obj is obj
+    assert op_x is x
+    torch.testing.assert_close(op_residual, residual + post)
+
+
+def test_rms_norm_bridge_uses_post_residual_when_residual_is_none(monkeypatch) -> None:
+    obj = SimpleNamespace()
+    x = torch.randn(2, 4)
+    post = torch.randn(2, 4)
+    calls = []
+
+    def fake_call_op(*args, **kwargs):
+        calls.append((args, kwargs))
+        return args[-1]
+
+    monkeypatch.setattr(bridge, "call_op", fake_call_op)
+
+    result = bridge.rms_norm_bridge(obj, x, post_residual_addition=post)
+
+    assert result is post
+    assert calls == [(("rms_norm", obj, x, post), {})]

--- a/tests/unit_tests/dispatch/bridge/test_rotary_embedding.py
+++ b/tests/unit_tests/dispatch/bridge/test_rotary_embedding.py
@@ -1,0 +1,113 @@
+from types import SimpleNamespace
+
+import torch
+
+import sglang_fl.dispatch.bridge.rotary_embedding as bridge
+
+
+def test_rotary_embedding_bridge_extracts_cache_and_forwards(monkeypatch) -> None:
+    positions = torch.tensor([0, 2])
+    query = torch.randn(2, 8)
+    key = torch.randn(2, 8)
+    cos = torch.randn(4, 4)
+    sin = torch.randn(4, 4)
+    obj = SimpleNamespace(
+        cos_sin_cache=torch.cat([cos, sin], dim=-1),
+        head_size=4,
+        is_neox_style=True,
+    )
+    q_embed = torch.randn(2, 2, 4)
+    k_embed = torch.randn(2, 2, 4)
+    calls = []
+
+    def fake_call_op(*args, **kwargs):
+        calls.append((args, kwargs))
+        return q_embed, k_embed
+
+    monkeypatch.setattr(bridge, "call_op", fake_call_op)
+
+    out_q, out_k = bridge.rotary_embedding_bridge(obj, positions, query, key)
+
+    args, kwargs = calls[0]
+    assert args[0] == "rotary_embedding"
+    assert args[1] is obj
+    assert args[2].shape == (2, 2, 4)
+    assert args[3].shape == (2, 2, 4)
+    torch.testing.assert_close(args[4], cos)
+    torch.testing.assert_close(args[5], sin)
+    assert args[6] is positions
+    assert kwargs == {"rotary_interleaved": False, "inplace": True}
+    torch.testing.assert_close(out_q, q_embed.reshape_as(query))
+    torch.testing.assert_close(out_k, k_embed.reshape_as(key))
+
+
+def test_rotary_embedding_bridge_applies_offsets(monkeypatch) -> None:
+    positions = torch.tensor([0, 2])
+    offsets = torch.tensor([1, 1])
+    query = torch.randn(2, 8)
+    key = torch.randn(2, 8)
+    obj = SimpleNamespace(
+        cos_sin_cache=torch.randn(4, 8),
+        head_size=4,
+        is_neox_style=False,
+    )
+    captured_positions = None
+
+    def fake_call_op(*args, **kwargs):
+        nonlocal captured_positions
+        captured_positions = args[6]
+        return args[2], args[3]
+
+    monkeypatch.setattr(bridge, "call_op", fake_call_op)
+
+    bridge.rotary_embedding_bridge(obj, positions, query, key, offsets=offsets)
+
+    torch.testing.assert_close(captured_positions, positions + offsets)
+
+
+def test_rotary_embedding_bridge_handles_partial_rotary_dim(monkeypatch) -> None:
+    positions = torch.tensor([0, 1])
+    query = torch.randn(2, 8)
+    key = torch.randn(2, 8)
+    pass_q = query.view(2, 2, 4)[..., 2:].clone()
+    pass_k = key.view(2, 2, 4)[..., 2:].clone()
+    obj = SimpleNamespace(
+        cos_sin_cache=torch.randn(4, 2),
+        head_size=4,
+        is_neox_style=True,
+    )
+
+    def fake_call_op(*args, **kwargs):
+        q_rot = args[2]
+        k_rot = args[3]
+        return torch.zeros_like(q_rot), torch.ones_like(k_rot)
+
+    monkeypatch.setattr(bridge, "call_op", fake_call_op)
+
+    out_q, out_k = bridge.rotary_embedding_bridge(obj, positions, query, key)
+    out_q = out_q.view(2, 2, 4)
+    out_k = out_k.view(2, 2, 4)
+
+    torch.testing.assert_close(out_q[..., :2], torch.zeros_like(out_q[..., :2]))
+    torch.testing.assert_close(out_q[..., 2:], pass_q)
+    torch.testing.assert_close(out_k[..., :2], torch.ones_like(out_k[..., :2]))
+    torch.testing.assert_close(out_k[..., 2:], pass_k)
+
+
+def test_rotary_embedding_bridge_falls_through_for_fused_kv_arg() -> None:
+    expected = (torch.randn(2, 8), torch.randn(2, 8))
+    obj = SimpleNamespace(
+        forward_native=lambda *args: expected,
+        cos_sin_cache=torch.randn(4, 8),
+        head_size=4,
+    )
+
+    result = bridge.rotary_embedding_bridge(
+        obj,
+        torch.tensor([0, 1]),
+        torch.randn(2, 8),
+        torch.randn(2, 8),
+        fused_set_kv_buffer_arg=object(),
+    )
+
+    assert result is expected

--- a/tests/unit_tests/dispatch/bridge/test_silu_and_mul.py
+++ b/tests/unit_tests/dispatch/bridge/test_silu_and_mul.py
@@ -1,0 +1,23 @@
+from types import SimpleNamespace
+
+import torch
+
+import sglang_fl.dispatch.bridge.silu_and_mul as bridge
+
+
+def test_silu_and_mul_bridge_forwards_to_call_op(monkeypatch) -> None:
+    obj = SimpleNamespace()
+    x = torch.randn(2, 8)
+    expected = torch.randn(2, 4)
+    calls = []
+
+    def fake_call_op(*args, **kwargs):
+        calls.append((args, kwargs))
+        return expected
+
+    monkeypatch.setattr(bridge, "call_op", fake_call_op)
+
+    result = bridge.silu_and_mul_bridge(obj, x)
+
+    assert result is expected
+    assert calls == [(("silu_and_mul", obj, x), {})]

--- a/tests/unit_tests/dispatch/bridge/test_topk.py
+++ b/tests/unit_tests/dispatch/bridge/test_topk.py
@@ -1,0 +1,37 @@
+from types import SimpleNamespace
+
+import torch
+
+import sglang_fl.dispatch.bridge.topk as bridge
+
+
+def test_topk_bridge_forwards_kwargs_to_call_op(monkeypatch) -> None:
+    obj = SimpleNamespace()
+    hidden_states = torch.randn(3, 8)
+    router_logits = torch.randn(3, 4)
+    num_token_non_padded = torch.tensor([3])
+    expert_info = object()
+    expected = object()
+    calls = []
+
+    def fake_call_op(*args, **kwargs):
+        calls.append((args, kwargs))
+        return expected
+
+    monkeypatch.setattr(bridge, "call_op", fake_call_op)
+
+    result = bridge.topk_bridge(
+        obj,
+        hidden_states,
+        router_logits,
+        num_token_non_padded=num_token_non_padded,
+        expert_location_dispatch_info=expert_info,
+    )
+
+    assert result is expected
+    args, kwargs = calls[0]
+    assert args == ("topk", obj, hidden_states, router_logits)
+    assert kwargs == {
+        "num_token_non_padded": num_token_non_padded,
+        "expert_location_dispatch_info": expert_info,
+    }

--- a/tests/unit_tests/distributed/test_communicator.py
+++ b/tests/unit_tests/distributed/test_communicator.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Unit tests for SGLang-FL CommunicatorFL.
+
+These tests use mocks to validate core initialization, backend routing, and
+global-rank mapping without starting a real torch.distributed process group.
+Detailed collective and tensor-dict behavior is covered by functional tests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import torch
+
+
+class _FakePlatform:
+    def __init__(self, backend: str) -> None:
+        self._dist_backend = backend
+
+
+class _FakeFlagCX:
+    disabled = False
+    available = True
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    def all_reduce(self, tensor):
+        self.calls.append(("all_reduce", tuple(tensor.shape)))
+        return tensor + 1
+
+    def send(self, tensor, dst):
+        self.calls.append(("send", dst, tuple(tensor.shape)))
+
+    def recv(self, tensor, src):
+        self.calls.append(("recv", src, tuple(tensor.shape)))
+
+
+def _make_comm(*, flagcx=None, world_size: int = 2, rank: int = 0):
+    from sglang_fl.distributed.communicator import CommunicatorFL
+
+    comm = CommunicatorFL.__new__(CommunicatorFL)
+    comm.cpu_group = "cpu-group"
+    comm.device = torch.device("cpu")
+    comm.device_group = "device-group"
+    comm.world_size = world_size
+    comm.rank_in_group = rank
+    comm.ranks = list(range(10, 10 + world_size))
+    comm._dist_backend = "flagcx" if flagcx else "nccl"
+    comm._flagcx_comm = flagcx
+    return comm
+
+
+def test_communicator_fl_import() -> None:
+    from sglang_fl.distributed.communicator import CommunicatorFL, TensorMetadata
+
+    assert CommunicatorFL.__name__ == "CommunicatorFL"
+    assert TensorMetadata("cpu", torch.float32, torch.Size([2])).size == torch.Size([2])
+
+
+def test_world_size_one_does_not_create_flagcx(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+    import sglang_fl.platform as platform_mod
+    import sglang_fl.distributed.device_communicators.flagcx as flagcx_mod
+
+    fake_ctor = Mock(return_value=_FakeFlagCX())
+    monkeypatch.setattr(platform_mod, "PlatformFL", lambda: _FakePlatform("flagcx"))
+    monkeypatch.setattr(flagcx_mod, "FlagCXCommunicator", fake_ctor)
+
+    comm = comm_mod.CommunicatorFL(
+        cpu_group="cpu-group",
+        device=torch.device("cpu"),
+        device_group="device-group",
+        world_size=1,
+        rank_in_group=0,
+        ranks=[0],
+    )
+
+    assert comm._dist_backend == "flagcx"
+    assert comm._flagcx_comm is None
+    fake_ctor.assert_not_called()
+
+
+def test_flagcx_creation_failure_falls_back_to_torch(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+    import sglang_fl.platform as platform_mod
+    import sglang_fl.distributed.device_communicators.flagcx as flagcx_mod
+
+    monkeypatch.setattr(platform_mod, "PlatformFL", lambda: _FakePlatform("flagcx"))
+    monkeypatch.setattr(
+        flagcx_mod,
+        "FlagCXCommunicator",
+        Mock(side_effect=RuntimeError("flagcx unavailable")),
+    )
+
+    comm = comm_mod.CommunicatorFL(
+        cpu_group="cpu-group",
+        device=torch.device("cpu"),
+        device_group="device-group",
+        world_size=2,
+        rank_in_group=0,
+        ranks=[0, 1],
+    )
+
+    assert comm._dist_backend == "flagcx"
+    assert comm._flagcx_comm is None
+
+
+def test_all_reduce_uses_flagcx_and_copies_back(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+
+    monkeypatch.setattr(comm_mod.dist, "all_reduce", Mock())
+    flagcx = _FakeFlagCX()
+    comm = _make_comm(flagcx=flagcx)
+    tensor = torch.tensor([1.0, 2.0])
+
+    assert comm.all_reduce(tensor) is tensor
+    assert torch.equal(tensor, torch.tensor([2.0, 3.0]))
+    assert flagcx.calls == [("all_reduce", (2,))]
+    comm_mod.dist.all_reduce.assert_not_called()
+
+
+def test_all_reduce_without_flagcx_uses_dist(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+
+    dist_all_reduce = Mock()
+    monkeypatch.setattr(comm_mod.dist, "all_reduce", dist_all_reduce)
+    comm = _make_comm()
+    tensor = torch.ones(2)
+
+    assert comm.all_reduce(tensor) is tensor
+    dist_all_reduce.assert_called_once_with(tensor, group="device-group")
+
+
+def test_send_recv_fallback_use_dist_global_ranks(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+
+    dist_send = Mock()
+    dist_recv = Mock()
+    monkeypatch.setattr(comm_mod.dist, "send", dist_send)
+    monkeypatch.setattr(comm_mod.dist, "recv", dist_recv)
+    comm = _make_comm(world_size=2, rank=0)
+    tensor = torch.ones(2)
+
+    comm.send(tensor, dst=1)
+    comm.recv(tensor, src=1)
+
+    dist_send.assert_called_once_with(tensor, 11, "device-group")
+    dist_recv.assert_called_once_with(tensor, 11, "device-group")

--- a/tests/unit_tests/distributed/test_flagcx.py
+++ b/tests/unit_tests/distributed/test_flagcx.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Unit tests for the FlagCX device communicator wrapper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+
+class _FakeFlagCXLibrary:
+    def __init__(self, library_path: str) -> None:
+        self.library_path = library_path
+
+
+class _FakeFlagCXId:
+    def __init__(self) -> None:
+        self.internal = [0] * 128
+
+
+def _fake_wrapper_tuple():
+    return (
+        _FakeFlagCXLibrary,
+        lambda ptr=None: ptr,
+        object,
+        object,
+        object,
+        _FakeFlagCXId,
+    )
+
+
+def _disabled_comm():
+    from sglang_fl.distributed.device_communicators.flagcx import FlagCXCommunicator
+
+    comm = FlagCXCommunicator.__new__(FlagCXCommunicator)
+    comm.disabled = True
+    comm.available = False
+    comm.device = torch.device("cpu")
+    return comm
+
+
+def test_import_flagcx_wrapper_requires_flagcx_path(monkeypatch) -> None:
+    from sglang_fl.distributed.device_communicators.flagcx import _import_flagcx_wrapper
+
+    monkeypatch.delenv("FLAGCX_PATH", raising=False)
+
+    with pytest.raises(RuntimeError, match="FLAGCX_PATH environment variable is not set"):
+        _import_flagcx_wrapper()
+
+
+def test_import_flagcx_wrapper_rejects_invalid_path(monkeypatch) -> None:
+    from sglang_fl.distributed.device_communicators.flagcx import _import_flagcx_wrapper
+
+    monkeypatch.setenv("FLAGCX_PATH", "/path/that/does/not/exist")
+
+    with pytest.raises(RuntimeError, match="is not a valid directory"):
+        _import_flagcx_wrapper()
+
+
+def test_world_size_one_disables_communicator(monkeypatch, tmp_path: Path) -> None:
+    from sglang_fl.distributed.device_communicators import flagcx as flagcx_mod
+
+    monkeypatch.setenv("FLAGCX_PATH", str(tmp_path))
+    monkeypatch.setattr(flagcx_mod, "_import_flagcx_wrapper", lambda: _fake_wrapper_tuple())
+    monkeypatch.setattr(flagcx_mod.dist, "get_rank", Mock(return_value=0))
+    monkeypatch.setattr(flagcx_mod.dist, "get_world_size", Mock(return_value=1))
+
+    comm = flagcx_mod.FlagCXCommunicator(group="group", device=torch.device("cpu"))
+
+    assert comm.disabled is True
+    assert comm.available is False
+    assert comm.group == "group"
+
+
+def test_destroy_marks_communicator_unavailable() -> None:
+    from sglang_fl.distributed.device_communicators.flagcx import FlagCXCommunicator
+
+    comm = FlagCXCommunicator.__new__(FlagCXCommunicator)
+    comm.comm = object()
+    comm.available = True
+    comm.disabled = False
+    comm.flagcx = Mock()
+
+    comm.destroy()
+
+    assert comm.comm is None
+    assert comm.available is False
+    assert comm.disabled is True
+    comm.flagcx.flagcxCommDestroy.assert_called_once()
+
+
+def test_disabled_all_reduce_returns_early() -> None:
+    comm = _disabled_comm()
+
+    assert comm.all_reduce(torch.ones(2)) is None
+
+
+def test_disabled_reduce_scatter_returns_early() -> None:
+    comm = _disabled_comm()
+
+    assert comm.reduce_scatter(torch.empty(2), torch.ones(4)) is None
+
+
+def test_disabled_all_gather_returns_early() -> None:
+    comm = _disabled_comm()
+
+    assert comm.all_gather(torch.empty(4), torch.ones(2)) is None
+
+
+def test_disabled_reduce_scatterv_returns_early() -> None:
+    comm = _disabled_comm()
+
+    assert comm.reduce_scatterv(torch.empty(2), torch.ones(4), sizes=[2, 2]) is None
+
+
+def test_disabled_all_gatherv_returns_early() -> None:
+    comm = _disabled_comm()
+
+    assert comm.all_gatherv(torch.empty(4), torch.ones(2), sizes=[2, 2]) is None
+
+
+def test_disabled_send_recv_broadcast_return_early() -> None:
+    comm = _disabled_comm()
+    tensor = torch.ones(2)
+
+    assert comm.broadcast(tensor, src=0) is None
+    assert comm.send(tensor, dst=1) is None
+    assert comm.recv(tensor, src=0) is None

--- a/tests/unit_tests/flaggems/test_setup_flaggems.py
+++ b/tests/unit_tests/flaggems/test_setup_flaggems.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import logging
+import sys
+from types import ModuleType
+
+import pytest
+
+
+@pytest.fixture
+def sglang_fl_module():
+    import sglang_fl
+
+    return sglang_fl
+
+
+@pytest.fixture
+def fake_flag_gems(monkeypatch):
+    module = ModuleType("flag_gems")
+    calls = []
+
+    def enable(**kwargs):
+        calls.append(("enable", kwargs))
+
+    def only_enable(**kwargs):
+        calls.append(("only_enable", kwargs))
+
+    module.enable = enable
+    module.only_enable = only_enable
+    module.calls = calls
+    monkeypatch.setitem(sys.modules, "flag_gems", module)
+    return module
+
+
+@pytest.fixture(autouse=True)
+def clean_flaggems_env(monkeypatch):
+    for key in (
+        "USE_FLAGGEMS",
+        "SGLANG_FL_FLAGOS_WHITELIST",
+        "SGLANG_FL_FLAGOS_BLACKLIST",
+        "SGLANG_FLAGGEMS_RECORD",
+        "SGLANG_FLAGGEMS_LOG_PATH",
+        "SGLANG_FLAGGEMS_LOG_ONCE",
+        "SGLANG_FL_CONFIG",
+        "SGLANG_FL_PLATFORM",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_use_flaggems_zero_does_not_import_or_enable(
+    monkeypatch,
+    sglang_fl_module,
+) -> None:
+    monkeypatch.setenv("USE_FLAGGEMS", "0")
+    monkeypatch.delitem(sys.modules, "flag_gems", raising=False)
+
+    sglang_fl_module._setup_flaggems({})
+
+    assert "flag_gems" not in sys.modules
+
+
+def test_no_whitelist_or_blacklist_calls_enable(
+    monkeypatch,
+    sglang_fl_module,
+    fake_flag_gems,
+) -> None:
+    monkeypatch.setenv("USE_FLAGGEMS", "1")
+
+    sglang_fl_module._setup_flaggems({})
+
+    assert fake_flag_gems.calls == [
+        ("enable", {"record": False, "once": True}),
+    ]
+
+
+def test_flagos_whitelist_calls_only_enable(
+    monkeypatch,
+    sglang_fl_module,
+    fake_flag_gems,
+) -> None:
+    monkeypatch.setenv("SGLANG_FL_FLAGOS_WHITELIST", "silu, rms_norm")
+
+    sglang_fl_module._setup_flaggems({})
+
+    assert fake_flag_gems.calls == [
+        (
+            "only_enable",
+            {
+                "include": ["silu", "rms_norm"],
+                "record": False,
+                "once": True,
+            },
+        ),
+    ]
+
+
+def test_flagos_blacklist_calls_enable_with_unused(
+    monkeypatch,
+    sglang_fl_module,
+    fake_flag_gems,
+) -> None:
+    monkeypatch.setenv("SGLANG_FL_FLAGOS_BLACKLIST", "count_nonzero, var_mean")
+
+    sglang_fl_module._setup_flaggems({})
+
+    assert fake_flag_gems.calls == [
+        (
+            "enable",
+            {
+                "unused": ["count_nonzero", "var_mean"],
+                "record": False,
+                "once": True,
+            },
+        ),
+    ]
+
+
+def test_flagos_whitelist_and_blacklist_are_mutually_exclusive(
+    monkeypatch,
+    sglang_fl_module,
+    fake_flag_gems,
+) -> None:
+    monkeypatch.setenv("SGLANG_FL_FLAGOS_WHITELIST", "silu")
+    monkeypatch.setenv("SGLANG_FL_FLAGOS_BLACKLIST", "rms_norm")
+
+    with pytest.raises(ValueError, match="Cannot set both"):
+        sglang_fl_module._setup_flaggems({})
+
+    assert fake_flag_gems.calls == []
+
+
+def test_flagos_lists_strip_spaces_and_empty_items(
+    monkeypatch,
+    sglang_fl_module,
+    fake_flag_gems,
+) -> None:
+    monkeypatch.setenv("SGLANG_FL_FLAGOS_BLACKLIST", " silu , , rms_norm , ")
+
+    sglang_fl_module._setup_flaggems({})
+
+    assert fake_flag_gems.calls[0] == (
+        "enable",
+        {
+            "unused": ["silu", "rms_norm"],
+            "record": False,
+            "once": True,
+        },
+    )
+
+
+def test_flaggems_record_and_log_path_are_forwarded(
+    monkeypatch,
+    sglang_fl_module,
+    fake_flag_gems,
+) -> None:
+    monkeypatch.setenv("SGLANG_FLAGGEMS_RECORD", "1")
+    monkeypatch.setenv("SGLANG_FLAGGEMS_LOG_PATH", "/tmp/flaggems.log")
+    monkeypatch.setenv("SGLANG_FLAGGEMS_LOG_ONCE", "0")
+
+    sglang_fl_module._setup_flaggems()
+
+    assert fake_flag_gems.calls == [
+        (
+            "enable",
+            {
+                "record": True,
+                "once": False,
+                "path": "/tmp/flaggems.log",
+            },
+        ),
+    ]
+
+
+def test_flaggems_record_installs_aten_only_filter(
+    sglang_fl_module,
+    fake_flag_gems,
+) -> None:
+    logger = logging.getLogger("flag_gems")
+    handler = logging.StreamHandler()
+    handler._flaggems_owned = True
+    old_handlers = list(logger.handlers)
+    logger.handlers = [handler]
+    try:
+        sglang_fl_module._setup_flaggems(
+            {
+                "flaggems_record": True,
+                "flaggems_log_path": "",
+                "flagos_blacklist": [],
+            }
+        )
+        assert handler.filters
+        filter_ = handler.filters[-1]
+        assert filter_.filter(logging.LogRecord(
+            "flag_gems.ops.add",
+            logging.INFO,
+            "",
+            0,
+            "",
+            (),
+            None,
+        ))
+        assert not filter_.filter(logging.LogRecord(
+            "flag_gems.modules.activation",
+            logging.INFO,
+            "",
+            0,
+            "",
+            (),
+            None,
+        ))
+    finally:
+        logger.handlers = old_handlers
+
+
+def test_yaml_flagos_blacklist_is_default_when_env_blacklist_absent(
+    sglang_fl_module,
+    fake_flag_gems,
+) -> None:
+    sglang_fl_module._setup_flaggems(
+        {
+            "flaggems_record": False,
+            "flaggems_log_path": "",
+            "flagos_blacklist": ["count_nonzero"],
+        }
+    )
+
+    assert fake_flag_gems.calls == [
+        (
+            "enable",
+            {
+                "unused": ["count_nonzero"],
+                "record": False,
+                "once": True,
+            },
+        ),
+    ]
+
+
+def test_env_blacklist_overrides_yaml_flagos_blacklist(
+    monkeypatch,
+    sglang_fl_module,
+    fake_flag_gems,
+) -> None:
+    monkeypatch.setenv("SGLANG_FL_FLAGOS_BLACKLIST", "silu")
+
+    sglang_fl_module._setup_flaggems(
+        {
+            "flaggems_record": False,
+            "flaggems_log_path": "",
+            "flagos_blacklist": ["count_nonzero"],
+        }
+    )
+
+    assert fake_flag_gems.calls == [
+        (
+            "enable",
+            {
+                "unused": ["silu"],
+                "record": False,
+                "once": True,
+            },
+        ),
+    ]
+
+
+def test_build_config_reads_flaggems_env(
+    monkeypatch,
+    sglang_fl_module,
+) -> None:
+    import sglang_fl.dispatch.config as config_module
+
+    monkeypatch.setattr(config_module, "get_effective_config", lambda: {})
+    monkeypatch.setenv("SGLANG_FLAGGEMS_RECORD", "true")
+    monkeypatch.setenv("SGLANG_FLAGGEMS_LOG_PATH", "/tmp/fg.log")
+
+    config = sglang_fl_module._build_config()
+
+    assert config["flaggems_record"] is True
+    assert config["flaggems_log_path"] == "/tmp/fg.log"
+
+
+def test_build_config_uses_yaml_flagos_blacklist_when_env_absent(
+    monkeypatch,
+    sglang_fl_module,
+) -> None:
+    import sglang_fl.dispatch.config as config_module
+
+    monkeypatch.setattr(
+        config_module,
+        "get_effective_config",
+        lambda: {"flagos_blacklist": ["yaml_op"]},
+    )
+
+    config = sglang_fl_module._build_config()
+
+    assert config["flagos_blacklist"] == ["yaml_op"]
+
+
+def test_build_config_env_flagos_blacklist_overrides_yaml(
+    monkeypatch,
+    sglang_fl_module,
+) -> None:
+    import sglang_fl.dispatch.config as config_module
+
+    monkeypatch.setattr(
+        config_module,
+        "get_effective_config",
+        lambda: {"flagos_blacklist": ["yaml_op"]},
+    )
+    monkeypatch.setenv("SGLANG_FL_FLAGOS_BLACKLIST", " env_op , other_op ")
+
+    config = sglang_fl_module._build_config()
+
+    assert config["flagos_blacklist"] == ["env_op", "other_op"]

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+# Shared test utilities for sglang-plugin-FL.

--- a/tests/utils/model_config.py
+++ b/tests/utils/model_config.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Model configuration loader for sglang-plugin-FL tests.
+
+Model YAML files use SGLang-native engine parameter names such as
+``tp_size``, ``context_length``, ``mem_fraction_static``, and
+``disable_cuda_graph``.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+_MODELS_DIR = Path(__file__).resolve().parents[1] / "models"
+
+
+def _load_structured(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8-sig")
+    try:
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(text) or {}
+    except ModuleNotFoundError:
+        data = json.loads(text)
+    return data if isinstance(data, dict) else {}
+
+
+@dataclass
+class GenerateConfig:
+    modality: str = "text"
+    prompts: list[Any] = field(default_factory=list)
+    assets: list[str] = field(default_factory=list)
+    sampling: dict[str, Any] = field(default_factory=dict)
+    vl: dict[str, Any] = field(default_factory=dict)
+    parametrize: dict[str, list[Any]] | list[dict[str, Any]] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "GenerateConfig":
+        return cls(
+            modality=raw.get("modality", "text"),
+            prompts=raw.get("prompts", []),
+            assets=raw.get("assets", []),
+            sampling=raw.get("sampling", {}),
+            vl=raw.get("vl", {}),
+            parametrize=raw.get("parametrize", {}),
+        )
+
+    def get_parametrize_combos(self) -> list[dict[str, Any]]:
+        """Return explicit combos or the Cartesian product of dimensions."""
+        if not self.parametrize:
+            return [{}]
+        if isinstance(self.parametrize, list):
+            return [dict(combo) for combo in self.parametrize]
+
+        keys = list(self.parametrize.keys())
+        values = [self.parametrize[k] for k in keys]
+        return [dict(zip(keys, combo)) for combo in itertools.product(*values)]
+
+
+@dataclass
+class ServeConfig:
+    api_key: str = ""
+    extra_engine: dict[str, Any] = field(default_factory=dict)
+    served_model_name: str = ""
+    startup_retries: int = 120
+    endpoints: list[str] = field(default_factory=list)
+    completion_prompt: str = "Hello"
+    stream: bool = False
+    max_tokens: int = 50
+    chat_messages: list[dict[str, Any]] = field(default_factory=list)
+    sampling: dict[str, Any] = field(default_factory=dict)
+    extra_body: dict[str, Any] = field(default_factory=dict)
+    embedding_input: str = ""
+
+    def request_model(self, model_path: str) -> str:
+        return self.served_model_name or model_path
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "ServeConfig":
+        return cls(
+            api_key=raw.get("api_key", ""),
+            extra_engine=raw.get("extra_engine", {}),
+            served_model_name=raw.get("served_model_name", ""),
+            startup_retries=int(raw.get("startup_retries", 120)),
+            endpoints=raw.get("endpoints", []),
+            completion_prompt=raw.get("completion_prompt", "Hello"),
+            stream=bool(raw.get("stream", False)),
+            max_tokens=int(raw.get("max_tokens", 50)),
+            chat_messages=raw.get("chat_messages", []),
+            sampling=raw.get("sampling", {}),
+            extra_body=raw.get("extra_body", {}),
+            embedding_input=raw.get("embedding_input", ""),
+        )
+
+@dataclass
+class ConcurrentConfig:
+    modes: list[str] = field(default_factory=list)
+    concurrent_n: int = 4
+    text_prompts: list[dict[str, Any]] = field(default_factory=list)
+    vl_cases: list[dict[str, Any]] = field(default_factory=list)
+    text_sampling: dict[str, Any] = field(default_factory=dict)
+    vl_sampling: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "ConcurrentConfig":
+        sampling = raw.get("sampling", {})
+        return cls(
+            modes=raw.get("modes", []),
+            concurrent_n=int(raw.get("concurrent_n", 4)),
+            text_prompts=raw.get("text", {}).get("prompts", []),
+            vl_cases=raw.get("vl", {}).get("cases", []),
+            text_sampling=sampling.get("text", {}),
+            vl_sampling=sampling.get("vl", {}),
+        )
+
+@dataclass
+class ModelConfig:
+    model: str
+    engine: dict[str, Any] = field(default_factory=dict)
+    generate: GenerateConfig = field(default_factory=GenerateConfig)
+    serve: ServeConfig = field(default_factory=ServeConfig)
+    concurrent: ConcurrentConfig = field(default_factory=ConcurrentConfig)
+
+    @classmethod
+    def load(
+        cls,
+        model: str,
+        case: str | None = None,
+        models_dir: Path | None = None,
+    ) -> "ModelConfig":
+        models_dir = models_dir or _MODELS_DIR
+        path = models_dir / model / f"{case}.yaml" if case else models_dir / f"{model}.yaml"
+        if not path.exists():
+            raise FileNotFoundError(f"Model config not found: {path}")
+        return cls.from_dict(_load_structured(path))
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "ModelConfig":
+        llm_raw = dict(raw.get("llm", {}))
+        model = llm_raw.pop("model", raw.get("model_path", ""))
+        engine = llm_raw or dict(raw.get("engine", {}))
+        return cls(
+            model=model,
+            engine=engine,
+            generate=GenerateConfig.from_dict(raw.get("generate", {})),
+            serve=ServeConfig.from_dict(raw.get("serve", {})),
+            concurrent=ConcurrentConfig.from_dict(raw.get("concurrent", {})),
+        )
+
+    def sglang_common_params(self) -> dict[str, Any]:
+        """Return engine parameters using SGLang CLI names."""
+        return {"model_path": self.model, **self.engine}
+
+    def engine_kwargs(self, **overrides: Any) -> dict[str, Any]:
+        """Return engine parameters as Python kwargs for SGLang Engine."""
+        params = self.sglang_common_params()
+        params.update(overrides)
+        return params
+
+    def sampling_kwargs(self, **overrides: Any) -> dict[str, Any]:
+        """Return sampling parameters using SGLang Engine names."""
+        params = dict(self.generate.sampling)
+        params.update(overrides)
+        return params
+
+    def benchmark_parameters(self, overrides: dict[str, Any]) -> dict[str, Any]:
+        params = self.sglang_common_params()
+        params.update(overrides)
+        return params
+
+    def server_parameters(self, overrides: dict[str, Any]) -> dict[str, Any]:
+        params = self.sglang_common_params()
+        params.update(overrides)
+        if self.serve.served_model_name:
+            params.setdefault("served_model_name", self.serve.served_model_name)
+        return params
+
+    def serve_args(self, **overrides: Any) -> list[str]:
+        params = self.sglang_common_params()
+        params.pop("model_path", None)
+        params.pop("tp_size", None)
+        params.update(overrides)
+
+        args: list[str] = []
+        for key, value in params.items():
+            if value is None or value is False:
+                continue
+            flag = "--" + key.replace("_", "-")
+            if value is True or value == "":
+                args.append(flag)
+            else:
+                args.extend([flag, str(value)])
+        return args
+
+
+
+

--- a/tests/utils/platform_config.py
+++ b/tests/utils/platform_config.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Platform configuration loader for sglang-plugin-FL tests."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+_PLATFORMS_DIR = Path(__file__).resolve().parents[1] / "platforms"
+
+
+def _load_structured(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8-sig")
+    try:
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(text) or {}
+    except ModuleNotFoundError:
+        data = json.loads(text)
+    return data if isinstance(data, dict) else {}
+
+
+@dataclass
+class Tolerance:
+    rtol: float = 1e-5
+    atol: float = 1e-8
+    exact: bool = False
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "Tolerance":
+        return cls(
+            rtol=float(raw.get("rtol", 1e-5)),
+            atol=float(raw.get("atol", 1e-8)),
+            exact=bool(raw.get("exact", False)),
+        )
+
+
+@dataclass
+class TestFilter:
+    include: str | list[str] = "*"
+    exclude: list[str] = field(default_factory=list)
+
+
+@dataclass
+class FunctionalTests:
+    tests: dict[str, dict[str, list[str]]] = field(default_factory=dict)
+
+    def get_cases(self, task: str | None = None, model: str | None = None) -> list[dict[str, str]]:
+        cases: list[dict[str, str]] = []
+        for task_name, models in self.tests.items():
+            if task and task_name != task:
+                continue
+            for model_name, case_list in models.items():
+                if model and model_name != model:
+                    continue
+                for case in case_list:
+                    cases.append({"task": task_name, "model": model_name, "case": case})
+        return cases
+
+
+@dataclass
+class PlatformConfig:
+    platform: str
+    vendor: str
+    device_types: dict[str, Any]
+    tolerance: dict[str, dict[str, Tolerance]]
+    device_overrides: dict[str, Any]
+    env_defaults: dict[str, str]
+    unsupported_features: list[str]
+    device_tests: dict[str, dict[str, Any]]
+    device: str
+
+    @classmethod
+    def load(
+        cls,
+        platform: str,
+        device: str | None = None,
+        platforms_dir: Path | None = None,
+    ) -> "PlatformConfig":
+        platforms_dir = platforms_dir or _PLATFORMS_DIR
+        path = _resolve_platform_file(platform, platforms_dir)
+        raw = _load_structured(path)
+        device_types = raw.get("device_types", {}) or {}
+        if isinstance(device_types, list):
+            device_types = {str(name): {} for name in device_types}
+
+        active_device = device or next(iter(device_types), "")
+        device_tests = {
+            str(name): raw.get(str(name), {})
+            for name in device_types
+            if isinstance(raw.get(str(name), {}), dict)
+        }
+        tolerance: dict[str, dict[str, Tolerance]] = {}
+        for category, dtypes in (raw.get("tolerance") or {}).items():
+            tolerance[category] = {}
+            for dtype_name, tol_raw in dtypes.items():
+                tolerance[category][dtype_name] = Tolerance.from_dict(tol_raw)
+
+        return cls(
+            platform=raw.get("platform", path.stem),
+            vendor=raw.get("vendor", ""),
+            device_types=device_types,
+            tolerance=tolerance,
+            device_overrides=raw.get("device_overrides", {}) or {},
+            env_defaults=raw.get("env_defaults", {}) or {},
+            unsupported_features=raw.get("unsupported_features", []) or [],
+            device_tests=device_tests,
+            device=active_device,
+        )
+
+    def apply_env_defaults(self) -> None:
+        for key, value in self.env_defaults.items():
+            os.environ.setdefault(str(key), str(value))
+
+    def get_unit_filter(self) -> TestFilter:
+        raw = self._tests_section("unit")
+        return TestFilter(include=raw.get("include", "*"), exclude=raw.get("exclude", []))
+
+    def get_e2e_tests(self) -> FunctionalTests:
+        raw = self._tests_section("e2e")
+        return FunctionalTests(tests=raw)
+
+    def get_functional_filter(self) -> TestFilter:
+        raw = self._tests_section("functional")
+        return TestFilter(include=raw.get("include", "*"), exclude=raw.get("exclude", []))
+
+    def get_benchmark_tests(self) -> dict[str, Any]:
+        return self._tests_section("benchmark")
+
+    def get_tolerance(self, category: str = "inference", dtype: str = "default") -> Tolerance:
+        device_override = self.device_overrides.get(self.device, {})
+        if isinstance(device_override, dict):
+            device_tolerance = device_override.get("tolerance", {}).get(category, {})
+            if dtype in device_tolerance:
+                return Tolerance.from_dict(device_tolerance[dtype])
+            if "default" in device_tolerance:
+                return Tolerance.from_dict(device_tolerance["default"])
+
+        category_tolerance = self.tolerance.get(category, {})
+        if dtype in category_tolerance:
+            return category_tolerance[dtype]
+        if "default" in category_tolerance:
+            return category_tolerance["default"]
+
+        return Tolerance()
+
+    def should_skip_model(self, model_name: str) -> bool:
+        return any(token in model_name for token in self.unsupported_features)
+
+    def _tests_section(self, name: str) -> dict[str, Any]:
+        return self.device_tests.get(self.device, {}).get("tests", {}).get(name, {}) or {}
+
+
+def _resolve_platform_file(platform: str, platforms_dir: Path) -> Path:
+    direct = platforms_dir / f"{platform}.yaml"
+    if direct.exists():
+        return direct
+
+    for candidate in platforms_dir.glob("*.yaml"):
+        if candidate.stem == "template":
+            continue
+        raw = _load_structured(candidate)
+        device_types = raw.get("device_types", {}) or {}
+        names = device_types if isinstance(device_types, list) else device_types.keys()
+        if platform in names:
+            return candidate
+
+    available = ", ".join(sorted(p.stem for p in platforms_dir.glob("*.yaml")))
+    raise FileNotFoundError(f"Platform config not found for {platform}. Available: {available}")
+
+


### PR DESCRIPTION
## Summary

This PR adds the initial test infrastructure and smoke coverage for `sglang-plugin-FL`.

Main changes:
- Add a unified `tests/run.py` runner for selecting tests by platform, scope, task, model, and case.
- Add model and platform YAML configurations for CUDA test cases.
- Add unit tests for:
  - SGLang dispatch bridges
  - reference backend correctness
  - FlagGems environment configuration
  - distributed communicator and FlagCX fallback behavior
- Add functional tests for:
  - op correctness
  - graph capability and capture smoke coverage
  - distributed collective routing and tensor-dictionary communication
- Add E2E smoke tests for:
  - offline text and vision-language inference
  - OpenAI-compatible serving
  - text, VL, and mixed concurrent inference
- Add benchmark smoke tests for:
  - offline throughput
  - single-batch latency
  - serving benchmark

## Validation

Validated on the target CUDA environment.

Validated items:
- unit tests: passed
- functional tests: passed
- e2e Qwen3.6-27B/Qwen3.6-35B-A3B TP=2 no-graph inference: passed
- e2e Qwen3.6-27B/Qwen3.6-35B-A3B TP=2 no-graph serving: passed
- e2e Qwen3.6-27B/Qwen3.6-35B-A3B TP=2 no-graph concurrent text/VL/mixed inference: passed
- benchmark latency smoke: passed
- benchmark serving smoke: passed
- benchmark throughout smoke: passed

## Notes

This PR focuses on deterministic smoke coverage and configuration-driven test execution. Model cases are selected from YAML files, allowing larger models and additional platform-specific cases to be added without changing the test runner.
