### PR TITLE
[NPU] Add ascend vendor patch for PP comm and qwen3-vl

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -19,3 +19,4 @@ cann = "cann"
 # SGLang env var uses "INBALANCE" (upstream spelling)
 INBALANCE = "INBALANCE"
 lod = "lod"
+thw = "thw"

--- a/sglang_fl/dispatch/backends/vendor/ascend/patch.py
+++ b/sglang_fl/dispatch/backends/vendor/ascend/patch.py
@@ -1,0 +1,35 @@
+"""Vendor monkey-patches on sglang internals for Ascend / NPU — entrypoint.
+
+These replace direct edits to sglang source that were previously required on
+Huawei NPU:
+  - scheduler_pp: PP send/recv ordering + stream syncs (HCCL deadlock fix)
+  - attention_registry: defer CUDA-only linear-attn backend imports on NPU
+  - qwen_vl_processor: transformers-version-compatible Qwen-VL preprocess
+"""
+
+import logging
+
+from .patches.attention_registry import patch_attn_backend_wrapper
+from .patches.qwen_vl_processor import patch_qwen_vl_processor
+from .patches.scheduler_pp import (
+    patch_pp_launch_batch_sync,
+    patch_pp_send_recv_order,
+)
+
+logger = logging.getLogger(__name__)
+_patches_applied = False
+
+
+def apply_ascend_patches() -> None:
+    """Apply all Ascend/NPU-specific patches."""
+    global _patches_applied
+    if _patches_applied:
+        return
+    _patches_applied = True
+
+    patch_pp_send_recv_order()
+    patch_pp_launch_batch_sync()
+    patch_attn_backend_wrapper()
+    patch_qwen_vl_processor()
+
+apply_ascend_patches()

