### PR TITLE
fix: align SGLANG_FL_STRICT semantics

### DIFF
--- a/sglang_fl/__init__.py
+++ b/sglang_fl/__init__.py
@@ -41,7 +41,7 @@ Environment variables:
   SGLANG_FL_OOT_ENABLED=1|0           Master switch for Layer 2 (default: 1)
   SGLANG_FL_PREFER=flagos|vendor|reference  Global backend priority
   SGLANG_FL_PER_OP=op=kind|kind;...         Per-op backend override
-  SGLANG_FL_STRICT=1|0                Fallback on error (default: 1=enabled)
+  SGLANG_FL_STRICT=1|0                Strict mode: 1=no fallback, 0=fallback (default: 0)
   SGLANG_FL_OOT_WHITELIST=op1,op2     Only dispatch listed ops through OOT
   SGLANG_FL_OOT_BLACKLIST=op1,op2     Skip listed ops from OOT dispatch
   SGLANG_FL_DENY_VENDORS=v1,v2       Deny specific vendor backends
@@ -154,12 +154,12 @@ def _build_config() -> dict:
     else:
         flagos_blacklist = yaml_cfg.get("flagos_blacklist", []) or []
 
-    # strict: SGLANG_FL_STRICT > yaml.strict > True (default: fallback enabled)
+    # strict: SGLANG_FL_STRICT > yaml.strict > False (default: fallback enabled)
     strict_str = os.environ.get("SGLANG_FL_STRICT", "").strip()
     if strict_str:
         strict = strict_str == "1"
     else:
-        strict = yaml_cfg.get("strict", True)
+        strict = yaml_cfg.get("strict", False)
 
     # deny_vendors: SGLANG_FL_DENY_VENDORS > yaml.deny_vendors > []
     deny_str = os.environ.get("SGLANG_FL_DENY_VENDORS", "").strip()
