### PR TITLE
chore(examples): remove platform-specific logic from multinode scripts

### DIFF
--- a/examples/qwen3_6_27b_multinode.py
+++ b/examples/qwen3_6_27b_multinode.py
@@ -6,9 +6,6 @@ Validates that sglang-plugin-FL correctly handles multi-node tensor parallelism
 for the dense Qwen3.6-27B model by launching a distributed SGLang server across
 2 nodes and running text, concurrent, multimodal (VL), and high-concurrency tests.
 
-Supports CUDA, MUSA, and Ascend NPU; platform-specific server flags and env
-vars are applied automatically at runtime.
-
 ============================================================================
 Usage:
   This script runs as EITHER master (node_rank=0) or worker (node_rank=1),
@@ -44,15 +41,13 @@ Full tested command (2 nodes × 2 GPUs each, TP=2 PP=2):
 
   Total GPUs: TP × PP = 2 × 2 = 4 (2 per node)
 
-  On MUSA, swap CUDA_VISIBLE_DEVICES → MUSA_VISIBLE_DEVICES; on Ascend NPU,
-  use ASCEND_RT_VISIBLE_DEVICES. SGLANG_FL_DIST_BACKEND=flagcx is recommended
-  on both non-CUDA platforms.
+  On non-CUDA platforms, use the corresponding VISIBLE_DEVICES variable (e.g.
+  MUSA_VISIBLE_DEVICES on Mthreads, ASCEND_RT_VISIBLE_DEVICES on Ascend NPU).
+  SGLANG_FL_DIST_BACKEND=flagcx is recommended on both non-CUDA platforms.
 
 Environment variables:
   MODEL_PATH       Model path (default: /models/Qwen3.6-27B)
-  CUDA_VISIBLE_DEVICES  GPU selection on CUDA (e.g. 0,1)
-  MUSA_VISIBLE_DEVICES  Device selection on MUSA
-  ASCEND_RT_VISIBLE_DEVICES  Device selection on Ascend NPU
+  CUDA_VISIBLE_DEVICES  GPU selection (e.g. 0,1)
   GLOO_SOCKET_IFNAME    Network interface for Gloo (default: eth0)
   NCCL_SOCKET_IFNAME    Network interface for NCCL (default: eth0)
   SGLANG_FL_DIST_BACKEND  Communication backend (flagcx / nccl)
@@ -79,41 +74,7 @@ import sys
 import time
 import urllib.request
 from pathlib import Path
-import torch
 
-# ─── Platform detection ──────────────────────────────────────────────────────
-
-_is_txda = hasattr(torch, "txda") and torch.txda.is_available()
-_is_musa = hasattr(torch, "musa") and torch.musa.is_available()
-_is_npu = hasattr(torch, "npu") and torch.npu.is_available()
-
-# Must be set before launching sglang. Subprocesses inherit os.environ.
-if _is_txda:
-    os.environ.setdefault("SGLANG_FL_TIMER_ENABLE", "1")
-    os.environ.setdefault("SGLANG_REQ_WAITING_TIMEOUT", "-1")
-    os.environ.setdefault("SGLANG_REQ_RUNNING_TIMEOUT", "-1")
-if _is_npu:
-    os.environ.setdefault("SGLANG_ENABLE_OVERLAP_PLAN_STREAM", "0")
-    os.environ.setdefault("SGLANG_ENABLE_SPEC_V2", "1")
-    os.environ.setdefault("HCCL_BUFFSIZE", "2400")
-    os.environ.setdefault("SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK", "128")
-elif _is_musa:
-    os.environ.setdefault("MCCL_IB_DISABLE", "1")
-    
-# Extra launch_server flags per platform.
-# - MUSA: page_size=1 works around a sglang platform bug.
-# - Ascend NPU: requires ascend attention backend, bfloat16, radix cache off.
-if _is_musa:
-    _PLATFORM_SERVER_ARGS: list = ["--page-size", "1"]
-elif _is_npu:
-    _PLATFORM_SERVER_ARGS = [
-        "--attention-backend", "ascend",
-        "--device", "npu",
-        "--dtype", "bfloat16",
-        "--disable-radix-cache",
-    ]
-else:
-    _PLATFORM_SERVER_ARGS = []
 
 # ─── Configuration ───────────────────────────────────────────────────────────
 
