### PR TITLE
feat: Qwen3.5 MoE bare-text (no vision) model coverage adapter

### DIFF
--- a/sglang_fl/__init__.py
+++ b/sglang_fl/__init__.py
@@ -799,13 +799,22 @@ def load_plugin():
     else:
         logger.info("Layer 2 (Fused Ops) disabled (SGLANG_FL_OOT_ENABLED=0)")
 
-    # 4. Communicator hooks (CommunicatorFL with FlagCX/torch.distributed)
-    _setup_communicator_hooks()
+    # 5. Model adapters — extra model coverage (e.g. Qwen3.5 MoE bare text)
+    try:
+        from sglang_fl.adapters.compressed_tensors import (
+            register_compressed_tensors_normalize,
+        )
+        from sglang_fl.adapters.qwen3_5_moe_text import register_qwen3_5_moe_text
 
-    # 5. Vendor-specific patches — final overlay on top of all sglang_fl layers
+        register_qwen3_5_moe_text()
+        register_compressed_tensors_normalize()
+    except Exception as e:
+        logger.warning("sglang_fl: model adapter registration failed: %s", e)
+
+    # 6. Vendor-specific patches — final overlay on top of all sglang_fl layers
     _apply_vendor_patches()
 
-    # 6. Summary banner — confirm plugin is active (rank 0 only)
+    # 7. Summary banner — confirm plugin is active (rank 0 only)
     if _is_rank0():
         use_fg = _parse_bool(os.environ.get("USE_FLAGGEMS", "1"), default=True)
         aten_status = "OFF" if not use_fg else "ON"

