### PR TITLE
fix(moe): delegate cuda fused_moe to native forward_cuda

### DIFF
--- a/sglang_fl/dispatch/backends/vendor/cuda/impl/fused_moe.py
+++ b/sglang_fl/dispatch/backends/vendor/cuda/impl/fused_moe.py
@@ -27,8 +27,13 @@ def fused_moe_cuda(
     """
     Fused MoE expert computation using SGLang's native Triton kernels.
 
-    This implementation delegates to SGLang's MoeRunner with the TRITON backend,
-    which uses the standard (non-triton_kernels, non-flashinfer) path.
+    Delegates to SGLang's native ``UnquantizedFusedMoEMethod.forward_cuda``, which
+    selects the runner backend (triton / deep_gemm / ...) and builds
+    ``TritonMoeQuantInfo`` correctly via ``get_triton_quant_info``. This mirrors the
+    MUSA backend (``obj.forward_musa``) and avoids re-implementing the quant_info
+    contract, which drifts across sglang versions: sglang 0.5.12's runner reads
+    ``use_fp8``/``use_int8``/... that a hand-built TritonMoeQuantInfo omits, raising
+    AttributeError on the MoE forward.
 
     Args:
         obj: The UnquantizedFusedMoEMethod instance
@@ -38,14 +43,4 @@ def fused_moe_cuda(
     Returns:
         CombineInput (StandardCombineInput)
     """
-    from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
-
-    # Use the TRITON backend (standard path, not triton_kernels or flashinfer)
-    # This matches the final fallback in forward_cuda
-    quant_info = TritonMoeQuantInfo(
-        w13_weight=layer.w13_weight,
-        w2_weight=layer.w2_weight,
-        b13=getattr(layer, "w13_weight_bias", None),
-        b2=getattr(layer, "w2_weight_bias", None),
-    )
-    return obj.runner.run(dispatch_output, quant_info)
+    return obj.forward_cuda(layer, dispatch_output)

--- a/tests/functional_tests/ops/test_ops_correctness.py
+++ b/tests/functional_tests/ops/test_ops_correctness.py
@@ -281,7 +281,18 @@ def test_fused_moe_output_contract(device) -> None:
             dtype=torch.float16,
         ),
     )
-    obj = SimpleNamespace(runner=MockRunner())
+    runner = MockRunner()
+
+    def forward_cuda(layer, dispatch_output):
+        # The CUDA vendor impl delegates to native
+        # UnquantizedFusedMoEMethod.forward_cuda (mirrors MUSA -> obj.forward_musa),
+        # which builds a TritonMoeQuantInfo from the layer and calls runner.run.
+        return runner.run(
+            dispatch_output,
+            SimpleNamespace(w13_weight=layer.w13_weight, w2_weight=layer.w2_weight),
+        )
+
+    obj = SimpleNamespace(runner=runner, forward_cuda=forward_cuda)
 
     try:
         output = _call_selected("fused_moe", obj, layer, dispatch_output)


### PR DESCRIPTION
## Summary

Fix the cuda `fused_moe` dispatch: it re-implemented the MoE forward by hand-building `TritonMoeQuantInfo` with only 4 fields (`w13_weight`, `w2_weight`, `b13`, `b2`). sglang 0.5.12's triton MoE runner reads many more attrs off the quant_info (`use_fp8`, `use_int8`, `local_num_experts`, `w13_weight_scale`, …), so the MoE forward raised `AttributeError` on any MoE model.

## Fix

Delegate to sglang's native `UnquantizedFusedMoEMethod.forward_cuda` instead — it selects the runner backend (triton/deep_gemm/…) and builds `TritonMoeQuantInfo` correctly via `get_triton_quant_info`. This mirrors the **MUSA** backend, which already delegates to `obj.forward_musa`. Robust to sglang API drift.

```python
# sglang_fl/dispatch/backends/vendor/cuda/impl/fused_moe.py
return obj.forward_cuda(layer, dispatch_output)
```

Also adapts the functional contract test (`test_fused_moe_output_contract`): its mock was `SimpleNamespace(runner=...)` (only provided `runner.run`, the old contract); the delegate calls `obj.forward_cuda`, so the mock now provides `forward_cuda` routing to the existing `MockRunner` (keeps the weight-identity + CombineInput assertions).

## Why

Found while bringing up the T-Head PPU CI platform (thead routes through the cuda backend → hit this on qwen3_6 MoE e2e). The 4B dense case (no MoE) masked it. This is a plugin-correctness fix for the cuda fused_moe path, independent of that CI work.

## Validation

On PPU (sglang 0.5.12+ppu2.1.0): `qwen3_6 35b_a3b_tp4` (MoE + VL) and `27b_tp4` (dense) e2e pass with this change (DeepGEMM MoE backend runs); the functional contract test passes. (Note: the thead CI platform PR is gated on this fix for its qwen3_6 cases.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