@@ -536,23 +497,7 @@ def run_master(args):
         "--disable-cuda-graph",
         "--disable-piecewise-cuda-graph",
         "--trust-remote-code",
-        *_PLATFORM_SERVER_ARGS,
     ]
-
-    if _is_txda:
-        insert_pos = cmd.index("--mem-fraction-static")
-        cmd[insert_pos + 1] = "0.6"
-        for flag in reversed([
-            "--device", "txda",
-            "--dtype", "bfloat16",
-            "--disable-radix-cache",
-            "--watchdog-timeout", "3600",
-            "--mm-attention-backend", "triton_attn",
-            "--disable-fast-image-processor",
-            "--context-length", "8192",
-            "--chunked-prefill-size", "256",
-        ]):
-            cmd.insert(insert_pos, flag)
 
     print("Launching server...")
     server_proc = subprocess.Popen(cmd)
@@ -643,23 +588,7 @@ def run_worker(args):
         "--disable-cuda-graph",
         "--disable-piecewise-cuda-graph",
         "--trust-remote-code",
-        *_PLATFORM_SERVER_ARGS,
     ]
-
-    if _is_txda:
-        insert_pos = cmd.index("--mem-fraction-static")
-        cmd[insert_pos + 1] = "0.6"
-        for flag in reversed([
-            "--device", "txda",
-            "--dtype", "bfloat16",
-            "--disable-radix-cache",
-            "--watchdog-timeout", "3600",
-            "--mm-attention-backend", "triton_attn",
-            "--disable-fast-image-processor",
-            "--context-length", "8192",
-            "--chunked-prefill-size", "256",
-        ]):
-            cmd.insert(insert_pos, flag)
 
     print("Starting worker node... (will block until master shuts down)\n")
     try:

--- a/examples/qwen3_6_35b_a3b_multinode.py
+++ b/examples/qwen3_6_35b_a3b_multinode.py
@@ -6,9 +6,6 @@ Validates that sglang-plugin-FL correctly handles multi-node tensor parallelism
 by launching a distributed SGLang server across 2 nodes and running text,
 concurrent, multimodal (VL), and high-concurrency inference tests.
 
-Supports CUDA, MUSA, and Ascend NPU; platform-specific server flags and env
-vars are applied automatically at runtime.
-
 ============================================================================
 Usage:
   This script runs as EITHER master (node_rank=0) or worker (node_rank=1),
@@ -44,15 +41,13 @@ Full tested command (2 nodes × 2 GPUs each, TP=2 PP=2):
 
   Total GPUs: TP × PP = 2 × 2 = 4 (2 per node)
 
-  On MUSA, swap CUDA_VISIBLE_DEVICES → MUSA_VISIBLE_DEVICES; on Ascend NPU,
-  use ASCEND_RT_VISIBLE_DEVICES. SGLANG_FL_DIST_BACKEND=flagcx is recommended
-  on both non-CUDA platforms.
+  On non-CUDA platforms, use the corresponding VISIBLE_DEVICES variable (e.g.
+  MUSA_VISIBLE_DEVICES on Mthreads, ASCEND_RT_VISIBLE_DEVICES on Ascend NPU).
+  SGLANG_FL_DIST_BACKEND=flagcx is recommended on both non-CUDA platforms.
 
 Environment variables:
   MODEL_PATH       Model path (default: /models/Qwen3.6-35B-A3B)
-  CUDA_VISIBLE_DEVICES  GPU selection on CUDA (e.g. 0,1)
-  MUSA_VISIBLE_DEVICES  Device selection on MUSA
-  ASCEND_RT_VISIBLE_DEVICES  Device selection on Ascend NPU
+  CUDA_VISIBLE_DEVICES  GPU selection (e.g. 0,1)
   GLOO_SOCKET_IFNAME    Network interface for Gloo (default: eth0)
   NCCL_SOCKET_IFNAME    Network interface for NCCL (default: eth0)
   SGLANG_FL_DIST_BACKEND  Communication backend (flagcx / nccl)
@@ -76,40 +71,7 @@ import sys
 import time
 import urllib.request
 from pathlib import Path
-import torch
 