--- a/sglang_fl/adapters/__init__.py
+++ b/sglang_fl/adapters/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/sglang_fl/adapters/compressed_tensors.py
+++ b/sglang_fl/adapters/compressed_tensors.py
@@ -1,0 +1,85 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compressed-tensors target-prefix normalization adapter.
+
+Bare ``ForCausalLM``-style checkpoints (e.g. Qwen-0812) carry compressed-tensors
+config targets like ``model.layers.*`` / ``mtp.*``, while the vision-optional
+wrapper models (``Qwen3_5MoeForConditionalGeneration`` and co.) build the inner
+language model under ``model.language_model.*``. Core v0.5.11's
+``CompressedTensorsConfig.from_config`` normalizes those prefixes; this adapter
+applies the same normalization by wrapping
+``CompressedTensorsConfig._quantization_scheme_map_from_config`` so the plugin
+works against unmodified core.
+
+The wrapped method runs before any ``hf_to_sglang_mapper`` transform, so the
+normalized keys flow through the exact same pipeline as the core change.
+"""
+import functools
+import logging
+
+from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
+    CompressedTensorsConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+_METHOD = "_quantization_scheme_map_from_config"
+
+
+def _normalize_targets(target_scheme_map: dict) -> dict:
+    """Map bare-model targets to the wrapper's constructed prefix.
+
+    Idempotent: already-prefixed (``model.language_model.*``) targets are left
+    untouched.
+    """
+    return {
+        (
+            key.replace("model.", "model.language_model.", 1)
+            if key.startswith("model.layers.")
+            else ("model.language_model." + key if key.startswith("mtp.") else key)
+        ): scheme
+        for key, scheme in target_scheme_map.items()
+    }
+
+
+def register_compressed_tensors_normalize() -> bool:
+    """Wrap the scheme-map builder to normalize bare-model targets.
+
+    Idempotent; returns True when the patch was newly applied.
+    """
+    desc = CompressedTensorsConfig.__dict__.get(_METHOD)
+    if desc is None:
+        logger.warning(
+            "sglang_fl: %s.%s not found, skip", CompressedTensorsConfig.__name__, _METHOD
+        )
+        return False
+    if getattr(desc.__func__, "_sglang_fl_normalize_patched", False):
+        return False
+    orig_fn = desc.__func__
+    is_classmethod = isinstance(desc, classmethod)
+
+    @functools.wraps(orig_fn)
+    def _patched(cls, config, *args, **kwargs):
+        scheme_map = orig_fn(cls, config, *args, **kwargs)
+        return _normalize_targets(scheme_map)
+
+    _patched._sglang_fl_normalize_patched = True
+    # class __dict__ is a mappingproxy — use setattr, not item assignment
+    setattr(CompressedTensorsConfig, _METHOD, classmethod(_patched) if is_classmethod else _patched)
+    logger.info(
+        "sglang_fl: compressed-tensors target normalization patched on %s",
+        CompressedTensorsConfig.__name__,
+    )
+    return True

--- a/sglang_fl/adapters/qwen3_5_moe_text.py
+++ b/sglang_fl/adapters/qwen3_5_moe_text.py
@@ -1,0 +1,136 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qwen3.5 MoE bare-text (no vision) coverage adapter.
+
+SGLang core models ``Qwen3_5MoeForConditionalGeneration``, a vision-optional
+MoE wrapper, but its config registry only knows the *wrapped* ``qwen3_5_moe``
+model_type. Some checkpoints (e.g. Qwen-0812, 2.3T) ship as **bare text**
+configs: ``model_type: qwen3_5_moe_text``, architecture
+``Qwen3_5MoeForCausalLM``, no ``vision_config``, and ``model.layers.*``
+weights directly (instead of ``model.language_model.*``).
+
+This adapter teaches sglang_fl about the bare variant with zero core changes:
+
+1. Register ``Qwen3_5MoeTextConfig`` into sglang's ``_CONFIG_REGISTRY`` so
+   ``get_config()`` re-resolves the ``qwen3_5_moe_text`` model_type to the
+   sglang config class — which carries ``layers_block_type`` and
+   ``norm_topk_prob=True`` needed by ``models/qwen2_moe.py`` TopK. Re-resolving
+   also means core ``qwen3_5.py`` never sees a native transformers config, so
+   no ``layer_types`` fallback is needed in core.
+2. Register a bare ``Qwen3_5MoeForCausalLM`` wrapper into the model registry
+   so the model loader routes the architecture to the vision-optional MoE
+   wrapper, reusing its forward / load_weights / lm_head / MTP hooks.
+3. Patch the core wrapper ``__init__``s to tolerate ``self.visual is None``
+   (bare text configs have no vision tower); core v0.5.11 unconditionally
+   reads ``self.visual.deepstack_visual_indexes`` after init.
+
+Registration happens inside ``load_plugin()``, which sglang runs before any
+model is loaded, so everything takes effect for every server launch.
+"""
+import functools
+import logging
+
+from sglang.srt.configs.qwen3_5 import Qwen3_5MoeTextConfig
+from sglang.srt.models.qwen3_5 import Qwen3_5MoeForConditionalGeneration
+from sglang.srt.models.registry import ModelRegistry
+from sglang.srt.utils.hf_transformers.common import _CONFIG_REGISTRY
+
+logger = logging.getLogger(__name__)
+
+_MODEL_TYPE = "qwen3_5_moe_text"
+_ARCH = "Qwen3_5MoeForCausalLM"
+
+# Core classes whose __init__ unconditionally reads self.visual when building
+# the (vision-optional) wrapper; harmless to patch for configs that do have a
+# visual tower, and required for bare text configs where self.visual is None.
+_WRAPPER_CLASSES = (
+    "Qwen3_5ForConditionalGeneration",
+    "Qwen3_5MoeForConditionalGeneration",
+)
+
+
+class Qwen3_5MoeForCausalLM(Qwen3_5MoeForConditionalGeneration):
+    """Bare Qwen3.5 MoE arch (no vision), e.g. Qwen-0812.
+
+    The vision-optional MoE wrapper builds its inner language model with the
+    core ``language_model_cls`` (the bare-LM class in
+    ``sglang.srt.models.qwen3_5``), so this wrapper body can stay empty.
+    """
+
+
+def _patch_core_visual_guard() -> None:
+    """Make core wrapper __init__ tolerate configs without a vision tower.
+
+    Core v0.5.11 does::
+
+        self.deepstack_visual_indexes = self.visual.deepstack_visual_indexes
+
+    right after super().__init__, which raises AttributeError when the config
+    has no ``vision_config`` (bare text checkpoints). Wrap each __init__ so an
+    AttributeError raised purely because ``self.visual is None`` is recovered
+    by setting ``deepstack_visual_indexes = None`` (and the MoE-only
+    ``num_fused_shared_experts = 0`` that core sets right after). Any other
+    exception is re-raised untouched.
+    """
+    import importlib
+
+    m = importlib.import_module("sglang.srt.models.qwen3_5")
+    for name in _WRAPPER_CLASSES:
+        cls = getattr(m, name, None)
+        if cls is None:
+            continue
+        if getattr(cls, "_sglang_fl_visual_guard_patched", False):
+            continue
+        orig_init = cls.__init__
+
+        @functools.wraps(orig_init)
+        def _patched_init(self, *args, **kwargs):
+            try:
+                orig_init(self, *args, **kwargs)
+            except AttributeError:
+                if self.visual is None:
+                    # bare text config: no vision tower
+                    self.deepstack_visual_indexes = None
+                    if not hasattr(self, "num_fused_shared_experts"):
+                        self.num_fused_shared_experts = 0
+                else:
+                    raise
+
+        cls.__init__ = _patched_init
+        cls._sglang_fl_visual_guard_patched = True
+        logger.info("sglang_fl: visual guard patched on %s", name)
+
+
+def register_qwen3_5_moe_text() -> bool:
+    """Idempotently register bare-text Qwen3.5 MoE config + arch.
+
+    Safe to call more than once; returns True if any registration was newly
+    applied. No-ops when the core already covers the model_type / arch.
+    """
+    applied = False
+    if _MODEL_TYPE not in _CONFIG_REGISTRY:
+        _CONFIG_REGISTRY[_MODEL_TYPE] = Qwen3_5MoeTextConfig
+        logger.info(
+            "sglang_fl: registered config %s for model_type %r",
+            Qwen3_5MoeTextConfig.__name__,
+            _MODEL_TYPE,
+        )
+        applied = True
+    if _ARCH not in ModelRegistry.models:
+        ModelRegistry.models[_ARCH] = Qwen3_5MoeForCausalLM
+        logger.info("sglang_fl: registered arch %s", _ARCH)
+        applied = True
+    _patch_core_visual_guard()
+    return applied