--- a/sglang_fl/dispatch/backends/vendor/ascend/patches/_qwen_vl_processor_impl.py
+++ b/sglang_fl/dispatch/backends/vendor/ascend/patches/_qwen_vl_processor_impl.py
@@ -1,0 +1,357 @@
+"""Fixed drop-in replacement for
+``sglang.srt.hardware_backend.npu.modules.qwen_vl_processor``.
+
+This module is injected into ``sys.modules`` under the original sglang path by
+``patches/qwen_vl_processor.py`` so that ``base_processor``'s lazy
+``from ...qwen_vl_processor import npu_apply_qwen_image_preprocess_patch`` picks
+up this fixed version instead of the original module (whose top-level import of
+``group_images_by_shape``/``reorder_images`` from
+``transformers.image_processing_utils_fast`` fails on the target transformers
+version).
+
+Differences from the original sglang module:
+  1. Import ``group_images_by_shape``/``reorder_images`` from
+     ``transformers.image_transforms``.
+  2. The image/video preprocess wrappers use ``*args``/``**kwargs`` so they are
+     compatible across transformers versions (handles NPU's 8-dim tensor limit).
+  3. ``npu_apply_qwen_image_preprocess_patch`` guards each ``apply_module_patch``
+     with ``try/except ModuleNotFoundError`` and also patches the ``*Fast``
+     processor variants.
+"""
+
+import torch
+import torchvision.transforms.v2.functional as tvF
+from transformers.image_processing_utils import BatchFeature
+from transformers.image_transforms import group_images_by_shape, reorder_images
+from transformers.image_utils import (
+    ChannelDimension,
+    PILImageResampling,
+    SizeDict,
+    get_image_size,
+)
+from transformers.models.qwen2_vl.image_processing_qwen2_vl import smart_resize
+from transformers.models.qwen3_vl.video_processing_qwen3_vl import (
+    smart_resize as smart_resize_video,
+)
+from transformers.utils import TensorType
+from transformers.video_utils import group_videos_by_shape, reorder_videos
+
+from sglang.srt.utils import apply_module_patch
+
+
+def transform_patches_to_flatten(
+    patches: torch.Tensor,
+    batch_size: int,
+    grid_t: int,
+    temporal_patch_size: int,
+    channel: int,
+    grid_h: int,
+    grid_w: int,
+    patch_size: int,
+    merge_size: int,
+) -> torch.Tensor:
+    patches = patches.view(
+        batch_size * grid_t,
+        temporal_patch_size * channel,
+        grid_h // merge_size,
+        merge_size,
+        patch_size,
+        grid_w // merge_size,
+        merge_size,
+        patch_size,
+    )
+    patches = patches.permute(0, 1, 2, 5, 3, 6, 4, 7)
+    patches = patches.reshape(
+        batch_size,
+        grid_t,
+        temporal_patch_size,
+        channel,
+        grid_h * grid_w,
+        patch_size,
+        patch_size,
+    )
+    patches = patches.permute(0, 1, 4, 3, 2, 5, 6)
+    flatten_patches = patches.reshape(
+        batch_size,
+        grid_t * grid_h * grid_w,
+        -1,
+    )
+    return flatten_patches
+
+
+# Func refers to transformers.models.qwen2_vl.image_processing_qwen2_vl.py
+# Qwen2VLImageProcessor._preprocess
+def npu_wrapper_preprocess(func):
+    """
+    Universal wrapper for Qwen2VL/Qwen3VL image preprocess that handles NPU's 8-dim tensor limit.
+    Uses *args/**kwargs to be compatible with different transformers versions.
+    """
+
+    def _preprocess(self, *args, **kwargs):
+        # Extract parameters from kwargs with defaults from self attributes
+        images = kwargs.get("images", args[0] if len(args) > 0 else None)
+        do_resize = kwargs.get("do_resize", getattr(self, "do_resize", True))
+        size = kwargs.get("size", getattr(self, "size", SizeDict(shortest_edge=3136, longest_edge=1003520)))
+        resample = kwargs.get("resample", getattr(self, "resample", PILImageResampling.BICUBIC))
+        do_rescale = kwargs.get("do_rescale", getattr(self, "do_rescale", True))
+        rescale_factor = kwargs.get("rescale_factor", getattr(self, "rescale_factor", 1 / 255.0))
+        do_normalize = kwargs.get("do_normalize", getattr(self, "do_normalize", True))
+        image_mean = kwargs.get("image_mean", getattr(self, "image_mean", None))
+        image_std = kwargs.get("image_std", getattr(self, "image_std", None))
+        patch_size = kwargs.get("patch_size", getattr(self, "patch_size", 14))
+        temporal_patch_size = kwargs.get("temporal_patch_size", getattr(self, "temporal_patch_size", 2))
+        merge_size = kwargs.get("merge_size", getattr(self, "merge_size", 2))
+        disable_grouping = kwargs.get("disable_grouping", None)
+        return_tensors = kwargs.get("return_tensors", "pt")
+        # Remove already extracted parameters from kwargs to avoid duplication
+        for key in ["images", "do_resize", "size", "resample", "do_rescale",
+                    "rescale_factor", "do_normalize", "image_mean", "image_std",
+                    "patch_size", "temporal_patch_size", "merge_size",
+                    "disable_grouping", "return_tensors"]:
+            kwargs.pop(key, None)
+
+        # Group images by size for batched resizing
+        grouped_images, grouped_images_index = group_images_by_shape(
+            images, disable_grouping=disable_grouping
+        )
+        resized_images_grouped = {}
+        for shape, stacked_images in grouped_images.items():
+            height, width = stacked_images.shape[-2:]
+            if do_resize:
+                resized_height, resized_width = smart_resize(
+                    height,
+                    width,
+                    factor=patch_size * merge_size,
+                    min_pixels=size.shortest_edge,
+                    max_pixels=size.longest_edge,
+                )
+                stacked_images = self.resize(
+                    image=stacked_images,
+                    size=SizeDict(height=resized_height, width=resized_width),
+                    resample=resample,
+                )
+            resized_images_grouped[shape] = stacked_images
+        resized_images = reorder_images(resized_images_grouped, grouped_images_index)
+
+        # Group images by size for further processing
+        # Needed in case do_resize is False, or resize returns images with different sizes
+        grouped_images, grouped_images_index = group_images_by_shape(
+            resized_images, disable_grouping=disable_grouping
+        )
+        processed_images_grouped = {}
+        processed_grids = {}
+        for shape, stacked_images in grouped_images.items():
+            resized_height, resized_width = stacked_images.shape[-2:]
+            # Fused rescale and normalize
+            patches = self.rescale_and_normalize(
+                stacked_images,
+                do_rescale,
+                rescale_factor,
+                do_normalize,
+                image_mean,
+                image_std,
+            )
+            if patches.ndim == 4:
+                # add a temporal dimension if we have images
+                patches = patches.unsqueeze(1)
+            if patches.shape[1] % temporal_patch_size != 0:
+                repeats = patches[:, -1:].repeat(1, temporal_patch_size - 1, 1, 1, 1)
+                patches = torch.cat([patches, repeats], dim=1)
+            batch_size, grid_t, channel = patches.shape[:3]
+            grid_t = grid_t // temporal_patch_size
+            grid_h, grid_w = resized_height // patch_size, resized_width // patch_size
+
+            flatten_patches = transform_patches_to_flatten(
+                patches,
+                batch_size,
+                grid_t,
+                temporal_patch_size,
+                channel,
+                grid_h,
+                grid_w,
+                patch_size,
+                merge_size,
+            )
+
+            processed_images_grouped[shape] = flatten_patches
+            processed_grids[shape] = [[grid_t, grid_h, grid_w]] * batch_size
+
+        processed_images = reorder_images(
+            processed_images_grouped, grouped_images_index
+        )
+        processed_grids = reorder_images(processed_grids, grouped_images_index)
+        pixel_values = torch.cat(processed_images, dim=0)
+        image_grid_thw = torch.tensor(processed_grids)
+
+        return BatchFeature(
+            data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw},
+            tensor_type=return_tensors,
+        )
+
+    return _preprocess
+
+
+def npu_wrapper_video_preprocess(func):
+    """
+    Universal wrapper for Qwen3VL video preprocess that handles NPU's 8-dim tensor limit.
+    Uses *args/**kwargs to be compatible with different transformers versions.
+    """
+
+    def _preprocess(self, *args, **kwargs):
+        # Extract parameters from kwargs with defaults from self attributes
+        videos = kwargs.get("videos", args[0] if len(args) > 0 else None)
+        do_convert_rgb = kwargs.get("do_convert_rgb", True)
+        do_resize = kwargs.get("do_resize", getattr(self, "do_resize", True))
+        size = kwargs.get("size", getattr(self, "size", SizeDict(shortest_edge=3136, longest_edge=1003520)))
+        resample = kwargs.get("resample", getattr(self, "resample", PILImageResampling.BICUBIC))
+        do_rescale = kwargs.get("do_rescale", getattr(self, "do_rescale", True))
+        rescale_factor = kwargs.get("rescale_factor", getattr(self, "rescale_factor", 1 / 255.0))
+        do_normalize = kwargs.get("do_normalize", getattr(self, "do_normalize", True))
+        image_mean = kwargs.get("image_mean", getattr(self, "image_mean", None))
+        image_std = kwargs.get("image_std", getattr(self, "image_std", None))
+        patch_size = kwargs.get("patch_size", getattr(self, "patch_size", 14))
+        temporal_patch_size = kwargs.get("temporal_patch_size", getattr(self, "temporal_patch_size", 2))
+        merge_size = kwargs.get("merge_size", getattr(self, "merge_size", 2))
+        return_tensors = kwargs.get("return_tensors", "pt")
+
+        # Remove already extracted parameters from kwargs
+        for key in ["videos", "do_convert_rgb", "do_resize", "size", "resample",
+                    "do_rescale", "rescale_factor", "do_normalize", "image_mean",
+                    "image_std", "patch_size", "temporal_patch_size", "merge_size",
+                    "return_tensors"]:
+            kwargs.pop(key, None)
+        grouped_videos, grouped_videos_index = group_videos_by_shape(videos)
+        resized_videos_grouped = {}
+
+        for shape, stacked_videos in grouped_videos.items():
+            B, T, C, H, W = stacked_videos.shape
+            num_frames, height, width = T, H, W
+            if do_resize:
+                resized_height, resized_width = smart_resize_video(
+                    num_frames=num_frames,
+                    height=height,
+                    width=width,
+                    temporal_factor=temporal_patch_size,
+                    factor=patch_size * merge_size,
+                    min_pixels=size.shortest_edge,
+                    max_pixels=size.longest_edge,
+                )
+                stacked_videos = stacked_videos.view(B * T, C, H, W)
+                stacked_videos = self.resize(
+                    stacked_videos,
+                    size=SizeDict(height=resized_height, width=resized_width),
+                    resample=resample,
+                )
+                stacked_videos = stacked_videos.view(
+                    B, T, C, resized_height, resized_width
+                )
+            resized_videos_grouped[shape] = stacked_videos
+        resized_videos = reorder_videos(resized_videos_grouped, grouped_videos_index)
+
+        # Group videos by size for further processing
+        # Needed in case do_resize is False, or resize returns videos with different sizes
+        grouped_videos, grouped_videos_index = group_videos_by_shape(resized_videos)
+        processed_videos_grouped = {}
+        processed_grids = {}
+        for shape, stacked_videos in grouped_videos.items():
+            resized_height, resized_width = get_image_size(
+                stacked_videos[0], channel_dim=ChannelDimension.FIRST
+            )
+
+            # Fused rescale and normalize
+            stacked_videos = self.rescale_and_normalize(
+                stacked_videos,
+                do_rescale,
+                rescale_factor,
+                do_normalize,
+                image_mean,
+                image_std,
+            )
+            patches = stacked_videos
+
+            # Check that videos have `num_frames` divisible by `temporal_patch_size`
+            T = patches.shape[1]
+            if pad := -T % temporal_patch_size:
+                repeats = patches[:, -1:].expand(-1, pad, -1, -1, -1)
+                patches = torch.cat((patches, repeats), dim=1)
+            batch_size, grid_t, channel = patches.shape[:3]
+            grid_t = grid_t // temporal_patch_size
+            grid_h, grid_w = resized_height // patch_size, resized_width // patch_size
+
+            flatten_patches = transform_patches_to_flatten(
+                patches,
+                batch_size,
+                grid_t,
+                temporal_patch_size,
+                channel,
+                grid_h,
+                grid_w,
+                patch_size,
+                merge_size,
+            )
+
+            processed_videos_grouped[shape] = flatten_patches
+            processed_grids[shape] = [[grid_t, grid_h, grid_w]] * batch_size
+
+        processed_videos = reorder_videos(
+            processed_videos_grouped, grouped_videos_index
+        )
+        processed_grids = reorder_videos(processed_grids, grouped_videos_index)
+        pixel_values_videos = torch.cat(processed_videos, dim=0)
+        video_grid_thw = torch.tensor(processed_grids)
+        data = {
+            "pixel_values_videos": pixel_values_videos,
+            "video_grid_thw": video_grid_thw,
+        }
+
+        return BatchFeature(data=data, tensor_type=return_tensors)
+
+    return _preprocess
+
+
+_npu_preprocess_patched = False
+
+
+def npu_apply_qwen_image_preprocess_patch():
+    global _npu_preprocess_patched
+    if _npu_preprocess_patched:
+        return
+
+    # Apply patches with try-except to handle modules that may not exist
+    try:
+        apply_module_patch(
+            "transformers.models.qwen2_vl.image_processing_qwen2_vl.Qwen2VLImageProcessor",
+            "_preprocess",
+            [npu_wrapper_preprocess],
+        )
+    except ModuleNotFoundError:
+        pass
+
+    try:
+        apply_module_patch(
+            "transformers.models.qwen2_vl.image_processing_qwen2_vl_fast.Qwen2VLImageProcessorFast",
+            "_preprocess",
+            [npu_wrapper_preprocess],
+        )
+    except ModuleNotFoundError:
+        pass
+
+    try:
+        apply_module_patch(
+            "transformers.models.qwen3_vl.video_processing_qwen3_vl.Qwen3VLVideoProcessor",
+            "_preprocess",
+            [npu_wrapper_video_preprocess],
+        )
+    except ModuleNotFoundError:
+        pass
+
+    try:
+        apply_module_patch(
+            "transformers.models.qwen3_vl.video_processing_qwen3_vl_fast.Qwen3VLVideoProcessorFast",
+            "_preprocess",
+            [npu_wrapper_video_preprocess],
+        )
+    except ModuleNotFoundError:
+        pass
+
+    _npu_preprocess_patched = True