@@ -236,7 +236,7 @@ def _init_dispatch(config: dict) -> None:
 
     policy = SelectionPolicy.from_dict(
         prefer=prefer,
-        strict=config.get("strict", True),
+        strict=config.get("strict", False),
         per_op_order=per_op_order if per_op_order else None,
         deny_vendors=config.get("deny_vendors"),
         allow_vendors=config.get("allow_vendors"),

--- a/sglang_fl/dispatch/manager.py
+++ b/sglang_fl/dispatch/manager.py
@@ -50,7 +50,7 @@ class OpManager:
     - Multi-process safety (PID detection + at_fork)
     - Policy-based operator selection
     - Dispatch caching with invalidation
-    - Ordered fallback when strict mode is enabled
+    - Ordered fallback when strict mode is disabled
     """
 
     def __init__(self, registry: Optional[OpRegistry] = None) -> None:
@@ -257,11 +257,11 @@ class OpManager:
         """
         Resolve and call an operator implementation with optional fallback.
 
-        When strict=True in the policy (default), tries alternative implementations
-        if primary fails. When strict=False, uses direct resolve only.
+        When strict=False, try alternative implementations on failure.
+        When strict=True, fail immediately without fallback.
         """
         policy = get_policy()
-        enable_fallback = policy.strict
+        enable_fallback = not policy.strict
 
         if not enable_fallback:
             fn = self.resolve(op_name)

--- a/sglang_fl/dispatch/policy.py
+++ b/sglang_fl/dispatch/policy.py
@@ -43,7 +43,7 @@ class SelectionPolicy:
 
     Attributes:
         prefer: Which implementation kind to prefer ("flagos", "vendor", "reference")
-        strict: If True, enable fallback when primary fails
+        strict: If True, raise immediately when primary implementation fails
         per_op_order: Per-operator custom selection order
         deny_vendors: Set of vendor names to deny
         allow_vendors: Set of vendor names to allow (whitelist)
@@ -331,7 +331,7 @@ class PolicyManager:
         elif platform_policy:
             strict = platform_policy.strict
         else:
-            strict = True
+            strict = False
 
         if env_deny_str:
             deny_vendors = self._parse_csv_set(env_deny_str)

--- a/tests/functional_tests/ops/test_ops_correctness.py
+++ b/tests/functional_tests/ops/test_ops_correctness.py
@@ -48,7 +48,7 @@ def _call_selected(op_name: str, *args, **kwargs):
     # Functional tests should validate the preferred implementation when it is
     # available, while still allowing fallback so partially wired backends do not
     # hide the rest of the operator surface.
-    policy = SelectionPolicy.from_dict(prefer=_selected_prefer(), strict=True)
+    policy = SelectionPolicy.from_dict(prefer=_selected_prefer(), strict=False)
     with policy_context(policy):
         return call_op(op_name, *args, **kwargs)
 

--- a/tests/test_e2e_config.py
+++ b/tests/test_e2e_config.py
@@ -329,9 +329,9 @@ def _verify_prefer_flagos(text, artifacts):
     assert "RotaryEmbedding" in log, "RotaryEmbedding not in dispatch log"
     slog = artifacts.get("server_log", "")
     _assert_all_ops_using_backend(slog, "flagos")
-    # Default strict=True → fallback-enabled mode
+    # Default strict=False → fallback-enabled mode
     assert "mode=fallback-enabled" in slog, (
-        "Default strict=True should use fallback-enabled mode"
+        "Default strict=False should use fallback-enabled mode"
     )
 
 
@@ -394,20 +394,23 @@ def _verify_oot_disabled(text, artifacts):
     )
 
 
-def _verify_strict_off(text, artifacts):
-    """STRICT=0 disables fallback. Verify ops resolve in direct mode (no fallback chain)."""
+def _verify_strict_on(text, artifacts):
+    """STRICT=1 disables fallback and uses direct resolve mode."""
     log = artifacts.get("dispatch_log", "")
     assert "[OOT-DISPATCH]" in log, "dispatch log empty"
     assert "SiluAndMul" in log, "SiluAndMul not in dispatch log"
     assert "RMSNorm" in log, "RMSNorm not in dispatch log"
     assert "RotaryEmbedding" in log, "RotaryEmbedding not in dispatch log"
+
     slog = artifacts.get("server_log", "")
-    # STRICT=0 → direct mode (no fallback chain)
+
+    # STRICT=1 → direct mode, no fallback chain
     assert "mode=direct" in slog, (
-        "STRICT=0 should use direct resolve mode, but 'mode=direct' not found in server log"
+        "STRICT=1 should use direct resolve mode, but 'mode=direct' "
+        "was not found in server log"
     )
     assert "mode=fallback-enabled" not in slog, (
-        "STRICT=0 should NOT use fallback-enabled mode"
+        "STRICT=1 should NOT use fallback-enabled mode"
     )
 
 
@@ -558,17 +561,17 @@ def _verify_flaggems_log_once_off(text, artifacts):
 
 
 def _verify_yaml_strict(text, artifacts):
-    """YAML strict=false: direct resolve only, no fallback chain."""
+    """YAML strict=true: direct resolve only, no fallback chain."""
     log = artifacts.get("dispatch_log", "")
     assert "[OOT-DISPATCH]" in log, "dispatch log empty"
     assert "SiluAndMul" in log, "SiluAndMul not in dispatch log"
     slog = artifacts.get("server_log", "")
-    # strict=false → direct mode
+    # strict=true → direct mode
     assert "mode=direct" in slog, (
-        "YAML strict=false should use direct resolve mode, but 'mode=direct' not found"
+        "YAML strict=true should use direct resolve mode, but 'mode=direct' not found"
     )
     assert "mode=fallback-enabled" not in slog, (
-        "YAML strict=false should NOT use fallback-enabled mode"
+        "YAML strict=true should NOT use fallback-enabled mode"
     )
 
 
@@ -667,15 +670,15 @@ TESTS: List[TestCase] = [
         },
         verify=_verify_oot_disabled,
     ),
-    # ═══ Layer 2: SGLANG_FL_STRICT=0 ═════════════════════════════════════════
+    # ═══ Layer 2: SGLANG_FL_STRICT=1 ═════════════════════════════════════════
     TestCase(
-        name="strict-off",
-        description="SGLANG_FL_STRICT=0 → no fallback, direct resolve only",
+        name="strict-on",
+        description="SGLANG_FL_STRICT=1 → no fallback, direct resolve only",
         env={
-            "SGLANG_FL_STRICT": "0",
+            "SGLANG_FL_STRICT": "1",
             "SGLANG_FL_DISPATCH_LOG": "/tmp/test_e2e_dispatch.log",
         },
-        verify=_verify_strict_off,
+        verify=_verify_strict_on,
     ),
     # ═══ Layer 2: SGLANG_FL_DENY_VENDORS ═════════════════════════════════════
     TestCase(
@@ -813,11 +816,11 @@ TESTS: List[TestCase] = [
         },
         verify=_verify_flaggems_log_once_off,
     ),
-    # ═══ YAML: strict=false ═════════════════════════════════════════════════
+    # ═══ YAML: strict=true ═════════════════════════════════════════════════
     TestCase(
         name="yaml-strict",
-        description="YAML strict=false → direct resolve only, no fallback",
-        yaml_content="prefer: flagos\nstrict: false\n",
+        description="YAML strict=true → direct resolve only, no fallback",
+        yaml_content="prefer: flagos\nstrict: true\n",
         env={
             "SGLANG_FL_DISPATCH_LOG": "/tmp/test_e2e_dispatch.log",
         },

--- a/tests/unit_tests/dispatch/test_manager.py
+++ b/tests/unit_tests/dispatch/test_manager.py
@@ -31,7 +31,6 @@ from sglang_fl.dispatch.policy import (
     set_global_policy,
     with_denied_vendors,
     with_preference,
-    with_strict_mode,
     PREFER_DEFAULT,
     PREFER_VENDOR,
     PREFER_REFERENCE,
@@ -141,12 +140,15 @@ class TestOpManagerCache:
 
 class TestOpManagerCall:
     def test_call_direct_mode(self, populated_manager):
-        reset_global_policy()
-        result = populated_manager.call("silu_and_mul")
+        policy = SelectionPolicy.from_dict(strict=True)
+
+        with policy_context(policy):
+            result = populated_manager.call("silu_and_mul")
+
         assert result == "flagos_silu"
 
     def test_call_with_fallback(self, populated_manager):
-        """When strict=True and primary fails, falls back to next."""
+        """When strict=False and primary fails, falls back to next."""
         registry = OpRegistry()
         manager = OpManager(registry=registry)
         manager._state.initialized = True
@@ -179,13 +181,61 @@ class TestOpManagerCall:
             ),
         ])
 
-        with with_strict_mode():
+        policy = SelectionPolicy.from_dict(strict=False)
+
+        with policy_context(policy):
             result = manager.call("test_op")
             assert result == "fallback_result"
             assert call_count["primary"] == 1
             assert call_count["fallback"] == 1
 
+    def test_call_strict_mode_raises_original_error(self):
+        """When strict=True, raise the primary error without trying fallback."""
+        registry = OpRegistry()
+        manager = OpManager(registry=registry)
+        manager._state.initialized = True
+        manager._state.init_pid = os.getpid()
+
+        call_count = {"primary": 0, "fallback": 0}
+
+        def failing_fn(*args, **kwargs):
+            call_count["primary"] += 1
+            raise RuntimeError("primary failed")
+
+        def fallback_fn(*args, **kwargs):
+            call_count["fallback"] += 1
+            return "fallback_result"
+
+        registry.register_many(
+            [
+                OpImpl(
+                    op_name="test_op",
+                    impl_id="default.flagos",
+                    kind=BackendImplKind.DEFAULT,
+                    fn=failing_fn,
+                    priority=BackendPriority.DEFAULT,
+                ),
+                OpImpl(
+                    op_name="test_op",
+                    impl_id="reference.pytorch",
+                    kind=BackendImplKind.REFERENCE,
+                    fn=fallback_fn,
+                    priority=BackendPriority.REFERENCE,
+                ),
+            ]
+        )
+
+        policy = SelectionPolicy.from_dict(strict=True)
+
+        with policy_context(policy):
+            with pytest.raises(RuntimeError, match="primary failed"):
+                manager.call("test_op")
+
+        assert call_count["primary"] == 1
+        assert call_count["fallback"] == 0
+
     def test_call_all_fail_raises(self, populated_manager):
+        """When strict=False and all candidates fail, raise a summary error."""
         registry = OpRegistry()
         manager = OpManager(registry=registry)
         manager._state.initialized = True
@@ -199,7 +249,9 @@ class TestOpManagerCall:
             priority=BackendPriority.DEFAULT,
         ))
 
-        with with_strict_mode():
+        policy = SelectionPolicy.from_dict(strict=False)
+
+        with policy_context(policy):
             with pytest.raises(RuntimeError, match="All implementations failed"):
                 manager.call("bad_op")
 


### PR DESCRIPTION
## Summary

This PR aligns `SGLANG_FL_STRICT` with conventional strict-mode semantics and supersedes #48.

- `SGLANG_FL_STRICT=1`: strict mode; fail immediately without fallback.
- `SGLANG_FL_STRICT=0`: fallback-enabled mode.
- Default to `strict=False`, preserving fallback-enabled behavior by default.

## Changes

- Invert the fallback condition to `not policy.strict`.
- Change the default strict value from `True` to `False`.
- Update policy documentation and configuration handling.
- Add tests verifying that:
  - `strict=False` falls back when the primary implementation fails.
  - `strict=True` raises the original error without invoking fallback.
- Update E2E expectations for environment-variable and YAML strict settings.
- Set functional operator tests to `strict=False` where fallback is expected.

## Tests

    pytest -vv \
      tests/unit_tests/dispatch/test_manager.py \
      tests/unit_tests/dispatch/test_env_policy.py \
      tests/unit_tests/dispatch/test_policy.py

    pytest -vv tests/functional_tests/ops/test_ops_correctness.py

    python tests/run.py --platform cuda --scope functional

Functional operator test result:

    8 passed, 3 skipped, 0 failed