### PR DESCRIPTION
# PR: sglang_fl model coverage — Qwen3.5 MoE bare-text (no vision) adapter

## Summary

Teach `sglang_fl` to serve **bare-text Qwen3.5 MoE** checkpoints such as
`Qwen-0812` (2.3T, 92 layers = 69 Gated-DeltaNet linear attention + 23 full
attention, 512 experts top-10). These checkpoints ship with a *bare* config:

- `model_type: qwen3_5_moe_text` (no `text_config`/`vision_config` sub-objects)
- architecture `Qwen3_5MoeForCausalLM`
- weights at `model.layers.*` / `mtp.*` (not `model.language_model.*`)

SGLang core already supports the *wrapped* variant
(`Qwen3_5MoeForConditionalGeneration`, model_type `qwen3_5_moe`). This PR adds a
small adapter that teaches `sglang_fl` about the bare variant — **no core
changes required**: every one-off patch previously needed to run 0812 on core
v0.5.11 is folded into the adapter.

## Changes

### `sglang_fl/adapters/__init__.py` (new)
Package marker for model-coverage adapters.

### `sglang_fl/adapters/qwen3_5_moe_text.py` (new)
`register_qwen3_5_moe_text()` — idempotent, called from `load_plugin()`:

1. **Config registration** — injects `Qwen3_5MoeTextConfig` (already defined in
   core `sglang.srt.configs.qwen3_5`) into
   `sglang.srt.utils.hf_transformers.common._CONFIG_REGISTRY` under
   `qwen3_5_moe_text`. SGLang's `get_config()` re-resolves the model_type to
   this sglang config class (carrying `layers_block_type` and
   `norm_topk_prob=True`), which fixes the `norm_topk_prob` AttributeError in
   `models/qwen2_moe.py` TopK for bare configs.