--- a/sglang_fl/dispatch/backends/vendor/ascend/patches/_qwen_vl_processor_impl.py
+++ b/sglang_fl/dispatch/backends/vendor/ascend/patches/_qwen_vl_processor_impl.py
@@ -316,42 +316,15 @@ def npu_apply_qwen_image_preprocess_patch():
     global _npu_preprocess_patched
     if _npu_preprocess_patched:
         return
+    apply_module_patch(
+        "transformers.models.qwen2_vl.image_processing_qwen2_vl.Qwen2VLImageProcessor",
+        "_preprocess",
+        [npu_wrapper_preprocess],
+    )
 
-    # Apply patches with try-except to handle modules that may not exist
-    try:
-        apply_module_patch(
-            "transformers.models.qwen2_vl.image_processing_qwen2_vl.Qwen2VLImageProcessor",
-            "_preprocess",
-            [npu_wrapper_preprocess],
-        )
-    except ModuleNotFoundError:
-        pass
-
-    try:
-        apply_module_patch(
-            "transformers.models.qwen2_vl.image_processing_qwen2_vl_fast.Qwen2VLImageProcessorFast",
-            "_preprocess",
-            [npu_wrapper_preprocess],
-        )
-    except ModuleNotFoundError:
-        pass
-
-    try:
-        apply_module_patch(
-            "transformers.models.qwen3_vl.video_processing_qwen3_vl.Qwen3VLVideoProcessor",
-            "_preprocess",
-            [npu_wrapper_video_preprocess],
-        )
-    except ModuleNotFoundError:
-        pass
-
-    try:
-        apply_module_patch(
-            "transformers.models.qwen3_vl.video_processing_qwen3_vl_fast.Qwen3VLVideoProcessorFast",
-            "_preprocess",
-            [npu_wrapper_video_preprocess],
-        )
-    except ModuleNotFoundError:
-        pass
-
+    apply_module_patch(
+        "transformers.models.qwen3_vl.video_processing_qwen3_vl.Qwen3VLVideoProcessor",
+        "_preprocess",
+        [npu_wrapper_video_preprocess],
+    )
     _npu_preprocess_patched = True

