### PR TITLE
ci(feishu): align Feishu notification with vllm-plugin-FL

### DIFF
--- a/.github/scripts/notify_feishu.py
+++ b/.github/scripts/notify_feishu.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Send CI status notification to Feishu via Bot API."""
+
+import json
+import os
+import sys
+import urllib.request
+
+# Feishu credentials — skip gracefully if not configured
+FEISHU_VARS = ["FEISHU_APP_ID", "FEISHU_APP_SECRET", "FEISHU_CHAT_ID"]
+
+# Required environment variables (script exits with error if any are missing)
+REQUIRED_VARS = [
+    # CI status (computed by the calling workflow)
+    "CI_STATUS",
+    # GitHub default env vars (available automatically on every runner)
+    "GITHUB_WORKFLOW",
+    "GITHUB_REPOSITORY",
+    "GITHUB_REF_NAME",
+    "GITHUB_SHA",
+    "GITHUB_ACTOR",
+    "GITHUB_RUN_ID",
+    "GITHUB_SERVER_URL",
+    "GITHUB_EVENT_NAME",
+]
+
+# Optional environment variables (logged as warning if missing)
+OPTIONAL_VARS = [
+    "PLATFORM",
+    # Override vars for workflow_run context — when set, these take precedence
+    # over the GitHub default env vars (which reflect the notification workflow,
+    # not the original CI run).
+    "OVERRIDE_REF",  # e.g. github.event.workflow_run.head_branch
+    "OVERRIDE_SHA",  # e.g. github.event.workflow_run.head_sha
+    "OVERRIDE_RUN_URL",  # e.g. github.event.workflow_run.html_url
+    "OVERRIDE_WORKFLOW",  # e.g. github.event.workflow_run.name
+    "PR_NUMBER",  # e.g. github.event.workflow_run.pull_requests[0].number
+    "PR_TITLE",  # PR title from GitHub API
+]
+
+
+def check_env_vars() -> bool:
+    """Validate environment variables. Return True if valid, False to skip."""
+    # Check Feishu credentials first — missing means "not configured", not an error
+    missing_feishu = [v for v in FEISHU_VARS if not os.environ.get(v, "").strip()]
+    if missing_feishu:
+        print(
+            f"::notice::Feishu notification skipped — "
+            f"missing credentials: {', '.join(missing_feishu)}"
+        )
+        return False
+
+    # Check remaining required vars — these should always be present
+    invalid = [v for v in REQUIRED_VARS if not os.environ.get(v, "").strip()]
+
+    for v in OPTIONAL_VARS:
+        if not os.environ.get(v, "").strip():
+            print(f"::warning::Optional environment variable '{v}' is not set")
+
+    if invalid:
+        for v in invalid:
+            print(
+                f"::warning::Required environment variable '{v}' is missing or empty",
+                file=sys.stderr,
+            )
+        return False
+
+    return True
+
+
+def main():
+    if not check_env_vars():
+        # Exit 0 — missing config is not a workflow failure
+        return
+
+    app_id = os.environ["FEISHU_APP_ID"]
+    app_secret = os.environ["FEISHU_APP_SECRET"]
+    chat_id = os.environ["FEISHU_CHAT_ID"]
+    ci_status = os.environ["CI_STATUS"].strip()
+    platform = os.environ.get("PLATFORM", "")
+
+    # GitHub default environment variables (always available on runners)
+    # Override vars take precedence — used when called from workflow_run context
+    workflow = os.environ.get("OVERRIDE_WORKFLOW") or os.environ["GITHUB_WORKFLOW"]
+    repo = os.environ["GITHUB_REPOSITORY"]
+    ref = os.environ.get("OVERRIDE_REF") or os.environ["GITHUB_REF_NAME"]
+    sha = os.environ.get("OVERRIDE_SHA") or os.environ["GITHUB_SHA"]
+    actor = os.environ["GITHUB_ACTOR"]
+    run_id = os.environ["GITHUB_RUN_ID"]
+    server_url = os.environ["GITHUB_SERVER_URL"]
+    event_name = os.environ["GITHUB_EVENT_NAME"]
+    pr_number = os.environ.get("PR_NUMBER", "")
+    pr_title = os.environ.get("PR_TITLE", "")
+
+    short_sha = sha[:7]
+    run_url = (
+        os.environ.get("OVERRIDE_RUN_URL")
+        or f"{server_url}/{repo}/actions/runs/{run_id}"
+    )
+
+    # --- 1. Obtain tenant_access_token ---
+    token_req = urllib.request.Request(
+        "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal",
+        data=json.dumps({"app_id": app_id, "app_secret": app_secret}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(token_req) as resp:
+        token_data = json.loads(resp.read())
+
+    tenant_token = token_data.get("tenant_access_token", "")
+    if not tenant_token:
+        print(
+            f"::warning::Failed to obtain tenant_access_token: {token_data}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # --- 2. Build message card ---
+    status_map = {
+        "success": ("✅", "Success", "green"),
+        "cancelled": ("⚠️", "Cancelled", "orange"),
+    }
+    emoji, text, color = status_map.get(ci_status, ("❌", "Failed", "red"))
+
+    title = f"CI {text} — {repo}"
+    if platform:
+        title = f"CI {text} [{platform}] — {repo}"
+
+    card_content = {
+        "config": {"wide_screen_mode": True},
+        "header": {
+            "title": {"tag": "plain_text", "content": title},
+            "template": color,
+        },
+        "elements": [
+            {
+                "tag": "div",
+                "fields": [
+                    {
+                        "is_short": True,
+                        "text": {
+                            "tag": "lark_md",
+                            "content": f"**Workflow:** {workflow}",
+                        },
+                    },
+                    {
+                        "is_short": True,
+                        "text": {
+                            "tag": "lark_md",
+                            "content": f"**Status:** {emoji} {text}",
+                        },
+                    },
+                    {
+                        "is_short": True,
+                        "text": {"tag": "lark_md", "content": f"**Branch:** {ref}"},
+                    },
+                    {
+                        "is_short": True,
+                        "text": {
+                            "tag": "lark_md",
+                            "content": f"**Trigger:** {event_name} by {actor}",
+                        },
+                    },
+                    {
+                        "is_short": False,
+                        "text": {
+                            "tag": "lark_md",
+                            "content": f"**Commit:** {short_sha}",
+                        },
+                    },
+                ]
+                + (
+                    [
+                        {
+                            "is_short": False,
+                            "text": {
+                                "tag": "lark_md",
+                                "content": f"**PR:** [{repo}#{pr_number}]({server_url}/{repo}/pull/{pr_number})",
+                            },
+                        },
+                    ]
+                    if pr_number
+                    else []
+                )
+                + (
+                    [
+                        {
+                            "is_short": False,
+                            "text": {
+                                "tag": "lark_md",
+                                "content": f"**Title:** {pr_title}",
+                            },
+                        },
+                    ]
+                    if pr_title
+                    else []
+                ),
+            },
+            {"tag": "hr"},
+            {
+                "tag": "action",
+                "actions": [
+                    {
+                        "tag": "button",
+                        "text": {"tag": "plain_text", "content": "View Run"},
+                        "url": run_url,
+                        "type": "primary",
+                    }
+                ],
+            },
+        ],
+    }
+
+    body = json.dumps(
+        {
+            "receive_id": chat_id,
+            "msg_type": "interactive",
+            "content": json.dumps(card_content),
+        }
+    ).encode()
+
+    # --- 3. Send message ---
+    msg_req = urllib.request.Request(
+        "https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=chat_id",
+        data=body,
+        headers={
+            "Authorization": f"Bearer {tenant_token}",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(msg_req) as resp:
+        result = json.loads(resp.read())
+
+    if result.get("code", -1) != 0:
+        print(f"::warning::Feishu API returned error: {result}", file=sys.stderr)
+        sys.exit(1)
+
+    print("Feishu notification sent successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/_notify_feishu.yml
+++ b/.github/workflows/_notify_feishu.yml
@@ -39,14 +39,4 @@ jobs:
           FEISHU_CHAT_ID: ${{ secrets.FEISHU_CHAT_ID }}
           CI_STATUS: ${{ inputs.status }}
           PLATFORM: ${{ inputs.platform }}
-          REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          COMMIT_SHA: ${{ github.sha }}
-          BRANCH: ${{ github.ref_name }}
-        run: |
-          if [ -f .github/scripts/notify_feishu.py ]; then
-            python .github/scripts/notify_feishu.py
-          else
-            echo "::notice::notify_feishu.py not found, skipping notification"
-          fi
+        run: python .github/scripts/notify_feishu.py

--- a/.github/workflows/notify-feishu.yml
+++ b/.github/workflows/notify-feishu.yml
@@ -1,0 +1,51 @@
+name: Feishu Notification (post-CI)
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+jobs:
+  notify:
+    name: "Notify (overall)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: true
+    steps:
+      - name: Checkout scripts
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          sparse-checkout: .github/scripts
+      - name: Resolve PR info
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # workflow_run.pull_requests is empty for fork PRs, so fall back to API lookup by SHA
+          PR_NUM="${{ github.event.workflow_run.pull_requests[0].number }}"
+          PR_TITLE=""
+          if [ -z "$PR_NUM" ]; then
+            HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+            PR_JSON=$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/pulls" \
+              --jq '.[0] | {number, title}' 2>/dev/null || true)
+            PR_NUM=$(echo "$PR_JSON" | jq -r '.number // empty' 2>/dev/null || true)
+            PR_TITLE=$(echo "$PR_JSON" | jq -r '.title // empty' 2>/dev/null || true)
+          elif [ -n "$PR_NUM" ]; then
+            PR_TITLE=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUM}" \
+              --jq '.title // empty' 2>/dev/null || true)
+          fi
+          echo "number=${PR_NUM}" >> "$GITHUB_OUTPUT"
+          echo "title=${PR_TITLE}" >> "$GITHUB_OUTPUT"
+      - name: Send Feishu notification
+        env:
+          FEISHU_APP_ID: ${{ secrets.FEISHU_APP_ID }}
+          FEISHU_APP_SECRET: ${{ secrets.FEISHU_APP_SECRET }}
+          FEISHU_CHAT_ID: ${{ secrets.FEISHU_CHAT_ID }}
+          CI_STATUS: ${{ github.event.workflow_run.conclusion }}
+          OVERRIDE_WORKFLOW: ${{ github.event.workflow_run.name }}
+          OVERRIDE_REF: ${{ github.event.workflow_run.head_branch }}
+          OVERRIDE_SHA: ${{ github.event.workflow_run.head_sha }}
+          OVERRIDE_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_TITLE: ${{ steps.pr.outputs.title }}
+        run: python .github/scripts/notify_feishu.py


### PR DESCRIPTION
## Summary

Extract the Feishu CI notification infra into its own PR so it can merge **independently** of the larger MUSA e2e PR (#54). It is platform-agnostic and benefits every platform's CI, not just MUSA.

## Changes (3 files, self-contained)

- `.github/scripts/notify_feishu.py` (new): notification script. Posts run results to a Feishu group chat via the Feishu OpenAPI (`tenant_access_token` + `/im/v1/messages`), driven by GitHub secrets (`FEISHU_APP_ID` / `FEISHU_APP_SECRET` / `FEISHU_CHAT_ID`) — no hardcoded credentials.
- `.github/workflows/notify-feishu.yml` (new): reusable workflow wiring.
- `.github/workflows/_notify_feishu.yml` (updated): aligned with vllm-plugin-FL's notification shape.

Mirrors the equivalent setup in `vllm-plugin-FL`.

## Relation to #54

#54 currently carries this exact commit (`ci(feishu): ...`). Once this PR merges to `main`, rebasing #54 will auto-drop it (identical patch), so there is no long-term duplication — splitting just lets the notification infra land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)