### PR TITLE
feat(disagg): add FlagCX KV transfer backend for PD disaggregation

### DIFF
--- a/sglang_fl/__init__.py
+++ b/sglang_fl/__init__.py
@@ -806,7 +806,7 @@ def load_plugin():
 
     # 5. Vendor-specific patches — final overlay on top of all sglang_fl layers
     _apply_vendor_patches()
-    
+
     # 6. FlagCX PD-disaggregation transfer backend. the FlagCX connector itself is
     #    imported lazily, when the user actually selects this backend.
     disagg_flagcx = _parse_bool(

--- a/sglang_fl/__init__.py
+++ b/sglang_fl/__init__.py
@@ -30,6 +30,7 @@ This plugin registers:
   Layer 2: SGLang fused kernels via MultiPlatformOp.register_oot_forward +
            HookRegistry AROUND hook on dispatch_forward
   Layer 3: FlagCX communicator (via Platform Plugin get_communicator_class)
+  Layer 4: FlagCX PD-disaggregation KV transfer backend (opt-out via env)
 
 Environment variables:
   USE_FLAGGEMS=1|0                    Master switch for Layer 1 (default: 1)
@@ -52,6 +53,7 @@ Environment variables:
   SGLANG_FL_CONFIG=<path>             YAML config file (overrides platform defaults)
   SGLANG_FL_DIST_BACKEND=nccl|hccl|flagcx   Override distributed backend
   FLAGCX_PATH=<path>                         If set, default to flagcx backend
+  SGLANG_FL_DISAGG_FLAGCX=1|0         Register FlagCX PD-disagg backend (default: 1)
 """
 
 import logging
@@ -804,8 +806,22 @@ def load_plugin():
 
     # 5. Vendor-specific patches — final overlay on top of all sglang_fl layers
     _apply_vendor_patches()
+    
+    # 6. FlagCX PD-disaggregation transfer backend. the FlagCX connector itself is
+    #    imported lazily, when the user actually selects this backend.
+    disagg_flagcx = _parse_bool(
+        os.environ.get("SGLANG_FL_DISAGG_FLAGCX", "1"), default=True
+    )
+    if disagg_flagcx:
+        try:
+            from sglang_fl.disaggregation.patch import apply_disaggregation_patch
 
-    # 6. Summary banner — confirm plugin is active (rank 0 only)
+            apply_disaggregation_patch()
+        except Exception as e:
+            logger.warning("FlagCX PD disaggregation registration failed: %s", e)
+            disagg_flagcx = False
+
+    # 7. Summary banner — confirm plugin is active (rank 0 only)
     if _is_rank0():
         use_fg = _parse_bool(os.environ.get("USE_FLAGGEMS", "1"), default=True)
         aten_status = "OFF" if not use_fg else "ON"
@@ -823,6 +839,11 @@ def load_plugin():
             "|" + f"  Layer 1 (ATen -> FlagGems):  {aten_status}".ljust(58) + "|\n"
             "|" + f"  Layer 2 (Fused Ops):         {oot_status}".ljust(58) + "|\n"
             "|" + f"  Layer 3 (Communication):     {dist_backend}".ljust(58) + "|\n"
+            "|"
+            + f"  Layer 4 (PD Disagg):         {'flagcx' if disagg_flagcx else 'OFF'}".ljust(
+                58
+            )
+            + "|\n"
             "+" + "=" * 58 + "+"
         )
         logger.info(banner)

--- a/sglang_fl/disaggregation/README.md
+++ b/sglang_fl/disaggregation/README.md
@@ -58,6 +58,7 @@ export FLAGCX_PATH=/path/to/FlagCX
 export FLAGCX_P2P_SLICE_SIZE=65536    # slice size per one-sided RDMA write (recommended)
 export FLAGCX_P2P_WORKERS_PER_POOL=2  # transfer workers per pool (recommended)
 export FLAGCX_P2P_QPS_PER_CONN=2      # queue pairs per connection (recommended)
+export SGLANG_SEND_AUX_TCP=0          # 1 → send aux data (output ids/logprobs) over TCP instead of RDMA
 ```
 
 | Variable | Description |
@@ -69,6 +70,7 @@ export FLAGCX_P2P_QPS_PER_CONN=2      # queue pairs per connection (recommended)
 | `FLAGCX_IB_HCA` | Usually **no need to set manually**: `conn.py:257` applies `setdefault` using the value of `--disaggregation-ib-device` |
 | `SGLANG_FL_DISAGG_FLAGCX` | Layer 4 switch, default `1`; setting `0` makes `flagcx` an invalid backend value |
 | `SGLANG_FL_OOT_ENABLED` / `USE_FLAGGEMS` | Layer 2 / Layer 1 switches; enable them one at a time during performance tuning |
+| `SGLANG_SEND_AUX_TCP` | Optional, default:0; Send aux data (first-token metadata) over TCP instead of RDMA |
 
 Throughout this guide, replace the placeholders with your own values:
 

--- a/sglang_fl/disaggregation/README.md
+++ b/sglang_fl/disaggregation/README.md
@@ -1,0 +1,292 @@
+# FlagCX PD Disaggregation (xPyD) Guide
+
+FlagCX's P2P engine unifies memory registration and transfer across multiple chip backends, so the
+same connector works on every supported vendor. Before using the FlagCX connector you must clone and
+build FlagCX yourself.
+
+Source layout:
+
+| File | Role |
+|---|---|
+| `patch.py` | Registers `flagcx` as a valid `--disaggregation-transfer-backend` value, injects the `TransferBackend` enum member, and wraps `get_kv_class` |
+| `conn.py` | `FlagcxKVManager` / `FlagcxKVSender` / `FlagcxKVReceiver` / `FlagcxKVBootstrapServer` |
+| `transfer_engine.py` | `FlagCXTransferEngine` — memory registration and batched one-sided writes via `flagcxP2pBatchWriteSync` |
+
+The plugin is auto-loaded through its setuptools entry point, and Layer 4 is enabled by default
+(`SGLANG_FL_DISAGG_FLAGCX=1`, see `sglang_fl/__init__.py:812`). The FlagCX shared library is loaded
+**lazily**: `conn.py` is only imported once you actually pass
+`--disaggregation-transfer-backend flagcx`.
+
+---
+
+## Supported Models
+
+| Model | Quantization | NVIDIA | PPU |
+|---|---|---|---|
+| Qwen3.6-35B-A3B | BF16 | ✅ | ✅ |
+| GLM-5.2-W4A8 | W4A8 | ✅ | ✅ |
+
+---
+
+## Prerequisites
+
+1. Follow [sglang-plugin-FL/README.md](https://github.com/flagos-ai/sglang-plugin-FL/blob/main/README.md)
+   to install the required packages. Note: `sglang[all]>=0.5.11` is required.
+
+2. Make sure FlagCX builds cleanly:
+
+   ```bash
+   git clone https://github.com/flagos-ai/FlagCX.git
+   cd FlagCX && make USE_NVIDIA=1
+   ```
+
+   If the build fails on your platform, see
+   https://github.com/flagos-ai/FlagCX/blob/main/docs/getting_started.md
+
+3. **Install `sglang-router`**: `pip install sglang-router`.
+
+---
+
+## Environment Variables
+
+Set these on both roles (prefill / decode):
+
+```bash
+export SGLANG_FL_OOT_ENABLED=0        # recommended off when only exercising FlagCX PD disaggregation
+export USE_FLAGGEMS=0                 # recommended off when only exercising FlagCX PD disaggregation
+export FLAGCX_PATH=/path/to/FlagCX
+export FLAGCX_P2P_SLICE_SIZE=65536    # slice size per one-sided RDMA write (recommended)
+export FLAGCX_P2P_WORKERS_PER_POOL=2  # transfer workers per pool (recommended)
+export FLAGCX_P2P_QPS_PER_CONN=2      # queue pairs per connection (recommended)
+```
+
+| Variable | Description |
+|---|---|
+| `FLAGCX_PATH` | FlagCX installation directory — **required** |
+| `FLAGCX_P2P_SLICE_SIZE` | Bytes per one-sided write slice; raise it for long sequences |
+| `FLAGCX_P2P_WORKERS_PER_POOL` | Number of transfer-pool workers |
+| `FLAGCX_P2P_QPS_PER_CONN` | Queue pairs per connection; raise it to get more concurrency across multiple NICs |
+| `FLAGCX_IB_HCA` | Usually **no need to set manually**: `conn.py:257` applies `setdefault` using the value of `--disaggregation-ib-device` |
+| `SGLANG_FL_DISAGG_FLAGCX` | Layer 4 switch, default `1`; setting `0` makes `flagcx` an invalid backend value |
+| `SGLANG_FL_OOT_ENABLED` / `USE_FLAGGEMS` | Layer 2 / Layer 1 switches; enable them one at a time during performance tuning |
+
+Throughout this guide, replace the placeholders with your own values:
+
+| Placeholder | Meaning |
+|---|---|
+| `<MODEL_PATH>` | Local path to the model weights |
+| `<PREFILL_HOST>` | IP or hostname of the prefill node |
+| `<DECODE_HOST>` | IP or hostname of the decode node |
+| `<ROUTER_HOST>` | IP or hostname of the node running the router |
+
+---
+
+## Step 1 — Launch prefill on node 1
+
+```bash
+mkdir -p log
+
+export SGLANG_FL_OOT_ENABLED=0
+export USE_FLAGGEMS=0
+export FLAGCX_PATH=/path/to/FlagCX
+export FLAGCX_P2P_SLICE_SIZE=65536
+export FLAGCX_P2P_WORKERS_PER_POOL=2
+export FLAGCX_P2P_QPS_PER_CONN=2
+
+python -m sglang.launch_server \
+    --model-path <MODEL_PATH> \
+    --trust-remote-code \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --tp 8 \
+    --max-running-requests 256 \
+    --mem-fraction-static 0.85 \
+    --disaggregation-mode prefill \
+    --disaggregation-transfer-backend flagcx \
+    --disaggregation-ib-device mlx5_bond_1,mlx5_bond_2,mlx5_bond_3,mlx5_bond_4,mlx5_bond_5,mlx5_bond_6,mlx5_bond_7,mlx5_bond_8 \
+    > log/prefill.log 2>&1 &
+```
+
+## Step 2 — Launch decode on node 2
+
+Only two things differ from prefill: `--disaggregation-mode decode` and the log filename.
+**`--disaggregation-transfer-backend` must be `flagcx` on both sides.**
+
+```bash
+mkdir -p log
+
+export SGLANG_FL_OOT_ENABLED=0
+export USE_FLAGGEMS=0
+export FLAGCX_PATH=/path/to/FlagCX
+export FLAGCX_P2P_SLICE_SIZE=65536
+export FLAGCX_P2P_WORKERS_PER_POOL=2
+export FLAGCX_P2P_QPS_PER_CONN=2
+
+python -m sglang.launch_server \
+    --model-path <MODEL_PATH> \
+    --trust-remote-code \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --tp 8 \
+    --max-running-requests 256 \
+    --mem-fraction-static 0.85 \
+    --disaggregation-mode decode \
+    --disaggregation-transfer-backend flagcx \
+    --disaggregation-ib-device mlx5_bond_1,mlx5_bond_2,mlx5_bond_3,mlx5_bond_4,mlx5_bond_5,mlx5_bond_6,mlx5_bond_7,mlx5_bond_8 \
+    > log/decode.log 2>&1 &
+```
+
+Both logs must show `Layer 4 (PD Disagg): flagcx` in the plugin banner, plus:
+
+```
+FlagCX PD disaggregation backend registered (--disaggregation-transfer-backend flagcx)
+```
+
+If it is missing, the patch did not take effect (`sglang_fl/disaggregation/patch.py:139`), and SGLang
+will exit with an error because `flagcx` is not a valid choice.
+
+## Step 3 — Launch the router
+
+`--mini-lb` is the built-in lightweight load balancer, which is enough for a 1P1D setup.
+
+```bash
+python3 -m sglang_router.launch_router \
+    --pd-disaggregation \
+    --prefill http://<PREFILL_HOST>:8000 \
+    --decode  http://<DECODE_HOST>:8000 \
+    --mini-lb \
+    --port 30000 \
+    > router.log 2>&1 &
+```
+
+**Scaling to xPyD**: pass `--prefill` / `--decode` once per instance:
+
+```bash
+python3 -m sglang_router.launch_router \
+    --pd-disaggregation \
+    --prefill http://<PREFILL_HOST_1>:8000 \
+    --prefill http://<PREFILL_HOST_2>:8000 \
+    --decode  http://<DECODE_HOST_1>:8000 \
+    --decode  http://<DECODE_HOST_2>:8000 \
+    --decode  http://<DECODE_HOST_3>:8000 \
+    --policy round_robin \
+    --port 30000 \
+    > router.log 2>&1 &
+```
+
+> A single decode instance can usually absorb the output of several prefill instances. Pick the
+> actual x:y ratio from benchmark data — prefill queueing time versus decode memory usage — rather
+> than guessing from defaults.
+
+## Step 4 — Single-request check
+
+Send requests to the **router port (30000)**, not to the servers' port 8000.
+
+```bash
+curl -v http://<ROUTER_HOST>:30000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "base_model",
+    "messages": [
+      {"role": "user", "content": "What is the capital of China? And the capital of the United States?"}
+    ],
+    "temperature": 0,
+    "max_tokens": 320
+  }'
+```
+
+A valid response means the whole path works: bootstrap handshake, one-sided KV write, and decode
+token generation.
+
+## Step 5 — Multi-request benchmark
+
+```bash
+#!/bin/bash
+# Disable Hugging Face network access on air-gapped machines; the tokenizer is read from a local path
+export HF_HUB_OFFLINE=1
+export TRANSFORMERS_OFFLINE=1
+
+MODEL_PATH=<MODEL_PATH>
+BASE_ARGS="python3 -m sglang.bench_serving \
+  --backend sglang-oai \
+  --base-url http://<ROUTER_HOST>:30000 \
+  --model $MODEL_PATH \
+  --served-model-name base_model \
+  --tokenizer $MODEL_PATH \
+  --dataset-name random \
+  --random-range-ratio 1.0 \
+  --warmup-requests 20"
+
+run_test() {
+  local input_len=$1
+  local output_len=$2
+  local rps=$3
+  local num_prompts=$(( rps * 5 ))
+  echo "========================================"
+  echo "Testing input=${input_len} output=${output_len} rps=${rps} num_prompts=${num_prompts}"
+  echo "========================================"
+  $BASE_ARGS \
+    --random-input-len  "$input_len"  \
+    --random-output-len "$output_len" \
+    --request-rate      "$rps"        \
+    --num-prompts       "$num_prompts"
+  # Flush the prefix cache between rounds so hits from the previous round do not skew TTFT
+  curl -X POST http://<ROUTER_HOST>:30000/flush_cache
+}
+
+# input   output  rps
+run_test  1024    1024   75
+run_test  4096    1024   70
+run_test  8192    1024   65
+run_test  16384   1024   60
+run_test  32768   1024   45
+
+echo "All tests done."
+```
+
+```bash
+bash bench.sh > log/bench.log 2>&1 &
+```
+
+---
+
+## End-to-end Path
+
+```
+                      ┌──────────────────────────┐
+   client ───────────►│  sglang_router (:30000)  │
+                      │  --pd-disaggregation     │
+                      │  --mini-lb               │
+                      └───────┬──────────┬───────┘
+                              │          │
+                 ① forward prompt        │② forward decode request
+                              ▼          ▼
+      ┌───────────────────────────┐   ┌───────────────────────────┐
+      │ Node1  prefill (:8000)    │   │ Node2  decode (:8000)     │
+      │ --disaggregation-mode     │   │ --disaggregation-mode     │
+      │       prefill             │   │       decode              │
+      │ --transfer-backend flagcx │   │ --transfer-backend flagcx │
+      ├───────────────────────────┤   ├───────────────────────────┤
+      │ FlagcxKVBootstrapServer   │◄──┤ FlagcxKVReceiver          │
+      │   (ZMQ handshake)         │ ③ │   send_metadata / register │
+      ├───────────────────────────┤   ├───────────────────────────┤
+      │ FlagcxKVSender            │   │                           │
+      │  → FlagcxKVManager        │   │                           │
+      │     transfer_worker pool  │   │                           │
+      │  → FlagCXTransferEngine   │   │                           │
+      └────────────┬──────────────┘   └────────────▲──────────────┘
+                   │  ④ flagcxP2pBatchWriteSync    │
+                   │     one-sided RDMA write of   │
+                   │     the KV cache              │
+                   └───────────────────────────────┘
+                        mlx5_bond_1..8 (FLAGCX_IB_HCA)
+
+  Plugin-side registration path (once, at process startup):
+    entry_point sglang.srt.plugins → sglang_fl.load_plugin()
+      └─ apply_disaggregation_patch()            patch.py:139
+           ├─ _add_backend_choice()   adds "flagcx" to the CLI choices
+           ├─ _add_enum_member()      injects TransferBackend.FLAGCX
+           └─ _patch_get_kv_class()   flagcx → the four Flagcx* classes
+                                      (conn.py is imported only here,
+                                       so libflagcx.so stays lazy)
+```

--- a/sglang_fl/disaggregation/__init__.py
+++ b/sglang_fl/disaggregation/__init__.py
@@ -1,0 +1,35 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""FlagCX PD-disaggregation KV transfer backend.
+
+Importing this package pulls in ``conn.py``, which transitively loads the
+FlagCX shared library. Keep it out of the plugin's import path at load time --
+``patch.py`` only imports it lazily, once the user actually selects
+``--disaggregation-transfer-backend flagcx``.
+"""
+
+from sglang_fl.disaggregation.conn import (
+    FlagcxKVBootstrapServer,
+    FlagcxKVManager,
+    FlagcxKVReceiver,
+    FlagcxKVSender,
+)
+
+__all__ = [
+    "FlagcxKVBootstrapServer",
+    "FlagcxKVManager",
+    "FlagcxKVReceiver",
+    "FlagcxKVSender",
+]

--- a/sglang_fl/disaggregation/conn.py
+++ b/sglang_fl/disaggregation/conn.py
@@ -264,25 +264,42 @@ class FlagcxKVManager(CommonKVManager):
     def register_buffer_to_engine(self):
         # Batch register KV data buffers
         if self.kv_args.kv_data_ptrs and self.kv_args.kv_data_lens:
-            self.engine.batch_register(
+            ret = self.engine.batch_register(
                 self.kv_args.kv_data_ptrs, self.kv_args.kv_data_lens
             )
+            if ret != 0:
+                logger.error(
+                    f"Failed to register KV data buffers to FlagCX engine: "
+                    f"{len(self.kv_args.kv_data_ptrs)} buffers, "
+                    f"total {sum(self.kv_args.kv_data_lens)} bytes"
+                )
 
         if self.kv_args.aux_data_ptrs and self.kv_args.aux_data_lens:
             if is_npu():
-                self.engine.batch_register(
+                ret = self.engine.batch_register(
                     self.kv_args.aux_data_ptrs, self.kv_args.aux_data_lens
                 )
             else:
-                self.engine.batch_register_host(
+                ret = self.engine.batch_register_host(
                     self.kv_args.aux_data_ptrs, self.kv_args.aux_data_lens
+                )
+            if ret != 0:
+                logger.error(
+                    f"Failed to register aux data buffers to FlagCX engine: "
+                    f"{len(self.kv_args.aux_data_ptrs)} buffers, "
+                    f"total {sum(self.kv_args.aux_data_lens)} bytes"
                 )
 
         for ptrs, lens in zip(
             self.kv_args.state_data_ptrs, self.kv_args.state_data_lens
         ):
             if ptrs and lens:
-                self.engine.batch_register(ptrs, lens)
+                ret = self.engine.batch_register(ptrs, lens)
+                if ret != 0:
+                    logger.error(
+                        f"Failed to register state data buffers to FlagCX engine: "
+                        f"{len(ptrs)} buffers, total {sum(lens)} bytes"
+                    )
 
     # ------------------------------------------------------------------
     # Staging buffer methods (all delegate to staging_handler.py)
@@ -864,6 +881,10 @@ class FlagcxKVManager(CommonKVManager):
         prefill_aux_index: int,
         dst_aux_ptrs: list[int],
     ):
+        if (
+            self.enable_custom_mem_pool and self.custom_mem_pool_type == "NVLINK"
+        ):
+            return self.send_aux_tcp(req, prefill_aux_index, dst_aux_ptrs)
 
         transfer_blocks = []
         prefill_aux_ptrs = self.kv_args.aux_data_ptrs

--- a/sglang_fl/disaggregation/conn.py
+++ b/sglang_fl/disaggregation/conn.py
@@ -881,9 +881,7 @@ class FlagcxKVManager(CommonKVManager):
         prefill_aux_index: int,
         dst_aux_ptrs: list[int],
     ):
-        if (
-            self.enable_custom_mem_pool and self.custom_mem_pool_type == "NVLINK"
-        ):
+        if os.environ.get("SGLANG_SEND_AUX_TCP") == "1":
             return self.send_aux_tcp(req, prefill_aux_index, dst_aux_ptrs)
 
         transfer_blocks = []

--- a/sglang_fl/disaggregation/conn.py
+++ b/sglang_fl/disaggregation/conn.py
@@ -142,8 +142,8 @@ class KVArgsRegisterInfo:
             endpoint=msg[1].decode("ascii"),
             dst_port=int(msg[2].decode("ascii")),
             flagcx_session_id=msg[3].decode("ascii"),
-            dst_kv_ptrs=list(struct.unpack(f"{len(msg[4])//8}Q", msg[4])),
-            dst_aux_ptrs=list(struct.unpack(f"{len(msg[5])//8}Q", msg[5])),
+            dst_kv_ptrs=list(struct.unpack(f"{len(msg[4]) // 8}Q", msg[4])),
+            dst_aux_ptrs=list(struct.unpack(f"{len(msg[5]) // 8}Q", msg[5])),
             dst_state_data_ptrs=unpack_int_lists(msg[6], "Q"),
             dst_tp_rank=int(msg[7].decode("ascii")),
             dst_attn_tp_size=int(msg[8].decode("ascii")),
@@ -330,9 +330,9 @@ class FlagcxKVManager(CommonKVManager):
         room = int(msg[1].decode("ascii"))
         session_id = msg[4].decode("ascii")
         handler = self._staging_handler
-        assert (
-            handler is not None
-        ), "STAGING_REQ received before staging handler initialized"
+        assert handler is not None, (
+            "STAGING_REQ received before staging handler initialized"
+        )
         decode_req = handler._room_to_decode_req.get(room)
         if decode_req is None:
             logger.warning(
@@ -1453,9 +1453,9 @@ class FlagcxKVManager(CommonKVManager):
                     num_pages = int(msg[4].decode("ascii"))
                     session_id = msg[5].decode("ascii")
                     handler = self._staging_handler
-                    assert (
-                        handler is not None
-                    ), "CHUNK_READY received before staging handler initialized"
+                    assert handler is not None, (
+                        "CHUNK_READY received before staging handler initialized"
+                    )
                     handler.handle_chunk_arrived(
                         room,
                         chunk_idx,
@@ -1637,7 +1637,6 @@ class FlagcxKVManager(CommonKVManager):
 
 
 class FlagcxKVSender(CommonKVSender):
-
     def __init__(
         self,
         mgr: FlagcxKVManager,

--- a/sglang_fl/disaggregation/conn.py
+++ b/sglang_fl/disaggregation/conn.py
@@ -37,6 +37,7 @@ from sglang.srt.disaggregation.utils import (
     DisaggregationMode,
     filter_kv_indices_for_cp_rank,
 )
+from sglang_fl.disaggregation import stats as flagcx_stats
 from sglang_fl.disaggregation.transfer_engine import (
     get_flagcx_transfer_engine,
     init_flagcx_transfer_engine,
@@ -193,6 +194,14 @@ class FlagcxKVManager(CommonKVManager):
         is_mla_backend: Optional[bool] = False,
     ):
         super().__init__(args, disaggregation_mode, server_args, is_mla_backend)
+        self._metric_labels = {
+            "model_name": server_args.served_model_name,
+            "engine_type": DisaggregationMode.to_engine_type(
+                server_args.disaggregation_mode
+            ),
+            "tp_rank": str(self.attn_tp_rank),
+            "pp_rank": str(self.pp_rank),
+        }
         self.init_engine()
         self.register_buffer_to_engine()
         self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()
@@ -602,9 +611,18 @@ class FlagcxKVManager(CommonKVManager):
             return 0
 
         src_addrs, dst_addrs, lengths = zip(*transfer_blocks)
-        return self.engine.batch_transfer_sync(
+        start = time.perf_counter()
+        ret = self.engine.batch_transfer_sync(
             flagcx_session_id, list(src_addrs), list(dst_addrs), list(lengths)
         )
+        if ret == 0:
+            flagcx_stats.record_transfer(
+                time.perf_counter() - start,
+                sum(lengths),
+                len(lengths),
+                self._metric_labels,
+            )
+        return ret
 
     def _send_kvcache_generic(
         self,
@@ -1318,6 +1336,7 @@ class FlagcxKVManager(CommonKVManager):
                                 executor,
                             )
                         if ret != 0:
+                            flagcx_stats.record_failed_transfer(self._metric_labels)
                             with self.session_lock:
                                 self.session_failures[req.flagcx_session_id] += 1
                                 # Failures should never happen if the session is not dead, if the session fails once, mark it as failed
@@ -1512,6 +1531,7 @@ class FlagcxKVManager(CommonKVManager):
                                 self._chunk_writer_counts.pop(bootstrap_room, None)
                             self.update_status(bootstrap_room, KVPoll.Success)
                 elif status == KVPoll.Failed:
+                    flagcx_stats.record_failed_recv(self._metric_labels)
                     self.record_failure(
                         bootstrap_room,
                         "Failed to get kvcache from prefill instance, it might be dead",
@@ -1730,6 +1750,7 @@ class FlagcxKVSender(CommonKVSender):
                             "which means prefill instances fail to receive the KV indices from the decode instance of this request. "
                             "If a greater mean TTFT is acceptable, you can 'export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=600' (10 minutes) to relax the timeout condition. "
                         )
+                        flagcx_stats.record_kv_expired_req(self.kv_mgr._metric_labels)
                         self.kv_mgr.record_failure(
                             self.bootstrap_room,
                             f"Request {self.bootstrap_room} timed out after {elapsed:.1f}s in KVPoll.Bootstrapping",
@@ -1892,6 +1913,7 @@ class FlagcxKVReceiver(CommonKVReceiver):
                             "Some requests fail to receive KV Cache transfer done signal after bootstrapping. "
                             "If a greater mean TTFT is acceptable, you can 'export SGLANG_DISAGGREGATION_WAITING_TIMEOUT=600' (10 minutes) to relax the timeout condition. "
                         )
+                        flagcx_stats.record_kv_expired_req(self.kv_mgr._metric_labels)
                         self.kv_mgr.record_failure(
                             self.bootstrap_room,
                             f"Request {self.bootstrap_room} timed out after {elapsed:.1f}s in KVPoll.WaitingForInput",

--- a/sglang_fl/disaggregation/conn.py
+++ b/sglang_fl/disaggregation/conn.py
@@ -1,0 +1,1904 @@
+from __future__ import annotations
+
+import concurrent.futures
+import ctypes
+import dataclasses
+import logging
+import os
+import struct
+import threading
+import time
+from collections import defaultdict
+from typing import List, Optional, Tuple
+
+import numpy as np
+import numpy.typing as npt
+
+from sglang.srt.disaggregation.base.conn import KVArgs, KVPoll, StateType
+from sglang.srt.disaggregation.common.conn import (
+    CommonKVBootstrapServer,
+    CommonKVManager,
+    CommonKVReceiver,
+    CommonKVSender,
+)
+from sglang.srt.disaggregation.common.staging_handler import (
+    DecodeStagingContext,
+    PrefillStagingContext,
+    StagingRegisterInfo,
+    StagingTransferInfo,
+)
+from sglang.srt.disaggregation.common.utils import (
+    FastQueue,
+    group_concurrent_contiguous,
+    pack_int_lists,
+    unpack_int_lists,
+)
+from sglang.srt.disaggregation.utils import (
+    DisaggregationMode,
+    filter_kv_indices_for_cp_rank,
+)
+from sglang_fl.disaggregation.transfer_engine import (
+    get_flagcx_transfer_engine,
+    init_flagcx_transfer_engine,
+)
+from sglang.srt.environ import envs
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto
+from sglang.srt.utils import is_npu
+
+logger = logging.getLogger(__name__)
+
+
+class KVTransferError(Exception):
+    def __init__(self, bootstrap_room: int, failure_reason: str):
+        super().__init__(failure_reason)
+        self.bootstrap_room = bootstrap_room
+        self.failure_reason = failure_reason
+
+    def __str__(self):
+        return f"KVTransferError(bootstrap_room={self.bootstrap_room}): {self.failure_reason}"
+
+
+# prefill
+@dataclasses.dataclass
+class TransferKVChunk:
+    room: int
+    prefill_kv_indices: npt.NDArray[np.int32]
+    index_slice: slice
+    is_last_chunk: bool
+    prefill_aux_index: Optional[int]
+    state_indices: Optional[List]
+
+
+# decode
+@dataclasses.dataclass
+class TransferInfo:
+    room: int
+    endpoint: str
+    dst_port: int
+    flagcx_session_id: str
+    dst_kv_indices: npt.NDArray[np.int32]
+    dst_aux_index: int
+    dst_state_indices: List[List[int]]  # parallel to receiver's state_types
+    required_dst_info_num: int
+    is_dummy: bool
+    decode_prefix_len: Optional[int] = None
+    # Note: always put the optional staging field at the final (it will be set through 'STAGING_RSP' pkg when needed)
+    staging: Optional[StagingTransferInfo] = None
+
+    @classmethod
+    def from_zmq(cls, msg: List[bytes]):
+        if msg[4] == b"" and msg[5] == b"":
+            is_dummy = True
+            dst_kv_indices = np.array([], dtype=np.int32)
+            dst_aux_index = None
+            dst_state_indices = []
+        else:
+            dst_kv_indices = np.frombuffer(msg[4], dtype=np.int32)
+            dst_aux_index = int(msg[5].decode("ascii"))
+            dst_state_indices = unpack_int_lists(msg[6], "i")
+            is_dummy = False
+        return cls(
+            room=int(msg[0].decode("ascii")),
+            endpoint=msg[1].decode("ascii"),
+            dst_port=int(msg[2].decode("ascii")),
+            flagcx_session_id=msg[3].decode("ascii"),
+            dst_kv_indices=dst_kv_indices,
+            dst_aux_index=dst_aux_index,
+            dst_state_indices=dst_state_indices,
+            required_dst_info_num=int(msg[7].decode("ascii")),
+            is_dummy=is_dummy,
+            decode_prefix_len=(
+                int(msg[8].decode("ascii")) if len(msg) > 8 and msg[8] != b"" else None
+            ),
+        )
+
+
+# decode
+@dataclasses.dataclass
+class KVArgsRegisterInfo:
+    room: str
+    endpoint: str
+    dst_port: int
+    flagcx_session_id: str
+    dst_kv_ptrs: list[int]
+    dst_aux_ptrs: list[int]
+    dst_state_data_ptrs: List[List[int]]  # parallel to state_types (same below)
+    dst_tp_rank: int
+    dst_attn_tp_size: int
+    dst_kv_item_len: int
+    # for mamba state different tp slice transfer
+    dst_state_item_lens: List[List[int]]
+    dst_state_dim_per_tensor: List[List[int]]
+    # HiSparse: decode host pool stores KV at token granularity
+    enable_hisparse: bool = False
+    # Note: always put the staging field at the final (since the staging field is optional and contains multiple inputs)
+    staging: Optional[StagingRegisterInfo] = None
+
+    @classmethod
+    def from_zmq(cls, msg: List[bytes]):
+        return cls(
+            room=str(msg[0].decode("ascii")),
+            endpoint=msg[1].decode("ascii"),
+            dst_port=int(msg[2].decode("ascii")),
+            flagcx_session_id=msg[3].decode("ascii"),
+            dst_kv_ptrs=list(struct.unpack(f"{len(msg[4])//8}Q", msg[4])),
+            dst_aux_ptrs=list(struct.unpack(f"{len(msg[5])//8}Q", msg[5])),
+            dst_state_data_ptrs=unpack_int_lists(msg[6], "Q"),
+            dst_tp_rank=int(msg[7].decode("ascii")),
+            dst_attn_tp_size=int(msg[8].decode("ascii")),
+            dst_kv_item_len=int(msg[9].decode("ascii")),
+            dst_state_item_lens=(
+                unpack_int_lists(msg[10], "I") if len(msg) > 10 else []
+            ),
+            dst_state_dim_per_tensor=(
+                unpack_int_lists(msg[11], "I") if len(msg) > 11 else []
+            ),
+            enable_hisparse=(
+                msg[12].decode("ascii") == "1" if len(msg) > 12 else False
+            ),
+            # Note: always put the staging field at the final
+            staging=StagingRegisterInfo.from_zmq_fields(msg, 13),
+        )
+
+
+class AuxDataCodec:
+    """Handles serialization and deserialization of auxiliary data buffers"""
+
+    @staticmethod
+    def serialize_data_from_buffer(src_addr, data_length):
+        """Serialize data from memory buffer to bytes"""
+        buffer = (ctypes.c_byte * data_length).from_address(src_addr)
+        return bytes(buffer)
+
+    @staticmethod
+    def deserialize_data_to_buffer(kv_args, buffer_index, aux_index, data):
+        """Deserialize bytes into target memory buffer"""
+        dst_aux_ptr = kv_args.aux_data_ptrs[buffer_index]
+        item_len = kv_args.aux_item_lens[buffer_index]
+        dst_addr = dst_aux_ptr + item_len * aux_index
+        buffer = (ctypes.c_byte * len(data)).from_address(dst_addr)
+        buffer[:] = data
+        return
+
+
+class FlagcxKVManager(CommonKVManager):
+    AUX_DATA_HEADER = b"AUX_DATA"
+
+    def __init__(
+        self,
+        args: KVArgs,
+        disaggregation_mode: DisaggregationMode,
+        server_args: ServerArgs,
+        is_mla_backend: Optional[bool] = False,
+    ):
+        super().__init__(args, disaggregation_mode, server_args, is_mla_backend)
+        self.init_engine()
+        self.register_buffer_to_engine()
+        self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()
+        if self.disaggregation_mode == DisaggregationMode.PREFILL:
+            self.start_prefill_thread()
+            self.session_failures = defaultdict(int)
+            self.failed_sessions = set()
+            self.session_lock = threading.Lock()
+            # Determine the number of threads to use for kv sender
+            cpu_count = os.cpu_count()
+            transfer_thread_pool_size = (
+                envs.SGLANG_DISAGGREGATION_THREAD_POOL_SIZE.get()
+            )
+            if transfer_thread_pool_size is None:
+                transfer_thread_pool_size = min(max(4, int(0.5 * cpu_count) // 8), 12)
+            transfer_queue_size = envs.SGLANG_DISAGGREGATION_QUEUE_SIZE.get()
+            self.transfer_queues: List[FastQueue] = [
+                FastQueue() for _ in range(transfer_queue_size)
+            ]
+            assert transfer_thread_pool_size >= transfer_queue_size, (
+                f"The environment variable SGLANG_DISAGGREGATION_THREAD_POOL_SIZE={transfer_thread_pool_size} must be "
+                f"greater than or equal to SGLANG_DISAGGREGATION_QUEUE_SIZE={transfer_queue_size}."
+            )
+            self.executors = [
+                concurrent.futures.ThreadPoolExecutor(
+                    transfer_thread_pool_size // transfer_queue_size
+                )
+                for _ in range(transfer_queue_size)
+            ]
+            self._staging_ctx = PrefillStagingContext() if self.enable_staging else None
+            if self.enable_staging:
+                self._init_staging_buffers(len(self.transfer_queues))
+            for i, (queue, executor) in enumerate(
+                zip(self.transfer_queues, self.executors)
+            ):
+                threading.Thread(
+                    target=self.transfer_worker,
+                    args=(
+                        queue,
+                        executor,
+                        (
+                            self._staging_ctx.buffers[i]
+                            if self.enable_staging and self._staging_ctx.buffers
+                            else None
+                        ),
+                    ),
+                    daemon=True,
+                ).start()
+        elif self.disaggregation_mode == DisaggregationMode.DECODE:
+            self._staging_ctx = DecodeStagingContext() if self.enable_staging else None
+            if self.enable_staging:
+                self._init_staging_allocator()
+                self._staging_handler = None
+                self._chunk_writer_counts: dict = defaultdict(lambda: defaultdict(list))
+            self.start_decode_thread()
+
+    def init_engine(self):
+        self.engine = get_flagcx_transfer_engine()
+        if self.engine is None:
+            ib_device = self.server_args.disaggregation_ib_device
+            if ib_device:
+                os.environ.setdefault("FLAGCX_IB_HCA", ib_device)
+            self.engine = init_flagcx_transfer_engine(
+                hostname=get_local_ip_auto(),
+                gpu_id=self.kv_args.gpu_id,
+                ib_device=ib_device,
+            )
+
+    def register_buffer_to_engine(self):
+        # Batch register KV data buffers
+        if self.kv_args.kv_data_ptrs and self.kv_args.kv_data_lens:
+            self.engine.batch_register(
+                self.kv_args.kv_data_ptrs, self.kv_args.kv_data_lens
+            )
+
+        if self.kv_args.aux_data_ptrs and self.kv_args.aux_data_lens:
+            if is_npu():
+                self.engine.batch_register(
+                    self.kv_args.aux_data_ptrs, self.kv_args.aux_data_lens
+                )
+            else:
+                self.engine.batch_register_host(
+                    self.kv_args.aux_data_ptrs, self.kv_args.aux_data_lens
+                )
+
+        for ptrs, lens in zip(
+            self.kv_args.state_data_ptrs, self.kv_args.state_data_lens
+        ):
+            if ptrs and lens:
+                self.engine.batch_register(ptrs, lens)
+
+    # ------------------------------------------------------------------
+    # Staging buffer methods (all delegate to staging_handler.py)
+    # ------------------------------------------------------------------
+
+    def register_staging_room_bootstrap(self, room, bootstrap_infos, receiver):
+        self._staging_ctx.room_bootstrap[room] = bootstrap_infos
+        self._staging_ctx.room_receivers[room] = receiver
+
+    def set_kv_buffer_tensors(self, k_buffers: list, v_buffers: list, page_size: int):
+        self.kv_buffer_tensors = {
+            "k_buffers": k_buffers,
+            "v_buffers": v_buffers,
+            "page_size": page_size,
+        }
+
+    def _init_staging_buffers(self, count: int):
+        from sglang.srt.disaggregation.common.staging_handler import (
+            init_staging_buffers,
+        )
+
+        self._staging_ctx.buffers = init_staging_buffers(
+            lambda ptr, size: self.engine.batch_register([ptr], [size]),
+            self.kv_args,
+            count,
+        )
+        self.kv_buffer_tensors = None
+
+    def _init_staging_allocator(self):
+        from sglang.srt.disaggregation.common.staging_handler import (
+            init_staging_allocator,
+        )
+
+        self._staging_ctx.allocator = init_staging_allocator(
+            lambda ptr, size: self.engine.batch_register([ptr], [size]),
+            self.kv_args,
+        )
+        self.kv_buffer_tensors = None
+
+    def _handle_staging_req(self, msg):
+        from sglang.srt.disaggregation.common.staging_handler import (
+            handle_staging_req,
+        )
+
+        room = int(msg[1].decode("ascii"))
+        session_id = msg[4].decode("ascii")
+        handler = self._staging_handler
+        assert (
+            handler is not None
+        ), "STAGING_REQ received before staging handler initialized"
+        decode_req = handler._room_to_decode_req.get(room)
+        if decode_req is None:
+            logger.warning(
+                "STAGING_REQ received for unregistered room=%s, skipping",
+                room,
+            )
+            return
+        prefill_tp = decode_req.kv_receiver.prefill_info.attn_tp_size
+        handle_staging_req(
+            msg,
+            self._staging_ctx.allocator,
+            self.kv_args,
+            self.attn_tp_size,
+            prefill_tp,
+            getattr(self, "kv_buffer_tensors", None),
+            self._staging_ctx.room_receivers,
+            self._staging_ctx.room_bootstrap,
+        )
+
+        receiver = self._staging_ctx.room_receivers.get(room)
+        if receiver is not None:
+            handler.register_wm_subscriber(receiver, session_id)
+
+    def _is_watermark_ready(
+        self, session_id: str, alloc_round: int, alloc_end: int
+    ) -> bool:
+        from sglang.srt.disaggregation.common.staging_handler import (
+            is_watermark_ready,
+        )
+
+        return is_watermark_ready(self._staging_ctx, session_id, alloc_round, alloc_end)
+
+    def _try_create_staging_strategy(self, staging_buffer):
+        if not self.enable_staging or self.kv_buffer_tensors is None:
+            return None
+        from sglang.srt.disaggregation.common.staging_handler import (
+            PrefillStagingStrategy,
+        )
+
+        return PrefillStagingStrategy(self, staging_buffer)
+
+    def _send_chunk_ready(self, req, chunk_idx, kv_chunk, prefill_unique_rank):
+        """Notify decode that a non-last staging chunk RDMA is complete."""
+        try:
+            na = NetworkAddress(req.endpoint, req.dst_port)
+            self._connect(
+                na.to_tcp(),
+                is_ipv6=na.is_ipv6,
+            ).send_multipart(
+                [
+                    b"CHUNK_READY",
+                    str(req.room).encode("ascii"),
+                    str(chunk_idx).encode("ascii"),
+                    str(kv_chunk.index_slice.start).encode("ascii"),
+                    str(len(kv_chunk.prefill_kv_indices)).encode("ascii"),
+                    req.flagcx_session_id.encode("ascii"),
+                    str(prefill_unique_rank).encode("ascii"),
+                ]
+            )
+        except Exception:
+            pass
+
+    def _do_staging_transfer(
+        self,
+        staging_strategy,
+        kv_chunk,
+        req,
+        target_info,
+        chunked_dst_kv_indice,
+        executor,
+        queue,
+        prefill_unique_rank,
+    ):
+        """Execute staging transfer for one chunk. Returns (ret, deferred).
+
+        Handles readiness check, transfer, fallback, and CHUNK_READY notification.
+        deferred=True means caller should re-enqueue and break.
+        """
+        _tp = self.attn_tp_rank
+        ready, chunk_idx, c_offset, _, _ = staging_strategy.check_ready(
+            req,
+            kv_chunk.index_slice.start,
+            len(kv_chunk.prefill_kv_indices),
+        )
+        if not ready:
+            from sglang.srt.disaggregation.common.staging_buffer import StagingAllocator
+
+            if c_offset == StagingAllocator.ALLOC_OVERSIZED:
+                raise RuntimeError(
+                    f"[Staging] Chunk staging allocation permanently failed: "
+                    f"chunk exceeds ring buffer total size (room={kv_chunk.room}). "
+                    f"Increase SGLANG_DISAGG_STAGING_POOL_SIZE_MB."
+                )
+            queue.put(kv_chunk)
+            return (-1, True)
+
+        ret = staging_strategy.transfer(
+            req.flagcx_session_id,
+            kv_chunk.prefill_kv_indices,
+            target_info.staging.base_ptr + c_offset,
+            target_info.staging.total_size - c_offset,
+            target_info,
+        )
+        if ret == -1:
+            logger.warning(
+                f"[Staging][tp{_tp}] Falling back to per-token slice path "
+                f"(room={kv_chunk.room})"
+            )
+            ret = self.send_kvcache_slice(
+                req.flagcx_session_id,
+                kv_chunk.prefill_kv_indices,
+                target_info.dst_kv_ptrs,
+                chunked_dst_kv_indice,
+                target_info.dst_tp_rank,
+                target_info.dst_attn_tp_size,
+                target_info.dst_kv_item_len,
+                executor,
+            )
+        elif ret == 0 and not kv_chunk.is_last_chunk:
+            self._send_chunk_ready(req, chunk_idx, kv_chunk, prefill_unique_rank)
+        return (ret, False)
+
+    def _prefetch_staging_reqs(self, room: int):
+        if not self.enable_staging or self.kv_buffer_tensors is None:
+            return
+
+        room_infos = self.transfer_infos.get(room, {})
+        needs_staging = any(
+            not tinfo.is_dummy
+            and self.decode_kv_args_table.get(tinfo.flagcx_session_id) is not None
+            and self.decode_kv_args_table[tinfo.flagcx_session_id].dst_attn_tp_size
+            != self.attn_tp_size
+            for tinfo in room_infos.values()
+        )
+        if not needs_staging:
+            return
+
+        from sglang.srt.disaggregation.common.staging_handler import (
+            prefetch_staging_reqs,
+        )
+
+        prefetch_staging_reqs(
+            room,
+            self.transfer_infos,
+            self.kv_buffer_tensors,
+            self.server_args.chunked_prefill_size,
+            self._staging_ctx.prefetch_requested,
+            self._staging_ctx.prefetch_sockets,
+        )
+
+    def send_kvcache_staged(
+        self,
+        flagcx_session_id: str,
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_staging_ptr: int,
+        dst_staging_size: int,
+        dst_tp_rank: int,
+        dst_attn_tp_size: int,
+        dst_kv_item_len: int,
+        staging_buffer=None,
+    ) -> int:
+        """Transfer KV cache via staging buffers (gather -> bulk RDMA -> scatter on decode)."""
+        from sglang.srt.disaggregation.common.staging_buffer import (
+            compute_head_slice_params,
+            compute_staging_layout,
+            resolve_total_kv_heads,
+        )
+
+        if self.kv_buffer_tensors is None or staging_buffer is None:
+            return -1
+
+        k_buffers = self.kv_buffer_tensors["k_buffers"]
+        v_buffers = self.kv_buffer_tensors["v_buffers"]
+        page_size = self.kv_buffer_tensors["page_size"]
+        num_layers = len(k_buffers)
+        head_dim = k_buffers[0].shape[-1]
+        dtype_size = k_buffers[0].element_size()
+
+        total_kv_heads = resolve_total_kv_heads(self.kv_args, self.attn_tp_size)
+
+        local_tp_rank = self.kv_args.engine_rank % self.attn_tp_size
+        src_head_start, num_heads_to_send, _, _ = compute_head_slice_params(
+            self.attn_tp_size,
+            dst_attn_tp_size,
+            local_tp_rank,
+            dst_tp_rank,
+            total_kv_heads,
+        )
+
+        num_tokens = len(prefill_kv_indices) * page_size
+        per_layer_bytes = num_tokens * num_heads_to_send * head_dim * dtype_size
+        per_rank_bytes = per_layer_bytes * num_layers * 2
+
+        num_writers, writer_rank_bytes, total_staging_needed = compute_staging_layout(
+            self.attn_tp_size,
+            dst_attn_tp_size,
+            dst_tp_rank,
+            total_kv_heads,
+            num_tokens,
+            head_dim * dtype_size,
+            num_layers,
+        )
+        writer_idx = local_tp_rank % num_writers if num_writers > 1 else 0
+        rank_offset = sum(writer_rank_bytes[:writer_idx])
+
+        if not staging_buffer.fits(per_rank_bytes):
+            logger.warning(
+                f"Prefill staging too small for {per_rank_bytes} bytes, falling back"
+            )
+            return -1
+        if dst_staging_size < total_staging_needed:
+            logger.warning(
+                f"Decode staging too small: need {total_staging_needed} bytes "
+                f"({num_writers if self.attn_tp_size > dst_attn_tp_size else 1} writers "
+                f"x {per_rank_bytes} bytes/rank), have {dst_staging_size}, falling back"
+            )
+            return -1
+
+        from sglang.srt.disaggregation.common.staging_buffer import (
+            gather_all_layers_to_staging,
+        )
+
+        gather_all_layers_to_staging(
+            k_buffers,
+            v_buffers,
+            prefill_kv_indices,
+            staging_buffer,
+            src_head_start,
+            num_heads_to_send,
+            page_size,
+            self.kv_args.gpu_id,
+        )
+
+        dst_write_ptr = dst_staging_ptr + rank_offset
+        ret = self._transfer_data(
+            flagcx_session_id,
+            [(staging_buffer.get_ptr(), dst_write_ptr, per_rank_bytes)],
+        )
+        if ret != 0:
+            raise RuntimeError(
+                f"[Staging] Bulk RDMA transfer failed with ret={ret}. "
+                f"src_ptr=0x{staging_buffer.get_ptr():x}, "
+                f"dst_ptr=0x{dst_write_ptr:x}, size={per_rank_bytes}. "
+                f"The decode staging buffer may not be properly registered."
+            )
+        return ret
+
+    def _transfer_data(self, flagcx_session_id, transfer_blocks):
+        if not transfer_blocks:
+            return 0
+
+        src_addrs, dst_addrs, lengths = zip(*transfer_blocks)
+        return self.engine.batch_transfer_sync(
+            flagcx_session_id, list(src_addrs), list(dst_addrs), list(lengths)
+        )
+
+    def _send_kvcache_generic(
+        self,
+        flagcx_session_id: str,
+        src_data_ptrs: list[int],
+        dst_data_ptrs: list[int],
+        item_lens: list[int],
+        prefill_data_indices: npt.NDArray[np.int32],
+        dst_data_indices: npt.NDArray[np.int32],
+        executor: concurrent.futures.ThreadPoolExecutor,
+    ) -> int:
+        """
+        Generic KV cache transfer supporting both MHA and MLA architectures.
+        This method is used by both send_kvcache (full pool) and maybe_send_extra.
+        """
+        # Group by indices for optimization
+        prefill_kv_blocks, dst_kv_blocks = group_concurrent_contiguous(
+            prefill_data_indices, dst_data_indices
+        )
+
+        layers_params = None
+
+        # Decode pp size should be equal to prefill pp size or 1
+        if self.is_mla_backend:
+            src_kv_ptrs, dst_kv_ptrs, layers_current_pp_stage = (
+                self.get_mla_kv_ptrs_with_pp(src_data_ptrs, dst_data_ptrs)
+            )
+            layers_params = [
+                (
+                    src_kv_ptrs[layer_id],
+                    dst_kv_ptrs[layer_id],
+                    item_lens[layer_id],
+                )
+                for layer_id in range(layers_current_pp_stage)
+            ]
+        else:
+            src_k_ptrs, src_v_ptrs, dst_k_ptrs, dst_v_ptrs, layers_current_pp_stage = (
+                self.get_mha_kv_ptrs_with_pp(src_data_ptrs, dst_data_ptrs)
+            )
+            # item_lens structure: [k_layer0, k_layer1, ..., k_layerN, v_layer0, v_layer1, ..., v_layerN]
+            # Use correct item lengths for K and V separately
+            if layers_current_pp_stage > len(dst_k_ptrs):
+                logger.error(
+                    "Prefill transfer kvcache error, layers_current_pp_stage is out of range: "
+                    f"layers_current_pp_stage={layers_current_pp_stage}, len(dst_k_ptrs)={len(dst_k_ptrs)}"
+                )
+                return -1
+            layers_params = [
+                (
+                    src_k_ptrs[layer_id],
+                    dst_k_ptrs[layer_id],
+                    item_lens[layer_id],  # K item length
+                )
+                for layer_id in range(layers_current_pp_stage)
+            ] + [
+                (
+                    src_v_ptrs[layer_id],
+                    dst_v_ptrs[layer_id],
+                    item_lens[layers_current_pp_stage + layer_id],  # V item length
+                )
+                for layer_id in range(layers_current_pp_stage)
+            ]
+        assert layers_params is not None
+
+        def set_transfer_blocks(
+            src_ptr: int, dst_ptr: int, item_len: int
+        ) -> List[Tuple[int, int, int]]:
+            transfer_blocks = []
+            for prefill_index, decode_index in zip(prefill_kv_blocks, dst_kv_blocks):
+                src_addr = src_ptr + int(prefill_index[0]) * item_len
+                dst_addr = dst_ptr + int(decode_index[0]) * item_len
+                length = item_len * len(prefill_index)
+                transfer_blocks.append((src_addr, dst_addr, length))
+            return transfer_blocks
+
+        # Worker function for processing all layers in a batch
+        def process_layers(layers_params: List[Tuple[int, int, int]]) -> int:
+            transfer_blocks = []
+            for src_ptr, dst_ptr, item_len in layers_params:
+                transfer_blocks.extend(set_transfer_blocks(src_ptr, dst_ptr, item_len))
+            return self._transfer_data(flagcx_session_id, transfer_blocks)
+
+        # Combining all layers' params in one batch transfer is more efficient
+        # compared to using multiple threads
+        return process_layers(layers_params)
+
+    def send_kvcache(
+        self,
+        flagcx_session_id: str,
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_ptrs: list[int],
+        dst_kv_indices: npt.NDArray[np.int32],
+        executor: concurrent.futures.ThreadPoolExecutor,
+    ):
+        return self._send_kvcache_generic(
+            flagcx_session_id=flagcx_session_id,
+            src_data_ptrs=self.kv_args.kv_data_ptrs,
+            dst_data_ptrs=dst_kv_ptrs,
+            item_lens=self.kv_args.kv_item_lens,
+            prefill_data_indices=prefill_kv_indices,
+            dst_data_indices=dst_kv_indices,
+            executor=executor,
+        )
+
+    def send_kvcache_hisparse(
+        self,
+        flagcx_session_id: str,
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_ptrs: list[int],
+        dst_kv_indices: npt.NDArray[np.int32],
+        page_index_slice: slice,
+        executor: concurrent.futures.ThreadPoolExecutor,
+    ):
+        """HiSparse transfer: prefill page_size > decode host page_size=1.
+
+        Receives page-level prefill_kv_indices and the full token-level
+        dst_kv_indices.  Expands both to token granularity before transfer.
+        """
+        page_size = self.kv_args.page_size
+        per_token_item_lens = [il // page_size for il in self.kv_args.kv_item_lens]
+
+        # Expand page-level src indices to token-level
+        base = np.repeat(prefill_kv_indices * page_size, page_size)
+        offsets = np.tile(np.arange(page_size, dtype=np.int32), len(prefill_kv_indices))
+        expanded_src = base + offsets
+
+        # Expand page-level index_slice to token-level for dst
+        token_start = page_index_slice.start * page_size
+        token_end = min(page_index_slice.stop * page_size, len(dst_kv_indices))
+        expanded_dst = dst_kv_indices[token_start:token_end]
+
+        # Clip src to match dst length (last page may be partial)
+        expanded_src = expanded_src[: len(expanded_dst)]
+
+        logger.debug(
+            f"Send KVCache for hisparse: {expanded_src.shape} -> {expanded_dst.shape}"
+        )
+        return self._send_kvcache_generic(
+            flagcx_session_id=flagcx_session_id,
+            src_data_ptrs=self.kv_args.kv_data_ptrs,
+            dst_data_ptrs=dst_kv_ptrs,
+            item_lens=per_token_item_lens,
+            prefill_data_indices=expanded_src,
+            dst_data_indices=expanded_dst,
+            executor=executor,
+        )
+
+    def send_kvcache_slice(
+        self,
+        flagcx_session_id: str,
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_ptrs: list[int],
+        dst_kv_indices: npt.NDArray[np.int32],
+        dst_tp_rank: int,
+        dst_attn_tp_size: int,
+        dst_kv_item_len: int,
+        executor: concurrent.futures.ThreadPoolExecutor,
+    ):
+        """
+        Sends KV cache slices from this Prefill rank to a target Decode rank,
+        supporting generic M-to-N TP size configurations.
+
+        NOTE: This implementation calls the transfer engine for each token slot within
+        each page to ensure correctness for any page_size and head-slicing configuration.
+        This may introduce performance overhead (increased TTFT) for long sequences.
+        """
+        # Extract configuration
+        local_tp_rank_in_group = self.kv_args.engine_rank % self.attn_tp_size
+        src_kv_item_len = self.kv_args.kv_item_lens[0]
+        dst_tp_rank_in_group = dst_tp_rank % dst_attn_tp_size
+        page_size = self.kv_args.page_size
+
+        # Use total KV head count (not per-rank) for correct head distribution.
+        # Per-rank kv_head_num is max(1, total//tp) which loses info when total < tp.
+        total_kv_heads = getattr(self.kv_args, "total_kv_head_num", 0)
+        if total_kv_heads <= 0:
+            total_kv_heads = self.kv_args.kv_head_num * self.attn_tp_size
+
+        src_heads_per_rank = max(1, total_kv_heads // self.attn_tp_size)
+        dst_heads_per_rank = max(1, total_kv_heads // dst_attn_tp_size)
+        bytes_per_head_slice_to_send = (
+            dst_kv_item_len // page_size // dst_heads_per_rank
+        )
+
+        # GQA replication: how many prefill ranks share the same KV head
+        src_replication = max(1, self.attn_tp_size // total_kv_heads)
+
+        # Determine slicing parameters based on TP configuration
+        if self.attn_tp_size > dst_attn_tp_size:
+            # Send KVCache from multiple prefill instances to 1 decode instance
+            src_head_start_offset = 0
+            num_heads_to_send = src_heads_per_rank
+            unique_head_idx = local_tp_rank_in_group // src_replication
+            dst_head_start_offset = (
+                unique_head_idx * src_heads_per_rank
+            ) % dst_heads_per_rank
+        else:
+            # Send KVCache from 1 prefill instance to multiple decode instances
+            src_head_start_offset = (
+                dst_tp_rank_in_group * dst_heads_per_rank
+            ) % src_heads_per_rank
+            num_heads_to_send = dst_heads_per_rank
+            dst_head_start_offset = 0
+
+        src_k_ptrs, src_v_ptrs, dst_k_ptrs, dst_v_ptrs, layers_current_pp_stage = (
+            self.get_mha_kv_ptrs_with_pp(self.kv_args.kv_data_ptrs, dst_kv_ptrs)
+        )
+
+        # Calculate precise byte offset and length for the sub-slice within the token
+        src_head_slice_offset = src_head_start_offset * bytes_per_head_slice_to_send
+        dst_head_slice_offset = dst_head_start_offset * bytes_per_head_slice_to_send
+        heads_bytes_per_token_to_send = num_heads_to_send * bytes_per_head_slice_to_send
+
+        # Sanity check: The data sub-slice to be sent should fit into the dst buffer.
+        # This means heads_bytes_per_token_to_send <= (dst_kv_item_len // page_size)
+        if heads_bytes_per_token_to_send > (dst_kv_item_len // page_size):
+            logger.error(
+                f"[{flagcx_session_id}] slice size ({heads_bytes_per_token_to_send}) exceeds "
+                f"target token slot size ({dst_kv_item_len // page_size})"
+            )
+            return -1
+
+        prefill_page_indices = prefill_kv_indices.reshape(-1, 1).astype(np.int64)
+        decode_page_indices = dst_kv_indices.reshape(-1, 1).astype(np.int64)
+        tokens_per_page = np.arange(page_size, dtype=np.int64).reshape(1, -1)
+        bytes_per_token_on_prefill = src_kv_item_len // page_size
+        bytes_per_token_on_decode = dst_kv_item_len // page_size
+        src_token_slot_offsets = (
+            tokens_per_page * bytes_per_token_on_prefill + src_head_slice_offset
+        )
+        dst_token_slot_offsets = (
+            tokens_per_page * bytes_per_token_on_decode + dst_head_slice_offset
+        )
+
+        def process_layer_tp_aware(src_layer_ptr, dst_layer_ptr):
+            src_page_base_addrs = src_layer_ptr + prefill_page_indices * src_kv_item_len
+            dst_page_base_addrs = dst_layer_ptr + decode_page_indices * dst_kv_item_len
+            src_slice_addrs = src_page_base_addrs + src_token_slot_offsets
+            dst_slice_addrs = dst_page_base_addrs + dst_token_slot_offsets
+
+            src_addr_list = src_slice_addrs.reshape(-1).tolist()
+            if not src_addr_list:
+                # Nothing to transfer for this layer.
+                return 0
+            dst_addr_list = dst_slice_addrs.reshape(-1).tolist()
+            total_slices = len(src_addr_list)
+            length_list = [heads_bytes_per_token_to_send] * total_slices
+            return self.engine.batch_transfer_sync(
+                flagcx_session_id, src_addr_list, dst_addr_list, length_list
+            )
+
+        futures = []
+        for i in range(layers_current_pp_stage):
+            futures.append(
+                executor.submit(process_layer_tp_aware, src_k_ptrs[i], dst_k_ptrs[i])
+            )
+        for i in range(layers_current_pp_stage):
+            futures.append(
+                executor.submit(process_layer_tp_aware, src_v_ptrs[i], dst_v_ptrs[i])
+            )
+
+        for future in concurrent.futures.as_completed(futures):
+            status = future.result()
+            if status != 0:
+                for f in futures:
+                    f.cancel()
+                return status
+
+        return 0
+
+    def send_aux(
+        self,
+        req: TransferInfo,
+        prefill_aux_index: int,
+        dst_aux_ptrs: list[int],
+    ):
+
+        transfer_blocks = []
+        prefill_aux_ptrs = self.kv_args.aux_data_ptrs
+        prefill_aux_item_lens = self.kv_args.aux_item_lens
+
+        for i, dst_aux_ptr in enumerate(dst_aux_ptrs):
+            length = prefill_aux_item_lens[i]
+            src_addr = prefill_aux_ptrs[i] + length * prefill_aux_index
+            dst_addr = dst_aux_ptrs[i] + length * req.dst_aux_index
+            transfer_blocks.append((src_addr, dst_addr, length))
+
+        return self._transfer_data(req.flagcx_session_id, transfer_blocks)
+
+    def send_aux_tcp(
+        self,
+        req: TransferInfo,
+        prefill_aux_index: int,
+        dst_aux_ptrs: list[int],
+    ):
+        prefill_aux_ptrs = self.kv_args.aux_data_ptrs
+        prefill_aux_item_lens = self.kv_args.aux_item_lens
+
+        for i in range(len(prefill_aux_ptrs)):
+            length = prefill_aux_item_lens[i]
+            src_addr = prefill_aux_ptrs[i] + length * prefill_aux_index
+            data = AuxDataCodec.serialize_data_from_buffer(src_addr, length)
+
+            self.send_aux_data_to_endpoint(
+                remote=req.endpoint,
+                dst_port=req.dst_port,
+                room=req.room,
+                buffer_index=i,
+                aux_index=req.dst_aux_index,
+                data=data,
+            )
+
+        return 0
+
+    def send_aux_data_to_endpoint(
+        self,
+        remote: str,
+        dst_port: int,
+        room: int,
+        buffer_index: int,
+        aux_index: int,
+        data: bytes,
+    ):
+        na = NetworkAddress(remote, dst_port)
+        socket = self._connect(na.to_tcp(), is_ipv6=na.is_ipv6)
+
+        socket.send_multipart(
+            [
+                FlagcxKVManager.AUX_DATA_HEADER,
+                str(room).encode("ascii"),
+                str(buffer_index).encode("ascii"),
+                str(aux_index).encode("ascii"),
+                struct.pack(">I", len(data)),
+                data,
+            ]
+        )
+
+    def _handle_aux_data(self, msg: List[bytes]):
+        """Handle AUX_DATA messages received by the decode thread."""
+        room = int(msg[1].decode("ascii"))
+        buffer_index = int(msg[2].decode("ascii"))
+        aux_index = int(msg[3].decode("ascii"))
+        data_length = struct.unpack(">I", msg[4])[0]
+        data = msg[5]
+
+        if len(data) != data_length:
+            logger.error(f"AUX_DATA length mismatch for bootstrap_room {room}")
+            return
+
+        AuxDataCodec.deserialize_data_to_buffer(
+            self.kv_args, buffer_index, aux_index, data
+        )
+
+        logger.debug(
+            f"Received AUX_DATA for bootstrap_room {room} with length:{len(data)}"
+        )
+
+    def maybe_send_extra(
+        self,
+        req: TransferInfo,
+        prefill_state_indices: List,
+        executor: concurrent.futures.ThreadPoolExecutor,
+        target_rank_registration_info: Optional[KVArgsRegisterInfo] = None,
+    ):
+        rc = 0
+        state_types = getattr(self.kv_args, "state_types", [])
+        for i, st in enumerate(state_types):
+            indices = (
+                prefill_state_indices[i] if i < len(prefill_state_indices) else None
+            )
+            if indices is None:
+                continue
+            src_data_ptrs = self.kv_args.state_data_ptrs[i]
+            src_item_lens = self.kv_args.state_item_lens[i]
+            src_dim_per_tensor = (
+                self.kv_args.state_dim_per_tensor[i]
+                if i < len(self.kv_args.state_dim_per_tensor)
+                else []
+            )
+            if target_rank_registration_info is not None:
+                dst_data_ptrs = (
+                    target_rank_registration_info.dst_state_data_ptrs[i]
+                    if i < len(target_rank_registration_info.dst_state_data_ptrs)
+                    else []
+                )
+                dst_item_lens = (
+                    target_rank_registration_info.dst_state_item_lens[i]
+                    if i < len(target_rank_registration_info.dst_state_item_lens)
+                    else []
+                )
+                dst_dim_per_tensor = (
+                    target_rank_registration_info.dst_state_dim_per_tensor[i]
+                    if i < len(target_rank_registration_info.dst_state_dim_per_tensor)
+                    else []
+                )
+            else:
+                dst_data_ptrs, dst_item_lens, dst_dim_per_tensor = [], [], []
+            dst_indices = (
+                req.dst_state_indices[i] if i < len(req.dst_state_indices) else []
+            )
+
+            if st == StateType.MAMBA:
+                if (
+                    target_rank_registration_info is not None
+                    and self.attn_tp_size
+                    != target_rank_registration_info.dst_attn_tp_size
+                ):
+                    rc = (
+                        self._send_mamba_state_slice(
+                            req,
+                            indices,
+                            src_data_ptrs,
+                            src_item_lens,
+                            src_dim_per_tensor,
+                            dst_data_ptrs,
+                            dst_indices,
+                            dst_item_lens,
+                            dst_dim_per_tensor,
+                            target_rank_registration_info.dst_tp_rank,
+                            target_rank_registration_info.dst_attn_tp_size,
+                        )
+                        or rc
+                    )
+                else:
+                    rc = (
+                        self._send_mamba_state(
+                            req,
+                            indices,
+                            src_data_ptrs,
+                            src_item_lens,
+                            dst_data_ptrs,
+                            dst_indices,
+                        )
+                        or rc
+                    )
+            elif st in (StateType.SWA, StateType.NSA):
+                if (
+                    target_rank_registration_info is not None
+                    and not self.is_mla_backend
+                    and self.attn_tp_size
+                    != target_rank_registration_info.dst_attn_tp_size
+                ):
+                    raise RuntimeError(
+                        f"PD Disaggregation does NOT support PD different TP sizes for non-MLA {st.upper()} hybrid models yet."
+                    )
+                src_indices = list(indices)
+                dst_indices_local = list(dst_indices)
+                if len(src_indices) > len(dst_indices_local):
+                    logger.warning(
+                        f"len(prefill_state_indices) = {len(src_indices)}, len(dst_state_indices) = {len(dst_indices_local)}"
+                    )
+                    src_indices = src_indices[: len(dst_indices_local)]
+                elif len(src_indices) < len(dst_indices_local):
+                    logger.warning(
+                        f"len(prefill_state_indices) = {len(src_indices)}, len(dst_state_indices) = {len(dst_indices_local)}"
+                    )
+                    dst_indices_local = dst_indices_local[: len(src_indices)]
+                rc = (
+                    self._send_kvcache_generic(
+                        flagcx_session_id=req.flagcx_session_id,
+                        src_data_ptrs=src_data_ptrs,
+                        dst_data_ptrs=dst_data_ptrs,
+                        item_lens=src_item_lens,
+                        prefill_data_indices=np.array(src_indices, dtype=np.int32),
+                        dst_data_indices=np.array(dst_indices_local, dtype=np.int32),
+                        executor=executor,
+                    )
+                    or rc
+                )
+        return rc
+
+    def _send_mamba_state(
+        self,
+        req: TransferInfo,
+        prefill_mamba_index: list,
+        src_state_data_ptrs: list[int],
+        src_state_item_lens: list[int],
+        dst_state_data_ptrs: list[int],
+        dst_mamba_index: list,
+    ):
+        assert len(prefill_mamba_index) == 1, "Mamba should have single state index"
+
+        transfer_blocks = []
+        for i, dst_state_ptr in enumerate(dst_state_data_ptrs):
+            length = src_state_item_lens[i]
+            src_addr = src_state_data_ptrs[i] + length * int(prefill_mamba_index[0])
+            dst_addr = dst_state_ptr + length * int(dst_mamba_index[0])
+            transfer_blocks.append((src_addr, dst_addr, length))
+
+        return self._transfer_data(req.flagcx_session_id, transfer_blocks)
+
+    def _send_mamba_state_slice(
+        self,
+        req: TransferInfo,
+        prefill_mamba_index: list,
+        src_state_data_ptrs: list[int],
+        src_state_item_lens: list[int],
+        src_state_dim_per_tensor: list[int],
+        dst_state_data_ptrs: list[int],
+        dst_mamba_index: list,
+        dst_state_item_lens: list[int],
+        dst_state_dim_per_tensor: list[int],
+        dst_tp_rank: int,
+        dst_attn_tp_size: int,
+    ):
+        """Transfer Mamba states with TP slice support.
+
+        Mamba state layout:
+        - conv_state: [num_layers, size+1, conv_dim/tp, conv_kernel-1]
+        - temporal_state: [num_layers, size+1, num_heads/tp, head_dim, state_size]
+
+        The 3rd dimension is sliced by TP. When prefill and decode have different
+        attn_tp_size, we need to slice the state accordingly.
+        """
+        logger.warning_once(
+            "Using Mamba state slice transfer for different TP sizes between prefill and decode. "
+            f"Prefill attn_tp_size={self.attn_tp_size}, Decode attn_tp_size={dst_attn_tp_size}. "
+            "Performance may be affected."
+        )
+        assert len(prefill_mamba_index) == 1, "Mamba should have single state index"
+
+        # If no dimension info available, fall back to regular transfer
+        if not src_state_dim_per_tensor or not dst_state_dim_per_tensor:
+            return self._send_mamba_state(
+                req,
+                prefill_mamba_index,
+                src_state_data_ptrs,
+                src_state_item_lens,
+                dst_state_data_ptrs,
+                dst_mamba_index,
+            )
+
+        local_tp_rank_in_group = self.kv_args.engine_rank % self.attn_tp_size
+        dst_tp_rank_in_group = dst_tp_rank % dst_attn_tp_size
+
+        transfer_blocks = []
+        for i, dst_state_ptr in enumerate(dst_state_data_ptrs):
+            src_item_len = src_state_item_lens[i]
+            dst_item_len = dst_state_item_lens[i]
+            src_dim = src_state_dim_per_tensor[i]
+            dst_dim = dst_state_dim_per_tensor[i]
+
+            # item_len = dim * trailing_dims_size, so trailing_dims_size = item_len / dim
+            src_bytes_per_dim = src_item_len // src_dim
+            dst_bytes_per_dim = dst_item_len // dst_dim
+
+            if self.attn_tp_size > dst_attn_tp_size:
+                # Multiple prefill ranks send to 1 decode rank
+                src_dim_start = 0
+                num_dims_to_send = src_dim
+                writers_per_decode = self.attn_tp_size // dst_attn_tp_size
+                local_writer_idx = local_tp_rank_in_group % writers_per_decode
+                dst_dim_start = local_writer_idx * src_dim
+            else:
+                # 1 prefill rank sends to multiple decode ranks
+                src_dim_start = (dst_tp_rank_in_group * dst_dim) % src_dim
+                num_dims_to_send = dst_dim
+                dst_dim_start = 0
+
+            src_dim_offset = src_dim_start * src_bytes_per_dim
+            dst_dim_offset = dst_dim_start * dst_bytes_per_dim
+            bytes_to_send = num_dims_to_send * src_bytes_per_dim
+
+            src_addr = (
+                src_state_data_ptrs[i]
+                + src_item_len * int(prefill_mamba_index[0])
+                + src_dim_offset
+            )
+            dst_addr = (
+                dst_state_ptr + dst_item_len * int(dst_mamba_index[0]) + dst_dim_offset
+            )
+
+            transfer_blocks.append((src_addr, dst_addr, bytes_to_send))
+
+        return self._transfer_data(req.flagcx_session_id, transfer_blocks)
+
+    def sync_status_to_decode_endpoint(
+        self, remote: str, dst_port: int, room: int, status: int, prefill_rank: int
+    ):
+        na = NetworkAddress(remote, dst_port)
+        self._connect(na.to_tcp(), is_ipv6=na.is_ipv6).send_multipart(
+            [
+                str(room).encode("ascii"),
+                str(status).encode("ascii"),
+                str(prefill_rank).encode("ascii"),
+            ]
+        )
+
+    def transfer_worker(
+        self,
+        queue: FastQueue,
+        executor: concurrent.futures.ThreadPoolExecutor,
+        staging_buffer=None,
+    ):
+        staging_strategy = None
+
+        while True:
+            try:
+                kv_chunk: TransferKVChunk = queue.get()
+                if (
+                    self.enable_staging
+                    and staging_strategy is None
+                    and staging_buffer is not None
+                ):
+                    staging_strategy = self._try_create_staging_strategy(staging_buffer)
+                reqs_to_be_processed = (
+                    self.transfer_infos[kv_chunk.room].values()
+                    if kv_chunk.room in self.transfer_infos
+                    else []
+                )
+                polls = []
+                dst_ranks_infos = []
+                # Unique id per prefill sender so decode's response set size matches expected_response_num.
+                prefill_unique_rank = (
+                    self.attn_tp_rank * (self.pp_size * self.attn_cp_size)
+                    + self.pp_rank * self.attn_cp_size
+                    + self.attn_cp_rank
+                )
+                # When staging transfer is not yet ready (watermark/allocation pending),
+                # the chunk is re-enqueued and we break out of the req loop to retry later.
+                staging_deferred = False
+                for req in reqs_to_be_processed:
+                    if not req.is_dummy:
+                        # Early exit if the request has failed
+                        with self.session_lock:
+                            if req.flagcx_session_id in self.failed_sessions:
+                                self.record_failure(
+                                    kv_chunk.room,
+                                    f"Decode instance could be dead, remote flagcx session {req.flagcx_session_id} is not alive",
+                                )
+                                self.update_status(kv_chunk.room, KVPoll.Failed)
+                                self.sync_status_to_decode_endpoint(
+                                    req.endpoint,
+                                    req.dst_port,
+                                    req.room,
+                                    KVPoll.Failed,
+                                    prefill_unique_rank,
+                                )
+                                break
+
+                        chunked_dst_kv_indice = req.dst_kv_indices[kv_chunk.index_slice]
+
+                        # NOTE: This is temporarily a workaround to deal with the case where the prefill_kv_indices
+                        # is mismatched with the dst_kv_indices when page size > 1, this should never happen.
+                        if len(chunked_dst_kv_indice) < len(
+                            kv_chunk.prefill_kv_indices
+                        ):
+                            logger.warning(
+                                f"len(chunked_dst_kv_indice) = {len(chunked_dst_kv_indice)}, len(kv_chunk.prefill_kv_indices) = {len(kv_chunk.prefill_kv_indices)}"
+                            )
+                            kv_chunk.prefill_kv_indices = kv_chunk.prefill_kv_indices[
+                                : len(chunked_dst_kv_indice)
+                            ]
+
+                        target_rank_registration_info: KVArgsRegisterInfo = (
+                            self.decode_kv_args_table[req.flagcx_session_id]
+                        )
+                        if len(kv_chunk.prefill_kv_indices) == 0:
+                            ret = 0
+                        elif self.is_mla_backend or (
+                            self.attn_tp_size
+                            == target_rank_registration_info.dst_attn_tp_size
+                        ):
+                            if target_rank_registration_info.enable_hisparse:
+                                ret = self.send_kvcache_hisparse(
+                                    req.flagcx_session_id,
+                                    kv_chunk.prefill_kv_indices,
+                                    target_rank_registration_info.dst_kv_ptrs,
+                                    req.dst_kv_indices,
+                                    kv_chunk.index_slice,
+                                    executor,
+                                )
+                            else:
+                                ret = self.send_kvcache(
+                                    req.flagcx_session_id,
+                                    kv_chunk.prefill_kv_indices,
+                                    target_rank_registration_info.dst_kv_ptrs,
+                                    chunked_dst_kv_indice,
+                                    executor,
+                                )
+                        elif (
+                            self.enable_staging
+                            and staging_strategy is not None
+                            and target_rank_registration_info.staging is not None
+                        ):
+                            ret, deferred = self._do_staging_transfer(
+                                staging_strategy,
+                                kv_chunk,
+                                req,
+                                target_rank_registration_info,
+                                chunked_dst_kv_indice,
+                                executor,
+                                queue,
+                                prefill_unique_rank,
+                            )
+                            if deferred:
+                                staging_deferred = True
+                                # Chunk re-enqueued; stop processing remaining reqs for this chunk
+                                break
+                        else:
+                            ret = self.send_kvcache_slice(
+                                req.flagcx_session_id,
+                                kv_chunk.prefill_kv_indices,
+                                target_rank_registration_info.dst_kv_ptrs,
+                                chunked_dst_kv_indice,
+                                target_rank_registration_info.dst_tp_rank,
+                                target_rank_registration_info.dst_attn_tp_size,
+                                target_rank_registration_info.dst_kv_item_len,
+                                executor,
+                            )
+                        if ret != 0:
+                            with self.session_lock:
+                                self.session_failures[req.flagcx_session_id] += 1
+                                # Failures should never happen if the session is not dead, if the session fails once, mark it as failed
+                                if self.session_failures[req.flagcx_session_id] >= 1:
+                                    self.failed_sessions.add(req.flagcx_session_id)
+                                    logger.error(
+                                        f"Session {req.flagcx_session_id} failed."
+                                    )
+                            self.record_failure(
+                                kv_chunk.room,
+                                f"Failed to send kv chunk of {kv_chunk.room} to "
+                                f"{NetworkAddress(req.endpoint, req.dst_port).to_host_port_str()}",
+                            )
+                            self.update_status(kv_chunk.room, KVPoll.Failed)
+                            self.sync_status_to_decode_endpoint(
+                                req.endpoint,
+                                req.dst_port,
+                                req.room,
+                                KVPoll.Failed,
+                                prefill_unique_rank,
+                            )
+                            break
+
+                        if kv_chunk.is_last_chunk:
+                            if kv_chunk.state_indices:
+                                self.maybe_send_extra(
+                                    req,
+                                    kv_chunk.state_indices,
+                                    executor,
+                                    target_rank_registration_info,
+                                )
+
+                            # Only the last chunk we need to send the aux data
+                            ret = self.send_aux(
+                                req,
+                                kv_chunk.prefill_aux_index,
+                                target_rank_registration_info.dst_aux_ptrs,
+                            )
+                            polls.append(True if ret == 0 else False)
+                            dst_ranks_infos.append(
+                                (req.endpoint, req.dst_port, req.room)
+                            )
+
+                            # Only sync status when all the dst ranks have received the kvcache
+                            if len(polls) == req.required_dst_info_num:
+                                status = KVPoll.Success if all(polls) else KVPoll.Failed
+                                self.update_status(req.room, status)
+                                for endpoint, dst_port, room in dst_ranks_infos:
+                                    self.sync_status_to_decode_endpoint(
+                                        endpoint,
+                                        dst_port,
+                                        room,
+                                        status,
+                                        prefill_unique_rank,
+                                    )
+                    else:
+                        # Dummy request means the decode instance is not used, so its status can be marked as success directly
+                        # Dummy request does not need to sync status to decode endpoint
+                        if kv_chunk.is_last_chunk and req.room in self.request_status:
+                            self.update_status(req.room, KVPoll.Success)
+
+                if staging_deferred:
+                    continue
+
+                if (
+                    kv_chunk.room not in self.request_status
+                    or self.check_status(kv_chunk.room) == KVPoll.Success
+                ):
+                    if kv_chunk.room in self.transfer_infos:
+                        self.transfer_infos.pop(kv_chunk.room)
+                    self.req_to_decode_prefix_len.pop(kv_chunk.room, None)
+
+            except Exception as e:
+                # NOTE(shangming): Remove this when we make sure the transfer thread is bug-free
+                raise RuntimeError(
+                    f"Transfer thread failed because of {e}. Prefill instance with bootstrap_port={self.bootstrap_port} is dead."
+                )
+
+    def start_prefill_thread(self):
+        def bootstrap_thread():
+            """This thread recvs pre-alloc notification from the decode engine"""
+            # KVPoll.Bootstrapping -> KVPoll.WaitingForInput
+            while True:
+                waiting_req_bytes = self.server_socket.recv_multipart()
+                room = waiting_req_bytes[0].decode("ascii")
+                # Staging: decode reports consumption watermark back to prefill
+                if room == "WATERMARK":
+                    from sglang.srt.disaggregation.common.staging_handler import (
+                        handle_watermark_msg,
+                    )
+
+                    handle_watermark_msg(self._staging_ctx, waiting_req_bytes)
+                    continue
+                # Staging: decode replies with allocated staging offset
+                if room == "STAGING_RSP":
+                    from sglang.srt.disaggregation.common.staging_handler import (
+                        handle_staging_rsp,
+                    )
+
+                    handle_staging_rsp(waiting_req_bytes, self.transfer_infos)
+                    continue
+                flagcx_session_id = waiting_req_bytes[3].decode("ascii")
+                if room == "None":
+                    self.decode_kv_args_table[flagcx_session_id] = (
+                        KVArgsRegisterInfo.from_zmq(waiting_req_bytes)
+                    )
+                    with self.session_lock:
+                        if flagcx_session_id in self.failed_sessions:
+                            self.failed_sessions.remove(flagcx_session_id)
+                        if flagcx_session_id in self.session_failures:
+                            del self.session_failures[flagcx_session_id]
+                    logger.debug(
+                        f"Register KVArgs from {flagcx_session_id} successfully"
+                    )
+                    continue
+                else:
+                    required_dst_info_num = int(waiting_req_bytes[7].decode("ascii"))
+                    room = int(room)
+                    if room not in self.transfer_infos:
+                        self.transfer_infos[room] = {}
+
+                    self.transfer_infos[room][flagcx_session_id] = (
+                        TransferInfo.from_zmq(waiting_req_bytes)
+                    )
+                    # NOTE: after bootstrapping we can mark the req as waiting for input
+                    if len(self.transfer_infos[room]) == required_dst_info_num:
+                        self.req_to_decode_prefix_len[room] = next(
+                            (
+                                info.decode_prefix_len
+                                for info in self.transfer_infos[room].values()
+                                if info.decode_prefix_len is not None
+                            ),
+                            0,
+                        )
+                        self.update_status(room, KVPoll.WaitingForInput)
+
+        threading.Thread(target=bootstrap_thread).start()
+
+    def start_decode_thread(self):
+        def decode_thread():
+            while True:
+                msg = self.server_socket.recv_multipart()
+                if msg[0] == FlagcxKVManager.AUX_DATA_HEADER:
+                    self._handle_aux_data(msg)
+                    continue
+
+                # Staging: prefill notifies a chunk written to staging buffer
+                if msg[0] == b"CHUNK_READY":
+                    room = int(msg[1].decode("ascii"))
+                    chunk_idx = int(msg[2].decode("ascii"))
+                    page_start = int(msg[3].decode("ascii"))
+                    num_pages = int(msg[4].decode("ascii"))
+                    session_id = msg[5].decode("ascii")
+                    handler = self._staging_handler
+                    assert (
+                        handler is not None
+                    ), "CHUNK_READY received before staging handler initialized"
+                    handler.handle_chunk_arrived(
+                        room,
+                        chunk_idx,
+                        page_start,
+                        num_pages,
+                        session_id,
+                        self._chunk_writer_counts,
+                    )
+                    continue
+
+                # Staging: prefill pre-requests staging allocation before forward
+                if msg[0] == b"STAGING_REQ":
+                    self._handle_staging_req(msg)
+                    continue
+
+                bootstrap_room, status, prefill_rank = msg
+                status = int(status.decode("ascii"))
+                bootstrap_room = int(bootstrap_room.decode("ascii"))
+                prefill_rank = int(prefill_rank.decode("ascii"))
+
+                if status == KVPoll.Success:
+                    if bootstrap_room in self.request_status:
+                        self.prefill_response_tracker[bootstrap_room].add(prefill_rank)
+                        expected_response_num = (
+                            self.required_prefill_response_num_table[bootstrap_room]
+                        )
+                        arrived_response_num = len(
+                            self.prefill_response_tracker[bootstrap_room]
+                        )
+                        if arrived_response_num == expected_response_num:
+                            if self.enable_staging:
+                                handler = self._staging_handler
+                                if handler.is_staging_room(bootstrap_room):
+                                    handler.submit_last_scatter_async(bootstrap_room)
+                                self._chunk_writer_counts.pop(bootstrap_room, None)
+                            self.update_status(bootstrap_room, KVPoll.Success)
+                elif status == KVPoll.Failed:
+                    self.record_failure(
+                        bootstrap_room,
+                        "Failed to get kvcache from prefill instance, it might be dead",
+                    )
+                    self.update_status(bootstrap_room, status)
+
+        def heartbeat_checker():
+            while True:
+                time.sleep(self.heartbeat_interval)
+                with self.connection_lock:
+                    addresses = list(self.prefill_info_table.keys())
+
+                for bootstrap_addr in addresses:
+                    session = None
+                    try:
+                        with self.session_pool_lock:
+                            session = self.session_pool[bootstrap_addr]
+                        response = session.get(
+                            f"http://{bootstrap_addr}/health",
+                            timeout=(2, 3),
+                            headers={"Connection": "keep-alive"},
+                        )
+                        if response.status_code == 200:
+                            self.heartbeat_failures[bootstrap_addr] = 0
+
+                            current_rooms = self.addr_to_rooms_tracker[
+                                bootstrap_addr
+                            ].copy()
+
+                            for bootstrap_room in current_rooms:
+                                # Remove KVPoll.Success requests from the tracker
+                                if bootstrap_room not in self.request_status:
+                                    self.addr_to_rooms_tracker[bootstrap_addr].discard(
+                                        bootstrap_room
+                                    )
+                        else:
+                            logger.info(
+                                f"Attempting to reconnect to {bootstrap_addr}..."
+                            )
+                            self.heartbeat_failures[bootstrap_addr] = (
+                                self.heartbeat_failures.get(bootstrap_addr, 0) + 1
+                            )
+                            with self.session_pool_lock:
+                                if bootstrap_addr in self.session_pool:
+                                    del self.session_pool[bootstrap_addr]
+                    except Exception:
+                        logger.info(f"Attempting to reconnect to {bootstrap_addr}...")
+                        self.heartbeat_failures[bootstrap_addr] = (
+                            self.heartbeat_failures.get(bootstrap_addr, 0) + 1
+                        )
+
+                    if (
+                        self.heartbeat_failures.get(bootstrap_addr, 0)
+                        >= self.max_failures
+                    ):
+                        self._handle_node_failure(bootstrap_addr)
+                        with self.session_pool_lock:
+                            if bootstrap_addr in self.session_pool:
+                                del self.session_pool[bootstrap_addr]
+
+        threading.Thread(target=decode_thread).start()
+        threading.Thread(target=heartbeat_checker).start()
+
+    def add_transfer_request(
+        self,
+        bootstrap_room: int,
+        kv_indices: npt.NDArray[np.int32],
+        index_slice: slice,
+        is_last_chunk: bool,
+        aux_index: Optional[int] = None,
+        state_indices: Optional[List] = None,
+    ):
+        assert self.disaggregation_mode == DisaggregationMode.PREFILL
+        assert not is_last_chunk or (is_last_chunk and aux_index is not None)
+
+        if (
+            bootstrap_room not in self.request_status
+            or self.check_status(bootstrap_room) == KVPoll.Failed
+        ):
+            logger.debug(
+                "Request with bootstrap_room=%s already failed", bootstrap_room
+            )
+            return
+
+        if bootstrap_room not in self.transfer_infos:
+            # This means that the current rank is a dummy rank for this request,
+            # and it has already been marked as success, so there is no need to
+            # add further chunks into the transfer queue.
+            return
+
+        # NOTE(shangming): sharding according to the dst_infos to make sure
+        # requests with the same dst_sessions will be added into the same
+        # queue, which enables early abort with failed sessions.
+        dst_infos = self.transfer_infos[bootstrap_room].keys()
+        session_port_sum = sum(int(session.rsplit(":", 1)[1]) for session in dst_infos)
+        shard_idx = session_port_sum % len(self.transfer_queues)
+
+        self.transfer_queues[shard_idx].put(
+            TransferKVChunk(
+                room=bootstrap_room,
+                prefill_kv_indices=kv_indices,
+                index_slice=index_slice,
+                is_last_chunk=is_last_chunk,
+                prefill_aux_index=aux_index,
+                state_indices=state_indices,
+            )
+        )
+
+    def get_session_id(self):
+        return self.engine.get_session_id()
+
+    def _handle_node_failure(self, failed_bootstrap_addr):
+        with self.connection_lock:
+            keys_to_remove = [
+                k for k in self.connection_pool if k.startswith(failed_bootstrap_addr)
+            ]
+            for k in keys_to_remove:
+                del self.connection_pool[k]
+
+            possible_affected_rooms = self.addr_to_rooms_tracker.get(
+                failed_bootstrap_addr, []
+            )
+            self.prefill_info_table.pop(failed_bootstrap_addr, None)
+            self.addr_to_rooms_tracker.pop(failed_bootstrap_addr, None)
+
+        # Report the requests associated with the failed bootstrap addr and mark their status as KVPoll.Failed
+        affected_rooms = []
+        for room in possible_affected_rooms:
+            if (
+                room in self.request_status
+                and self.check_status(room) != KVPoll.Success
+            ):
+                self.record_failure(
+                    room,
+                    f"Losing connection with prefill instance (bootstrap_addr: {failed_bootstrap_addr})",
+                )
+                self.update_status(room, KVPoll.Failed)
+                affected_rooms.append(room)
+        logger.error(
+            f"Losing connection with prefill instance (bootstrap_addr: {failed_bootstrap_addr}), {len(affected_rooms)} requests affected"
+        )
+
+
+class FlagcxKVSender(CommonKVSender):
+
+    def __init__(
+        self,
+        mgr: FlagcxKVManager,
+        bootstrap_addr: str,
+        bootstrap_room: int,
+        dest_tp_ranks: List[int],
+        pp_rank: int,
+    ):
+        super().__init__(mgr, bootstrap_addr, bootstrap_room, dest_tp_ranks, pp_rank)
+        self.conclude_state = None
+        self.init_time = time.time()
+
+    def pop_decode_prefix_len(self) -> int:
+        return self.kv_mgr.req_to_decode_prefix_len.pop(self.bootstrap_room, 0)
+
+    def should_send_kv_chunk(self, num_pages: int, last_chunk: bool) -> bool:
+        return num_pages > 0 or last_chunk
+
+    def send(
+        self,
+        kv_indices: npt.NDArray[np.int32],
+        state_indices: Optional[List] = None,
+    ):
+        index_slice = slice(self.curr_idx, self.curr_idx + len(kv_indices))
+        self.curr_idx += len(kv_indices)
+        is_last_chunk = self.curr_idx == self.num_kv_indices
+
+        # Special handling for cp
+        if self.kv_mgr.enable_all_cp_ranks_for_transfer:
+            kv_indices, index_slice = filter_kv_indices_for_cp_rank(
+                self.kv_mgr,
+                kv_indices,
+                index_slice,
+            )
+        elif self.kv_mgr.is_dummy_cp_rank:
+            if not is_last_chunk:
+                return
+            else:
+                self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Success)
+                return
+
+        if not is_last_chunk:
+            self.kv_mgr.add_transfer_request(
+                self.bootstrap_room,
+                kv_indices,
+                index_slice,
+                False,
+            )
+        else:
+            self.kv_mgr.add_transfer_request(
+                self.bootstrap_room,
+                kv_indices,
+                index_slice,
+                True,
+                aux_index=self.aux_index,
+                state_indices=state_indices,
+            )
+        self._record_transfer_indices(kv_indices, state_indices)
+
+    def poll(self) -> KVPoll:
+        if self.conclude_state is None:
+            status = self.kv_mgr.check_status(self.bootstrap_room)
+            if status in (KVPoll.Success, KVPoll.Failed):
+                self.conclude_state = status
+            elif status == KVPoll.Bootstrapping:
+                if self.init_time is not None:
+                    now = time.time()
+                    elapsed = now - self.init_time
+                    if elapsed >= self.kv_mgr.bootstrap_timeout:
+                        logger.warning_once(
+                            "Some requests timed out when bootstrapping, "
+                            "which means prefill instances fail to receive the KV indices from the decode instance of this request. "
+                            "If a greater mean TTFT is acceptable, you can 'export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=600' (10 minutes) to relax the timeout condition. "
+                        )
+                        self.kv_mgr.record_failure(
+                            self.bootstrap_room,
+                            f"Request {self.bootstrap_room} timed out after {elapsed:.1f}s in KVPoll.Bootstrapping",
+                        )
+                        self.conclude_state = KVPoll.Failed
+                        return KVPoll.Failed
+
+            return status
+        else:
+            return self.conclude_state
+
+    def failure_exception(self):
+        # Explicitly set the status to failure since this request has failed in another rank
+        if self.conclude_state is None:
+            self.conclude_state = KVPoll.Failed
+
+        self.clear()
+
+        with self.kv_mgr.failure_lock:
+            failure_reason = self.kv_mgr.failure_records.pop(
+                self.bootstrap_room, "Failed due to an unknown reason from another rank"
+            )
+        raise KVTransferError(self.bootstrap_room, failure_reason)
+
+
+class FlagcxKVReceiver(CommonKVReceiver):
+    def __init__(
+        self,
+        mgr: FlagcxKVManager,
+        bootstrap_addr: str,
+        bootstrap_room: Optional[int] = None,
+    ):
+        self.session_id = mgr.get_session_id()
+        self.init_time = None
+        super().__init__(mgr, bootstrap_addr, bootstrap_room)
+
+    def _register_kv_args(self):
+        for bootstrap_info in self.bootstrap_infos:
+            packed_kv_data_ptrs = b"".join(
+                struct.pack("Q", ptr) for ptr in self.kv_mgr.kv_args.kv_data_ptrs
+            )
+            packed_aux_data_ptrs = b"".join(
+                struct.pack("Q", ptr) for ptr in self.kv_mgr.kv_args.aux_data_ptrs
+            )
+            packed_state_data_ptrs = pack_int_lists(
+                self.kv_mgr.kv_args.state_data_ptrs, "Q"
+            )
+            packed_state_item_lens = pack_int_lists(
+                self.kv_mgr.kv_args.state_item_lens, "I"
+            )
+            packed_state_dim_per_tensor = pack_int_lists(
+                getattr(self.kv_mgr.kv_args, "state_dim_per_tensor", []) or [], "I"
+            )
+            # Note(shangming): No need to add pp rank here since decode pp size should be equal to prefill pp size or 1
+            tp_rank = self.kv_mgr.kv_args.engine_rank
+            kv_item_len = self.kv_mgr.kv_args.kv_item_lens[0]
+            dst_tp_rank = str(tp_rank).encode("ascii")
+            dst_attn_tp_size = str(self.kv_mgr.attn_tp_size).encode("ascii")
+            dst_kv_item_len = str(kv_item_len).encode("ascii")
+            enable_hisparse = b"1" if self.kv_mgr.server_args.enable_hisparse else b"0"
+
+            if (
+                self.kv_mgr.enable_staging
+                and self.kv_mgr._staging_ctx.allocator is not None
+            ):
+                _alloc = self.kv_mgr._staging_ctx.allocator
+                packed_staging_base_ptr = struct.pack("Q", _alloc.get_base_ptr())
+                staging_total_size_str = str(_alloc.get_total_size()).encode("ascii")
+            else:
+                packed_staging_base_ptr = b""
+                staging_total_size_str = b""
+
+            sock, lock = self._connect_to_bootstrap_server(bootstrap_info)
+            with lock:
+                sock.send_multipart(
+                    [
+                        "None".encode("ascii"),
+                        self.kv_mgr.local_ip.encode("ascii"),
+                        str(self.kv_mgr.rank_port).encode("ascii"),
+                        self.session_id.encode("ascii"),
+                        packed_kv_data_ptrs,
+                        packed_aux_data_ptrs,
+                        packed_state_data_ptrs,
+                        dst_tp_rank,
+                        dst_attn_tp_size,
+                        dst_kv_item_len,
+                        packed_state_item_lens,
+                        packed_state_dim_per_tensor,
+                        enable_hisparse,
+                        packed_staging_base_ptr,
+                        staging_total_size_str,
+                    ]
+                )
+
+    def init(
+        self,
+        prefill_dp_rank: int,
+    ):
+        super().init(prefill_dp_rank)
+
+    def send_metadata(
+        self,
+        kv_indices: npt.NDArray[np.int32],
+        aux_index: Optional[int] = None,
+        state_indices: Optional[List] = None,
+        decode_prefix_len: Optional[int] = None,
+    ):
+        if self.bootstrap_infos is None:
+            self.kv_mgr.record_failure(
+                self.bootstrap_room,
+                f"Could not fetch prefill parallel info from bootstrap_addr: {self.bootstrap_addr}",
+            )
+            self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
+            return
+
+        if (
+            self.kv_mgr.enable_staging
+            and self.kv_mgr._staging_ctx.allocator is not None
+        ):
+            self.chunk_staging_infos = []
+            self.kv_mgr.register_staging_room_bootstrap(
+                self.bootstrap_room, self.bootstrap_infos, self
+            )
+
+        for bootstrap_info in self.bootstrap_infos:
+            sock, lock = self._connect_to_bootstrap_server(bootstrap_info)
+            is_dummy = bootstrap_info["is_dummy"]
+
+            with lock:
+                sock.send_multipart(
+                    [
+                        str(self.bootstrap_room).encode("ascii"),
+                        self.kv_mgr.local_ip.encode("ascii"),
+                        str(self.kv_mgr.rank_port).encode("ascii"),
+                        self.session_id.encode("ascii"),
+                        kv_indices.tobytes() if not is_dummy else b"",
+                        str(aux_index).encode("ascii") if not is_dummy else b"",
+                        (
+                            pack_int_lists(state_indices, "i")
+                            if not is_dummy and state_indices
+                            else b""
+                        ),
+                        str(self.required_dst_info_num).encode("ascii"),
+                        str(decode_prefix_len or 0).encode("ascii"),
+                    ]
+                )
+        self.init_time = time.time()
+
+    def poll(self) -> KVPoll:
+        if self.conclude_state is None:
+            status = self.kv_mgr.check_status(self.bootstrap_room)
+            if status in (KVPoll.Success, KVPoll.Failed):
+                self.conclude_state = status
+            elif status == KVPoll.WaitingForInput:
+                if self.init_time is not None:
+                    now = time.time()
+                    elapsed = now - self.init_time
+                    if elapsed >= self.kv_mgr.waiting_timeout:
+                        logger.warning_once(
+                            "Some requests fail to receive KV Cache transfer done signal after bootstrapping. "
+                            "If a greater mean TTFT is acceptable, you can 'export SGLANG_DISAGGREGATION_WAITING_TIMEOUT=600' (10 minutes) to relax the timeout condition. "
+                        )
+                        self.kv_mgr.record_failure(
+                            self.bootstrap_room,
+                            f"Request {self.bootstrap_room} timed out after {elapsed:.1f}s in KVPoll.WaitingForInput",
+                        )
+                        self.conclude_state = KVPoll.Failed
+                        return KVPoll.Failed
+
+            return status
+
+        else:
+            return self.conclude_state
+
+    def failure_exception(self):
+        # Explicitly set the status to failure since this request has failed in another rank
+        if self.conclude_state is None:
+            self.conclude_state = KVPoll.Failed
+
+        self.clear()
+
+        with self.kv_mgr.failure_lock:
+            failure_reason = self.kv_mgr.failure_records.pop(
+                self.bootstrap_room, "Failed due to an unknown reason from another rank"
+            )
+        raise KVTransferError(self.bootstrap_room, failure_reason)
+
+
+class FlagcxKVBootstrapServer(CommonKVBootstrapServer):
+    pass

--- a/sglang_fl/disaggregation/patch.py
+++ b/sglang_fl/disaggregation/patch.py
@@ -17,9 +17,7 @@ import sys
 
 logger = logging.getLogger(__name__)
 
-# NOTE: if SGLang grows a new caller, add it here. The unit test
-# ``test_alias_modules_cover_all_importers`` scans the installed SGLang source
-# and fails when this tuple drifts, rather than silently losing the patch.
+# NOTE: if SGLang grows a new caller, add it here.
 _ALIAS_MODULES = (
     "sglang.srt.disaggregation.utils",
     "sglang.srt.disaggregation.prefill",

--- a/sglang_fl/disaggregation/patch.py
+++ b/sglang_fl/disaggregation/patch.py
@@ -1,0 +1,145 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+
+# NOTE: if SGLang grows a new caller, add it here. The unit test
+# ``test_alias_modules_cover_all_importers`` scans the installed SGLang source
+# and fails when this tuple drifts, rather than silently losing the patch.
+_ALIAS_MODULES = (
+    "sglang.srt.disaggregation.utils",
+    "sglang.srt.disaggregation.prefill",
+    "sglang.srt.disaggregation.decode",
+    "sglang.srt.managers.disagg_service",
+)
+
+_BACKEND_NAME = "flagcx"
+
+# Marker attribute set on our wrapper so re-applying is a no-op instead of
+# stacking wrappers on top of each other.
+_PATCH_MARKER = "_sglang_fl_flagcx_patched"
+
+
+def _inject_enum_member(cls, name: str, value):
+    """Add a new member to an already-created Enum class at runtime.
+
+    ``TransferBackend(server_args.disaggregation_transfer_backend)`` is called
+    in scheduler.py / disagg_service.py / multi_tokenizer_mixin.py and raises
+    ValueError for unknown values, so the member has to really exist.
+
+    Mutates the private lookup tables that ``EnumMeta`` uses. ``setattr`` on an
+    Enum class is blocked ("Cannot reassign members"), hence
+    ``type.__setattr__``. Verified to keep identity, ``isinstance`` and
+    dict-key semantics intact on CPython 3.8-3.11.
+    """
+    member = object.__new__(cls)
+    member._name_ = name
+    member._value_ = value
+    cls._value2member_map_[value] = member
+    cls._member_map_[name] = member
+    cls._member_names_.append(name)
+    type.__setattr__(cls, name, member)
+    return member
+
+
+def _add_backend_choice() -> None:
+    """Make ``--disaggregation-transfer-backend flagcx`` a valid CLI value."""
+    from sglang.srt.server_args import (
+        DISAGG_TRANSFER_BACKEND_CHOICES,
+        add_disagg_transfer_backend_choices,
+    )
+
+    if _BACKEND_NAME not in DISAGG_TRANSFER_BACKEND_CHOICES:
+        add_disagg_transfer_backend_choices([_BACKEND_NAME])
+
+
+def _add_enum_member() -> None:
+    """Make ``TransferBackend("flagcx")`` resolve instead of raising."""
+    from sglang.srt.disaggregation.utils import TransferBackend
+
+    if _BACKEND_NAME not in TransferBackend._value2member_map_:
+        # Member *name* is upper-case (TransferBackend.FLAGCX), matching the
+        # other members; the *value* is the CLI string.
+        _inject_enum_member(TransferBackend, _BACKEND_NAME.upper(), _BACKEND_NAME)
+
+
+def _flagcx_class_mapping(class_type):
+    """Resolve a KVClassType to the FlagCX implementation.
+
+    Imports ``sglang_fl.disaggregation`` lazily: that module loads the FlagCX
+    shared library, which must not be a hard requirement for users who never
+    select this backend.
+    """
+    from sglang.srt.disaggregation.base import KVArgs
+    from sglang.srt.disaggregation.utils import KVClassType
+
+    from sglang_fl.disaggregation import (
+        FlagcxKVBootstrapServer,
+        FlagcxKVManager,
+        FlagcxKVReceiver,
+        FlagcxKVSender,
+    )
+
+    return {
+        KVClassType.KVARGS: KVArgs,
+        KVClassType.MANAGER: FlagcxKVManager,
+        KVClassType.SENDER: FlagcxKVSender,
+        KVClassType.RECEIVER: FlagcxKVReceiver,
+        KVClassType.BOOTSTRAP_SERVER: FlagcxKVBootstrapServer,
+    }.get(class_type)
+
+
+def _patch_get_kv_class() -> None:
+    """Wrap ``get_kv_class`` on the defining module and every alias site."""
+    from sglang.srt.disaggregation import utils as _utils
+
+    original = _utils.get_kv_class
+    if getattr(original, _PATCH_MARKER, False):
+        return  # already wrapped
+
+    def get_kv_class(transfer_backend, class_type):
+        if getattr(transfer_backend, "value", None) == _BACKEND_NAME:
+            return _flagcx_class_mapping(class_type)
+        return original(transfer_backend, class_type)
+
+    get_kv_class.__doc__ = original.__doc__
+    get_kv_class.__wrapped__ = original
+    setattr(get_kv_class, _PATCH_MARKER, True)
+
+    patched = []
+    for module_name in _ALIAS_MODULES:
+        # Only touch modules that are already imported -- importing them here
+        # just to patch would perturb SGLang's import order. The defining
+        # module is patched unconditionally below, so any module imported
+        # *later* naturally binds the wrapper.
+        module = sys.modules.get(module_name)
+        if module is not None and hasattr(module, "get_kv_class"):
+            module.get_kv_class = get_kv_class
+            patched.append(module_name)
+
+    logger.debug("flagcx get_kv_class patched on: %s", patched)
+
+
+def apply_disaggregation_patch() -> None:
+    """Register the FlagCX transfer backend with SGLang. Idempotent."""
+    _add_backend_choice()
+    _add_enum_member()
+    _patch_get_kv_class()
+    logger.info(
+        "FlagCX PD disaggregation backend registered "
+        "(--disaggregation-transfer-backend flagcx)"
+    )

--- a/sglang_fl/disaggregation/stats.py
+++ b/sglang_fl/disaggregation/stats.py
@@ -1,0 +1,173 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Prometheus metrics for FlagCX KV cache transfers.
+
+Counters carry the volume series (use ``rate()``/``increase()`` in PromQL);
+histograms carry the per-transfer distributions:
+
+  sglang:flagcx_total_bytes_transferred -> rate() = KV transfer bytes/s
+  sglang:flagcx_total_xfer_time_seconds -> ratio with the above gives
+                                           effective bytes/s while the link
+                                           was actually busy
+  sglang:flagcx_transfers               -> rate() = transfers/s
+  sglang:flagcx_total_descriptors       -> descriptors/s
+  sglang:flagcx_num_failed_transfers    -> P-side write failures
+  sglang:flagcx_num_failed_recvs        -> D-side side-channel failures
+  sglang:flagcx_num_kv_expired_reqs     -> requests timed out before transfer
+  sglang:flagcx_xfer_time_seconds       -> per-transfer latency histogram
+  sglang:flagcx_bytes_transferred       -> per-transfer size histogram
+  sglang:flagcx_num_descriptors         -> per-transfer descriptor count
+"""
+
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
+
+# Uniform 2KB to 16GB range, matching the vLLM connector.
+_BYTES_BUCKETS = [2 ** (10 + i) for i in range(1, 25, 2)]
+_TIME_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.2, 0.3, 0.5, 0.75, 1.0, 5.0]
+_DESC_BUCKETS = [
+    10, 20, 30, 50, 75, 100, 200, 400, 1000, 2000, 4000, 10000, 20000, 50000,
+]
+
+_lock = threading.Lock()
+_metrics = None
+_labelnames = None
+
+
+class _FlagcxMetrics:
+    """Holds the registered collectors. Built once, on first record_* call."""
+
+    def __init__(self, labelnames):
+        from prometheus_client import Counter, Histogram
+
+        def counter(name, doc):
+            return Counter(name, doc, labelnames)
+
+        def histogram(name, doc, buckets):
+            return Histogram(name, doc, labelnames, buckets=buckets)
+
+        self.total_bytes = counter(
+            "sglang:flagcx_total_bytes_transferred",
+            "Total bytes transferred by FlagCX KV Cache transfers.",
+        )
+        self.total_time = counter(
+            "sglang:flagcx_total_xfer_time_seconds",
+            "Total time spent inside FlagCX KV Cache transfers. Divide "
+            "sglang:flagcx_total_bytes_transferred_total by this to get "
+            "effective link throughput.",
+        )
+        self.transfers = counter(
+            "sglang:flagcx_transfers",
+            "Number of successful FlagCX KV Cache transfers.",
+        )
+        self.total_descriptors = counter(
+            "sglang:flagcx_total_descriptors",
+            "Total number of descriptors written by FlagCX KV Cache transfers.",
+        )
+        self.failed_transfers = counter(
+            "sglang:flagcx_num_failed_transfers",
+            "Number of failed FlagCX KV Cache transfers. "
+            "NOTE: This metric is tracked on the P instance.",
+        )
+        self.failed_recvs = counter(
+            "sglang:flagcx_num_failed_recvs",
+            "Number of failed FlagCX KV Cache receives (side-channel or "
+            "transfer errors reported to D). "
+            "NOTE: This metric is tracked on the D instance.",
+        )
+        self.kv_expired_reqs = counter(
+            "sglang:flagcx_num_kv_expired_reqs",
+            "Number of requests that timed out before their KV was transferred.",
+        )
+        self.xfer_time = histogram(
+            "sglang:flagcx_xfer_time_seconds",
+            "Histogram of transfer duration for FlagCX KV Cache transfers.",
+            _TIME_BUCKETS,
+        )
+        self.bytes_transferred = histogram(
+            "sglang:flagcx_bytes_transferred",
+            "Histogram of bytes transferred per FlagCX KV Cache transfer.",
+            _BYTES_BUCKETS,
+        )
+        self.num_descriptors = histogram(
+            "sglang:flagcx_num_descriptors",
+            "Histogram of number of descriptors per FlagCX KV Cache transfer.",
+            _DESC_BUCKETS,
+        )
+
+
+def _get(labels):
+    """Return the collectors bound to `labels`, registering them on first call.
+
+    Returns None if prometheus_client is unavailable, registration failed, or a
+    later caller passed a different label set -- a metrics problem must never
+    take down a KV transfer.
+    """
+    global _metrics, _labelnames
+    if _metrics is None:
+        with _lock:
+            if _metrics is None:
+                try:
+                    _labelnames = sorted(labels)
+                    _metrics = _FlagcxMetrics(_labelnames)
+                except Exception:
+                    logger.warning(
+                        "FlagCX metrics unavailable; transfers continue unmeasured.",
+                        exc_info=True,
+                    )
+                    _metrics = False
+    if not _metrics:
+        return None
+    if sorted(labels) != _labelnames:
+        logger.warning(
+            "FlagCX metrics label mismatch: registered %s, got %s; sample dropped.",
+            _labelnames,
+            sorted(labels),
+        )
+        return None
+    return _metrics
+
+
+def record_transfer(duration_s, total_bytes, num_descs, labels):
+    """One successful batch transfer: advance counters and the histograms."""
+    m = _get(labels)
+    if m is None:
+        return
+    m.total_bytes.labels(**labels).inc(total_bytes)
+    m.total_time.labels(**labels).inc(duration_s)
+    m.transfers.labels(**labels).inc()
+    m.total_descriptors.labels(**labels).inc(num_descs)
+    m.xfer_time.labels(**labels).observe(duration_s)
+    m.bytes_transferred.labels(**labels).observe(total_bytes)
+    m.num_descriptors.labels(**labels).observe(num_descs)
+
+
+def record_failed_transfer(labels):
+    m = _get(labels)
+    if m is not None:
+        m.failed_transfers.labels(**labels).inc()
+
+
+def record_failed_recv(labels):
+    m = _get(labels)
+    if m is not None:
+        m.failed_recvs.labels(**labels).inc()
+
+
+def record_kv_expired_req(labels):
+    m = _get(labels)
+    if m is not None:
+        m.kv_expired_reqs.labels(**labels).inc()

--- a/sglang_fl/disaggregation/transfer_engine.py
+++ b/sglang_fl/disaggregation/transfer_engine.py
@@ -14,7 +14,6 @@
 
 import logging
 import threading
-import torch
 
 from typing import List, Optional
 from sglang.srt.platforms import current_platform

--- a/sglang_fl/disaggregation/transfer_engine.py
+++ b/sglang_fl/disaggregation/transfer_engine.py
@@ -1,0 +1,188 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import threading
+import torch
+
+from typing import List, Optional
+from sglang.srt.platforms import current_platform
+from sglang.srt.utils.network import NetworkAddress
+
+logger = logging.getLogger(__name__)
+
+# Module-level shared engine instance, set by init_flagcx_transfer_engine().
+_flagcx_transfer_engine: Optional["FlagCXTransferEngine"] = None
+
+
+class FlagCXTransferEngine:
+    """Shared FlagCX transfer engine for one-sided RDMA KV transfer.
+
+    Addresses a remote peer by a ``"host:port"`` session string and performs
+    synchronous batched one-sided writes into the peer's registered memory.
+    """
+
+    def __init__(
+        self,
+        hostname: str,
+        gpu_id: Optional[int] = None,
+        ib_device: Optional[str] = None,
+    ):
+        # Reuse the collective communicator's FLAGCX_PATH/sys.path handling so
+        # there is a single place that knows how to locate the FlagCX wrapper.
+        from sglang_fl.distributed.device_communicators.flagcx import (
+            _import_flagcx_wrapper,
+        )
+
+        flagcx_library = _import_flagcx_wrapper()[0]
+
+        self.hostname = hostname
+        self.gpu_id = gpu_id if gpu_id is not None else 0
+        self.ib_device = ib_device
+        current_platform.set_device(current_platform.get_device(self.gpu_id))
+        self.flagcx = flagcx_library()
+        self.engine = self.flagcx.flagcxP2pEngineCreate()
+        self.rpc_port = self.flagcx.flagcxP2pGetRpcPort(self.engine)
+        self.flagcx.flagcxP2pStartRpcServer(self.engine)
+        self.session_id = NetworkAddress(
+            self.hostname, self.rpc_port
+        ).to_host_port_str()
+
+        # Cache of session_id -> P2P connection handle. The first GetConn for a
+        # session performs the QP + descriptor-table handshake, so cache it.
+        self.session_conns: dict = {}
+        self.conn_lock = threading.Lock()
+
+        logger.debug(
+            "FlagCX transfer engine initialized: session_id=%s gpu_id=%s ib_device=%s",
+            self.session_id,
+            self.gpu_id,
+            self.ib_device,
+        )
+
+    def register(self, ptr, length):
+        """Register a single memory region for one-sided access."""
+        try:
+            self.flagcx.flagcxP2pRegister(self.engine, ptr, length)
+        except Exception:
+            logger.debug("FlagCX memory registration %s failed.", ptr)
+
+    def register_host(self, ptr, length):
+        """Register a single host (CPU) memory region for one-sided access.
+
+        Uses the host-registration path so FlagCX skips the CUDA IPC probe
+        (CPU pointers can't yield a CUDA IPC handle; probing them leaves a
+        sticky CUDA error that would poison the next torch call).
+        """
+        self.flagcx.flagcxP2pRegisterHost(self.engine, ptr, length)
+
+    def deregister(self, ptr):
+        """FlagCX has no explicit deregister; memory is released on engine
+        destroy."""
+        logger.debug("FlagCX deregister is a no-op for %s.", ptr)
+
+    def batch_register(self, ptrs: List[int], lengths: List[int]) -> int:
+        """Batch register multiple memory regions."""
+        try:
+            for ptr, length in zip(ptrs, lengths):
+                self.flagcx.flagcxP2pRegister(self.engine, ptr, length)
+        except Exception:
+            logger.debug("FlagCX batch memory registration failed.")
+            return -1
+        return 0
+
+    def batch_register_host(self, ptrs: List[int], lengths: List[int]) -> int:
+        """Batch register host (CPU) memory regions, skipping the CUDA IPC
+        probe entirely (see register_host)."""
+        for ptr, length in zip(ptrs, lengths):
+            self.flagcx.flagcxP2pRegisterHost(self.engine, ptr, length)
+        return 0
+
+    def batch_deregister(self, ptrs: List[int]) -> int:
+        """Batch deregister; no-op for FlagCX."""
+        return 0
+
+    def _get_conn(self, session_id: str):
+        conn = self.session_conns.get(session_id)
+        if conn is not None:
+            return conn
+        with self.conn_lock:
+            conn = self.session_conns.get(session_id)
+            if conn is None:
+                conn = self.flagcx.flagcxP2pGetConn(self.engine, session_id)
+                self.session_conns[session_id] = conn
+            return conn
+
+    def transfer_sync(
+        self, session_id: str, buffer: int, peer_buffer_address: int, length: int
+    ) -> int:
+        """Synchronously write data to the specified remote address."""
+        return self.batch_transfer_sync(
+            session_id, [buffer], [peer_buffer_address], [length]
+        )
+
+    def batch_transfer_sync(
+        self,
+        session_id: str,
+        buffers: List[int],
+        peer_buffer_addresses: List[int],
+        lengths: List[int],
+    ) -> int:
+        """Synchronously write data to the specified remote addresses in
+        batches. Returns 0 on success, -1 on failure."""
+        try:
+            conn = self._get_conn(session_id)
+            self.flagcx.flagcxP2pBatchWriteSync(
+                conn, buffers, peer_buffer_addresses, lengths
+            )
+        except Exception:
+            logger.debug(
+                "Failed to batch transfer data. Buffers: %s, Session: %s, "
+                "Peer addresses: %s",
+                buffers,
+                session_id,
+                peer_buffer_addresses,
+            )
+            return -1
+        return 0
+
+    def get_session_id(self):
+        return self.session_id
+
+    def get_ib_device(self):
+        return self.ib_device
+
+
+def init_flagcx_transfer_engine(
+    hostname: str,
+    gpu_id: Optional[int] = None,
+    ib_device: Optional[str] = None,
+) -> FlagCXTransferEngine:
+    """
+    Initialize the shared FlagCXTransferEngine. Note: if already initialized,
+    returns the existing instance. Called lazily from FlagcxKVManager when the
+    FlagCX transfer backend is selected for PD disaggregation.
+    """
+    global _flagcx_transfer_engine
+    if _flagcx_transfer_engine is not None:
+        return _flagcx_transfer_engine
+    _flagcx_transfer_engine = FlagCXTransferEngine(
+        hostname=hostname, gpu_id=gpu_id, ib_device=ib_device
+    )
+    return _flagcx_transfer_engine
+
+
+def get_flagcx_transfer_engine() -> Optional[FlagCXTransferEngine]:
+    """Return the shared FlagCXTransferEngine if initialized, else None."""
+    return _flagcx_transfer_engine


### PR DESCRIPTION
## Summary
Add a FlagCX-based KV transfer backend for PD disaggregation, enabling `--disaggregation-transfer-backend flagcx` without any SGLang source changes — `patch.py` injects the `TransferBackend.FLAGCX` enum member, extends the CLI choices, and wraps `get_kv_class` to return the FlagCX implementations.

## Changes
- New `sglang_fl/disaggregation/`: `patch.py` (non-invasive registration), `transfer_engine.py` (`FlagCXTransferEngine`, one-sided RDMA writes over the FlagCX P2P engine), `conn.py` (`FlagcxKVManager` / `Sender` / `Receiver` / `BootstrapServer` on top of SGLang's `common.conn` bases).
- `sglang_fl/__init__.py`: register as Layer 4 in `load_plugin()`, opt-out via `SGLANG_FL_DISAGG_FLAGCX=0`, plus a banner line.