--- a/sglang_fl/dispatch/backends/vendor/ascend/patches/attention_registry.py
+++ b/sglang_fl/dispatch/backends/vendor/ascend/patches/attention_registry.py
@@ -1,0 +1,125 @@
+"""Ascend/NPU patch for SGLang attention backend wrapper.
+
+Ports the source edit from
+``sglang/srt/layers/attention/attention_registry.py``: on NPU the CUDA-only
+``KDAAttnBackend`` / ``LightningAttentionBackend`` modules fail to import, so
+their imports must be deferred into the ``not is_npu()`` branch instead of
+running at the top of the ``mambaish_config`` block.
+
+``attn_backend_wrapper`` is a module-level function that ``model_runner``
+imports by name (``from ... import attn_backend_wrapper``). We therefore rebind
+it both on ``attention_registry`` and, if already imported, on ``model_runner``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def patch_attn_backend_wrapper() -> None:
+    try:
+        from sglang.srt.layers.attention import attention_registry as ar
+    except Exception as e:
+        logger.warning("Ascend attn_backend_wrapper patch skipped: %s", e)
+        return
+
+    def attn_backend_wrapper(runner, full_attn_backend):
+        """
+        Wrapper for special models like hybrid GDN, so we don't
+        need to change the code of the original attention backend.
+        """
+        assert not (
+            runner.hybrid_gdn_config is not None and runner.use_mla_backend
+        ), "hybrid_gdn can only be used with non-MLA models."
+
+        if cfg := runner.mambaish_config:
+            from sglang.srt.configs.linear_attn_model_registry import (
+                get_linear_attn_config,
+                import_backend_class,
+            )
+            from sglang.srt.layers.attention.fla.utils import check_environments
+            from sglang.srt.layers.attention.linear.utils import (
+                initialize_linear_attn_config,
+            )
+            from sglang.srt.utils import is_blackwell, is_npu
+
+            if not is_npu():
+                from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
+                    HybridLinearAttnBackend,
+                    Mamba2AttnBackend,
+                )
+                from sglang.srt.layers.attention.linear.gdn_backend import (
+                    GDNAttnBackend,
+                )
+                from sglang.srt.layers.attention.linear.kda_backend import (
+                    KDAAttnBackend,
+                )
+                from sglang.srt.layers.attention.linear.lightning_backend import (
+                    LightningAttentionBackend,
+                )
+            else:
+                from sglang.srt.hardware_backend.npu.attention.ascend_gdn_backend import (
+                    AscendGDNAttnBackend as GDNAttnBackend,
+                )
+                from sglang.srt.hardware_backend.npu.attention.ascend_hybrid_linear_attn_backend import (
+                    AscendHybridLinearAttnBackend as HybridLinearAttnBackend,
+                )
+                from sglang.srt.hardware_backend.npu.attention.ascend_hybrid_linear_attn_backend import (
+                    AscendMamba2AttnBackend as Mamba2AttnBackend,
+                )
+
+            check_environments()
+            initialize_linear_attn_config(runner.server_args)
+            if runner.hybrid_gdn_config is not None:
+                if is_blackwell():
+                    assert (
+                        runner.server_args.attention_backend == "triton"
+                        or runner.server_args.attention_backend == "trtllm_mha"
+                        or runner.server_args.attention_backend == "fa4"
+                        or runner.server_args.attention_backend == "flashinfer"
+                    ), "triton, trtllm_mha, fa4, or flashinfer backend are the only supported backends on Blackwell GPUs for hybrid GDN models, use --attention-backend to specify the backend."
+                if is_npu():
+                    assert (
+                        runner.server_args.attention_backend == "ascend"
+                    ), "ascend backend is the only supported backend on NPU for hybrid GDN models, use --attention-backend ascend to specify the backend."
+                logger.info(
+                    "Using hybrid linear attention backend for hybrid GDN models."
+                )
+                linear_attn_backend = GDNAttnBackend(runner)
+            elif runner.mamba2_config is not None:
+                linear_attn_backend = Mamba2AttnBackend(runner)
+            elif runner.kimi_linear_config is not None:
+                linear_attn_backend = KDAAttnBackend(runner)
+            elif runner.hybrid_lightning_config is not None:
+                linear_attn_backend = LightningAttentionBackend(runner)
+            else:
+                spec_result = get_linear_attn_config(runner.model_config.hf_config)
+                if spec_result is not None:
+                    spec, _ = spec_result
+                    BackendClass = import_backend_class(spec.backend_class_name)
+                    linear_attn_backend = BackendClass(runner)
+                else:
+                    raise ValueError(
+                        "Expected hybrid GDN or NemotronH models, but got unknown model. "
+                        "If this is a custom hybrid model, use register_linear_attn_model() "
+                        "from sglang.srt.configs.linear_attn_model_registry."
+                    )
+            full_attn_layers = cfg.full_attention_layer_ids
+            return HybridLinearAttnBackend(
+                full_attn_backend, linear_attn_backend, full_attn_layers
+            )
+
+        return full_attn_backend
+
+    ar.attn_backend_wrapper = attn_backend_wrapper
+
+    # model_runner imports the function by name at its module top level; if it
+    # is already imported, rebind its reference too so the patch takes effect.
+    mr = sys.modules.get("sglang.srt.model_executor.model_runner")
+    if mr is not None and hasattr(mr, "attn_backend_wrapper"):
+        mr.attn_backend_wrapper = attn_backend_wrapper
+
+    logger.info("Ascend attn_backend_wrapper patch applied")

--- a/sglang_fl/dispatch/backends/vendor/ascend/patches/qwen_vl_processor.py
+++ b/sglang_fl/dispatch/backends/vendor/ascend/patches/qwen_vl_processor.py
@@ -1,0 +1,59 @@
+"""Ascend/NPU patch for SGLang's Qwen-VL image/video preprocess.
+
+The original module
+``sglang.srt.hardware_backend.npu.modules.qwen_vl_processor`` fails to import on
+the target transformers version because it imports
+``group_images_by_shape``/``reorder_images`` from
+``transformers.image_processing_utils_fast`` (moved to
+``transformers.image_transforms``). Since the module can't be imported, we can't
+monkey-patch its attributes the usual way.
+
+Instead we install a lightweight shim module into ``sys.modules`` under the
+original path. ``base_processor`` does a lazy
+``from ...qwen_vl_processor import npu_apply_qwen_image_preprocess_patch`` at
+request time, so it will pick up the shim, which lazily delegates to the fixed
+implementation in ``_qwen_vl_processor_impl`` (deferring the transformers import
+to first use, matching the original timing).
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+import types
+
+logger = logging.getLogger(__name__)
+
+_SGLANG_QWEN_MODULE = "sglang.srt.hardware_backend.npu.modules.qwen_vl_processor"
+_IMPL_MODULE = (
+    "sglang_fl.dispatch.backends.vendor.ascend.patches._qwen_vl_processor_impl"
+)
+
+
+def patch_qwen_vl_processor() -> None:
+    if _SGLANG_QWEN_MODULE in sys.modules:
+        # The real (broken) module is already imported — don't clobber it.
+        logger.warning(
+            "Ascend qwen_vl_processor patch skipped: %s already imported",
+            _SGLANG_QWEN_MODULE,
+        )
+        return
+
+    shim = types.ModuleType(_SGLANG_QWEN_MODULE)
+    shim.__doc__ = "sglang_fl Ascend shim for qwen_vl_processor (lazy)."
+
+    def npu_apply_qwen_image_preprocess_patch():
+        impl = importlib.import_module(_IMPL_MODULE)
+        return impl.npu_apply_qwen_image_preprocess_patch()
+
+    def __getattr__(name):
+        # Lazily expose any other public symbol from the fixed implementation.
+        impl = importlib.import_module(_IMPL_MODULE)
+        return getattr(impl, name)
+
+    shim.npu_apply_qwen_image_preprocess_patch = npu_apply_qwen_image_preprocess_patch
+    shim.__getattr__ = __getattr__
+
+    sys.modules[_SGLANG_QWEN_MODULE] = shim
+    logger.info("Ascend qwen_vl_processor shim installed into sys.modules")