2. **Arch registration** — defines a bare `Qwen3_5MoeForCausalLM`
   (`Qwen3_5MoeForConditionalGeneration` subclass, empty body) and injects it
   into `ModelRegistry.models` under `Qwen3_5MoeForCausalLM`, so the model
   loader routes the arch to the vision-optional MoE wrapper and reuses its
   forward / load_weights / lm_head / MTP hooks.
3. **Visual-tower guard (monkey-patch)** — core v0.5.11's wrapper `__init__`
   unconditionally reads `self.visual.deepstack_visual_indexes` after
   `super().__init__()`, which raises `AttributeError` for configs with no
   `vision_config`. The adapter wraps the `__init__` of
   `Qwen3_5ForConditionalGeneration` and `Qwen3_5MoeForConditionalGeneration`:
   an `AttributeError` caused purely by `self.visual is None` is recovered by
   setting `deepstack_visual_indexes = None` (plus the MoE-only
   `num_fused_shared_experts = 0` core sets right after); any other exception is
   re-raised. Idempotent; harmless for configs that do have a vision tower.

### `sglang_fl/adapters/compressed_tensors.py` (new)
`register_compressed_tensors_normalize()` — idempotent. Bare checkpoints carry
compressed-tensors config targets like `model.layers.*` / `mtp.*`, while the
wrapper models build the inner language model under `model.language_model.*`.
Core v0.5.11's `CompressedTensorsConfig.from_config` normalizes those prefixes
only in newer core; this adapter applies the same normalization by wrapping
`CompressedTensorsConfig._quantization_scheme_map_from_config` (idempotent:
already-prefixed targets are left untouched), so the plugin works against
unmodified core.

### `sglang_fl/__init__.py`
`load_plugin()` gains step 5 "Model adapters" that calls both register
functions, wrapped in try/except so a failing adapter never blocks server
startup.

## Why no core changes

The four one-off core patches used during the original 0812 adaptation are all
superseded by the adapter:

| Core patch (v0.5.11, unmerged) | Superseded by |
|---|---|
| `_CONFIG_REGISTRY` entry for `qwen3_5_moe_text` in `hf_transformers/common.py` | adapter config registration (step 1) |
| `Qwen3_5MoeTextConfig` export in `configs/__init__.py` | adapter imports the config class directly |
| `renormalize=getattr(config, "norm_topk_prob", True)` in `models/qwen2_moe.py` | config re-resolution guarantees `norm_topk_prob=True` |
| compressed-tensors target normalization in `layers/.../compressed_tensors.py` | adapter `compressed_tensors.py` wrapper |
| visual-tower `None` guards in `models/qwen3_5.py` | adapter visual-tower monkey-patch (step 3) |

The only remaining core diff from the adaptation is three generic guards in
`models/qwen3_5.py` (a `layer_types` fallback in `get_layer()` and two
`deepstack_visual_indexes` None-guards); they are defensive only and redundant
once the adapter is active — they are **not** part of this PR.

## Verified

- Import-level verification (120 and 121, no NPU device touched):
  `get_config()` re-resolves `/public-flash/models/Qwen-0812-W8A8-attn-moe-bf16-init8`
  to `Qwen3_5MoeTextConfig` (`layers_block_type`: 69 linear_attention + 23
  attention = 92, `norm_topk_prob=True`); `get_model_architecture()` resolves
  `Qwen3_5MoeForCausalLM` to the adapter wrapper; both register functions are
  idempotent; both wrapper `__init__`s carry the visual-guard patch; the
  compressed-tensors normalization maps all 167 bare targets to
  `model.language_model.*` and `find_matched_target` resolves a prefixed weight
  name against the normalized map.
- Full server launch + GPQA evaluation on TP16×PP4 (64× Ascend 910C): startup
  OK, accuracy 47/55 = 85.5% (strict, 0 missing/garbled).