### PR TITLE
[MUSA] Maintaining the FlagGems blacklist using YAML configuration

### DIFF
--- a/sglang_fl/dispatch/config/musa.yaml
+++ b/sglang_fl/dispatch/config/musa.yaml
@@ -14,3 +14,14 @@
 
 # SGLang-FL Dispatch Configuration for MUSA (Moore Threads) platform
 prefer: flagos
+
+# FlagGems tag:    v5.3.0
+# FlagGems commit: 98fae44cdf2898f39c7f24f080d7c88b83d7c593
+flagos_blacklist:
+  - count_nonzero
+  - cumsum
+  - mm
+  - unique
+  - _unique2
+  - unique_dim
+  - unique_consecutive


### PR DESCRIPTION
## Summary
Add a flagos_blacklist to the MUSA dispatch config [sglang_fl/dispatch/config/musa.yaml], listing 7 operators that should NOT use the FlagOS (FlagGems) implementation on FlagGems v5.3.0 and instead fall back to the native MUSA op.

## Changes
Added the flagos_blacklist field (7 entries), pinned to a specific FlagGems build via comments:
tag v5.3.0 / commit 98fae44cdf2898f39c7f24f080d7c88b83d7c593
Blacklisted ops: count_nonzero, cumsum, mm, unique, _unique2, unique_dim, unique_consecutive
```Note: Pinning the FlagGems tag+commit in comments is important — the blacklist is a version-specific workaround list, so these ops may be fixed or behave differently on a newer FlagGems and must be re-verified when the version changes.```

## Tests
- Tested on MTT S5000.
- Ran all examples — all passing.