--- a/sglang_fl/dispatch/backends/vendor/ascend/patches/scheduler_pp.py
+++ b/sglang_fl/dispatch/backends/vendor/ascend/patches/scheduler_pp.py
@@ -1,0 +1,111 @@
+"""Ascend/NPU patches for SGLang pipeline-parallel scheduler mixin.
+
+Ports two source edits from
+``sglang/srt/managers/scheduler_pp_mixin.py`` into the plugin patch layer:
+
+  1. ``_pp_send_recv_and_preprocess_output_tensors``: HCCL isend is
+     effectively blocking (unlike CUDA), so if every PP rank sends first the
+     ring deadlocks. Order send/recv by ``pp_rank`` parity (even: send->recv,
+     odd: recv->send) and synchronize the device before the exchange.
+  2. ``_pp_launch_batch``: synchronize ``forward_stream`` before returning so
+     the forward computation is complete before the PP send/recv runs.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import wraps
+
+logger = logging.getLogger(__name__)
+
+
+def patch_pp_send_recv_order() -> None:
+    try:
+        from sglang.srt.managers.scheduler_pp_mixin import SchedulerPPMixin
+        from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
+    except Exception as e:
+        logger.warning("Ascend PP send/recv order patch skipped: %s", e)
+        return
+
+    import torch
+
+    def _pp_send_recv_and_preprocess_output_tensors(
+        self,
+        next_first_rank_mb_id,
+        next_mb_id,
+        mbs,
+        mb_metadata,
+        last_rank_comm_queue,
+        pp_outputs,
+    ):
+        next_pp_outputs = None
+        d2h_event = None
+        batch_result = None
+        send_output_work = []
+
+        # On CUDA, isend is async: it enqueues to the stream and returns,
+        # so every rank can send first safely. On HCCL isend is effectively
+        # blocking and does not return until the peer posts a matching recv;
+        # if every PP rank sends first, all ranks block waiting for a receiver
+        # and the ring deadlocks. Order send/recv by pp_rank parity (even:
+        # send->recv, odd: recv->send) so each adjacent pair has one sender and
+        # one receiver posted at the same time.
+        send_first = (self.pp_rank % 2) == 0
+        if self.device == "npu":
+            self.device_module.synchronize()
+
+        def _do_send():
+            return self._pp_send_output_to_next_stage(
+                next_first_rank_mb_id,
+                mbs,
+                last_rank_comm_queue,
+                pp_outputs,
+            )
+
+        def _do_recv():
+            nonlocal next_pp_outputs, batch_result, d2h_event
+            if mbs[next_mb_id] is None or mbs[next_mb_id].forward_mode.is_prebuilt():
+                return
+            with torch.profiler.record_function("recv_res_dict_from_prev_stage"):
+                next_pp_outputs = PPProxyTensors(self._pp_recv_dict_from_prev_stage())
+            with self.copy_stream_ctx:
+                self.copy_stream.wait_stream(self.schedule_stream)
+                batch_result = self._pp_prep_batch_result(
+                    mbs[next_mb_id], mb_metadata[next_mb_id], next_pp_outputs
+                )
+                d2h_event = self.device_module.Event()
+                d2h_event.record(self.device_module.current_stream())
+
+        if send_first:
+            send_output_work = _do_send()
+            _do_recv()
+        else:
+            _do_recv()
+            send_output_work = _do_send()
+
+        return next_pp_outputs, batch_result, d2h_event, send_output_work
+
+    SchedulerPPMixin._pp_send_recv_and_preprocess_output_tensors = (
+        _pp_send_recv_and_preprocess_output_tensors
+    )
+    logger.info("Ascend PP send/recv ordering patch applied")
+
+
+def patch_pp_launch_batch_sync() -> None:
+    try:
+        from sglang.srt.managers.scheduler_pp_mixin import SchedulerPPMixin
+    except Exception as e:
+        logger.warning("Ascend PP launch sync patch skipped: %s", e)
+        return
+
+    orig_fn = SchedulerPPMixin._pp_launch_batch
+
+    @wraps(orig_fn)
+    def _pp_launch_batch_with_forward_stream_sync(self, *args, **kwargs):
+        result, event = orig_fn(self, *args, **kwargs)
+        # NPU fix: ensure forward computation completes before PP send/recv
+        self.forward_stream.synchronize()
+        return result, event
+
+    SchedulerPPMixin._pp_launch_batch = _pp_launch_batch_with_forward_stream_sync
+    logger.info("Ascend PP launch forward_stream sync patch applied")


### PR DESCRIPTION
## Summary
Move three Huawei NPU adaptations from direct sglang source edits into the plugin's vendor patch mechanism (vendor/ascend/patch.py, auto-loaded when vendor is ascend). No sglang source changes needed.

## Changes
New files under sglang_fl/dispatch/backends/vendor/ascend/:

- patch.py — entrypoint, applies all three patches at import.
- patches/scheduler_pp.py — PP send/recv ordered by pp_rank parity + NPU stream syncs (HCCL deadlock fix).
- patches/attention_registry.py — defer CUDA-only KDA/Lightning imports into the not is_npu() branch.
- patches/qwen_vl_processor.py + _qwen_vl_processor_impl.py — inject a fixed, transformers-version-tolerant Qwen-VL preprocess via sys.modules.

## Test

- Tested on Ascend 910B and 910C.
- Ran all examples under examples/ on both platforms — all passing.