### PR TITLE
[NPU] Maintaining the FlagGems blacklist using YAML configuration

### DIFF
--- a/sglang_fl/dispatch/config/ascend.yaml
+++ b/sglang_fl/dispatch/config/ascend.yaml
@@ -14,3 +14,20 @@
 
 # SGLang-FL Dispatch Configuration for Ascend NPU
 prefer: flagos
+
+# FlagGems tag:    v5.3.0
+# FlagGems commit: 98fae44cdf2898f39c7f24f080d7c88b83d7c593
+flagos_blacklist:
+  - index_copy_
+  - gather
+  - count_nonzero
+  - index_put_
+  - _index_put_impl_
+  - cumsum
+  - fill_scalar_
+  - argmax
+  - index
+  - add_
+  - conv1d
+  - floor_divide
+  - true_divide_

--- a/sglang_fl/dispatch/config/ascend.yaml
+++ b/sglang_fl/dispatch/config/ascend.yaml
@@ -18,6 +18,7 @@ prefer: flagos
 # FlagGems tag:    v5.3.0
 # FlagGems commit: 98fae44cdf2898f39c7f24f080d7c88b83d7c593
 flagos_blacklist:
+  - full_like
   - index_copy_
   - gather
   - count_nonzero


### PR DESCRIPTION
## Summary
Add a flagos_blacklist to the Ascend NPU dispatch config [sglang_fl/dispatch/config/ascend.yaml], listing 13 operators that should NOT use the FlagOS (FlagGems) implementation on FlagGems v5.3.0 and instead fall back to the native NPU op. 

## Changes
Added the flagos_blacklist field (13 entries), pinned to a specific FlagGems build via comments:
tag v5.3.0 / commit 98fae44cdf2898f39c7f24f080d7c88b83d7c593
Blacklisted ops: index_copy_, gather, count_nonzero, index_put_, _index_put_impl_, cumsum, fill_scalar_, argmax, index, add_, conv1d, floor_divide, true_divide_
```Note:Pinning the FlagGems tag+commit in comments is important — the blacklist is a version-specific workaround list, so the ops may be fixed or behave differently on a newer FlagGems and must be re-verified when the version changes.```

## Tests
- Tested on Ascend 910B and 910C.
- Ran all examples under examples/ on both platforms — all passing.