-# ─── Platform detection ──────────────────────────────────────────────────────
-
-_is_txda = hasattr(torch, "txda") and torch.txda.is_available()
-_is_musa = hasattr(torch, "musa") and torch.musa.is_available()
-_is_npu = hasattr(torch, "npu") and torch.npu.is_available()
-
-if _is_txda:
-    os.environ.setdefault("SGLANG_FL_TIMER_ENABLE", "1")
-    os.environ.setdefault("SGLANG_REQ_WAITING_TIMEOUT", "-1")
-    os.environ.setdefault("SGLANG_REQ_RUNNING_TIMEOUT", "-1")
-if _is_npu:
-    os.environ.setdefault("SGLANG_ENABLE_OVERLAP_PLAN_STREAM", "0")
-    os.environ.setdefault("SGLANG_ENABLE_SPEC_V2", "1")
-    os.environ.setdefault("HCCL_BUFFSIZE", "2400")
-    os.environ.setdefault("SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK", "128")
-elif _is_musa:
-    os.environ.setdefault("MCCL_IB_DISABLE", "1")
-    
-# Extra launch_server flags per platform.
-# - MUSA: page_size=1 works around a sglang platform bug.
-# - Ascend NPU: requires ascend attention backend, bfloat16, radix cache off.
-if _is_musa:
-    _PLATFORM_SERVER_ARGS: list = ["--page-size", "1"]
-elif _is_npu:
-    _PLATFORM_SERVER_ARGS = [
-        "--attention-backend", "ascend",
-        "--device", "npu",
-        "--dtype", "bfloat16",
-        "--disable-radix-cache",
-    ]
-else:
-    _PLATFORM_SERVER_ARGS = []
 
 # ─── Configuration ───────────────────────────────────────────────────────────
 
@@ -523,22 +485,7 @@ def run_master(args):
         "--disable-cuda-graph",
         "--disable-piecewise-cuda-graph",
         "--trust-remote-code",
-        *_PLATFORM_SERVER_ARGS,
     ]
-    if _is_txda:
-        insert_pos = cmd.index("--mem-fraction-static")
-        cmd[insert_pos + 1] = "0.6"
-        for flag in reversed([
-            "--device", "txda",
-            "--dtype", "bfloat16",
-            "--disable-radix-cache",
-            "--watchdog-timeout", "3600",
-            "--mm-attention-backend", "triton_attn",
-            "--disable-fast-image-processor",
-            "--context-length", "8192",
-            "--chunked-prefill-size", "256",
-        ]):
-            cmd.insert(insert_pos, flag)
 
     print("Launching server...")
     server_proc = subprocess.Popen(cmd)
@@ -629,22 +576,7 @@ def run_worker(args):
         "--disable-cuda-graph",
         "--disable-piecewise-cuda-graph",
         "--trust-remote-code",
-        *_PLATFORM_SERVER_ARGS,
     ]
-    if _is_txda:
-        insert_pos = cmd.index("--mem-fraction-static")
-        cmd[insert_pos + 1] = "0.6"
-        for flag in reversed([
-            "--device", "txda",
-            "--dtype", "bfloat16",
-            "--disable-radix-cache",
-            "--watchdog-timeout", "3600",
-            "--mm-attention-backend", "triton_attn",
-            "--disable-fast-image-processor",
-            "--context-length", "8192",
-            "--chunked-prefill-size", "256",
-        ]):
-            cmd.insert(insert_pos, flag)
 
     print("Starting worker node... (will block until master shuts down)\n")
     try:


### PR DESCRIPTION
## Summary

Remove platform-specific logic from multi-node example scripts. Examples should be platform-agnostic — the plugin handles platform detection and users set device env vars externally based on their hardware.

### Changes
- Remove `import torch` and the platform detection blocks (`_is_musa`/`_is_npu`/`_is_txda`) from both files
- Remove `_PLATFORM_SERVER_ARGS` injection into launch_server command
- Update docstrings to remove MUSA/Ascend/TXDA-specific documentation
- Consolidate to `CUDA_VISIBLE_DEVICES` as the documented env var

### Motivation
Platform-specific env vars and server flags belong in the plugin or the deployment environment, not in example scripts. This keeps examples clean and maintainable as new platforms are added.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)