### PR TITLE
[PPU] Add PPU default attention_backend into _ATTN_BACKEND_MAP

### DIFF
--- a/sglang_fl/platform.py
+++ b/sglang_fl/platform.py
@@ -61,6 +61,7 @@ _ATTN_BACKEND_MAP = {
     "ascend": "ascend",
     "mthreads": "fa3",
     "enflame": "fa3",
+    "thead": "fa3",
     "kunlunxin": "kunlunxin",
     "iluvatar": "triton",
     "hygon": "hcu",


### PR DESCRIPTION
## Summary
The PPU platform was missing an entry in _ATTN_BACKEND_MAP. As a result, PlatformFL.get_default_attention_backend() fell back to the generic "torch_native" backend for PPU instead of the intended fa3 backend. 

## Changes
[sglang_fl/platform.py] : add "thead": "fa3" to _ATTN_BACKEND_MAP

## Tests
- Tested on PPU-ZW810E by online mode.