### PR TITLE
feat(musa): support SGLang profiling endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,67 @@ SGLANG_FL_CONFIG=./my_config.yaml SGLANG_FL_PREFER=reference \
 
 ## Debugging & Diagnostics
 
+### MUSA profiling with msys and mcu
+
+On Moore Threads devices, the plugin replaces the CUDA assumptions in
+SGLang v0.5.11's existing profiling endpoint:
+
+| SGLang activity | MUSA behavior | Purpose |
+|---|---|---|
+| `GPU` or `MUSA` | `torch.profiler.ProfilerActivity.MUSA` | PyTorch/MUSA Chrome traces |
+| `MSYS` or `MUSA_PROFILER` | `musaProfilerStart/Stop` | msys capture-range control |
+| `CUDA_PROFILER` | Mapped to `musaProfilerStart/Stop` on MUSA | Backward-compatible clients |
+
+Launch the server under msys, then use SGLang's existing endpoints to delimit
+the steady-state capture:
+
+```bash
+SGLANG_PROFILE_V2=0 /data/tools/bin/msys profile \
+  --trace=musa \
+  --capture-range=musaProfilerApi \
+  --capture-range-end=stop-shutdown \
+  -o sglang.msys-rep \
+  python -m sglang.launch_server \
+    --model-path /path/to/model \
+    --port 30000 \
+    --disable-piecewise-cuda-graph
+
+curl -X POST http://127.0.0.1:30000/start_profile \
+  -H 'Content-Type: application/json' \
+  -d '{"activities":["MSYS"]}'
+
+# Send the warmed-up representative request(s).
+
+curl -X POST http://127.0.0.1:30000/stop_profile
+```
+
+SGLang v0.5.11 requires `SGLANG_PROFILE_V2=0` for manual start/stop; V2 only
+supports stage-based triggering. MUSA 4.3 may return error 801 from the
+profiler API even when msys accepts the marker. The plugin clears that sticky
+runtime error so it cannot poison the next TorchMUSA kernel. Treat the
+generated `.msys-rep` as the source of truth. Moore Perf System 1.8.0 was
+observed to finalize the report after the wrapped server exits.
+
+`mcu` is a launch-only, application-replay kernel profiler and cannot attach
+to a live server, so mapping it to `/start_profile` would have incorrect
+semantics. Run it against a deterministic offline workload or minimal kernel
+reproducer instead:
+
+```bash
+/data/tools/bin/mcu \
+  --devices 0 \
+  -k regex:"hot_kernel|gemm" \
+  --launch-skip 0 --launch-count 1 \
+  --sections SpeedOfLight,LaunchStats,MemoryWorkloadAnalysis \
+  -o hot-kernel.mcu-rep \
+  python examples/qwen3_6_27b_offline_inference.py
+```
+
+Use msys to identify cumulative hotspots first, then narrow mcu collection to
+one to three kernels. Full sections relaunch the whole application repeatedly,
+so inputs, launch order, and random seeds must be deterministic. Use an
+equivalent eager reproducer for workloads that normally execute under Graph.
+
 ### Dispatch Log
 
 See which backend each fused op resolved to (written at server startup):

--- a/README.md
+++ b/README.md
@@ -531,14 +531,20 @@ The plugin scans `dispatch/backends/vendor/*/register_ops.py` at startup. If `is
 
 #### Performance profiling with msys
 
-The MThreads backend replaces the CUDA assumptions in SGLang v0.5.11's
-existing profiling endpoint:
+The MThreads backend lets SGLang v0.5.11 own the profiler lifecycle and
+redirects its two CUDA-oriented leaves on MUSA workers:
 
 | SGLang activity | MUSA behavior | Purpose |
 |---|---|---|
-| `GPU` or `MUSA` | `torch.profiler.ProfilerActivity.MUSA` | PyTorch/MUSA Chrome traces |
-| `MSYS` or `MUSA_PROFILER` | `musaProfilerStart/Stop` | msys capture-range control |
-| `CUDA_PROFILER` | Mapped to `musaProfilerStart/Stop` on MUSA | Backward-compatible clients |
+| `GPU` | `torch.profiler.ProfilerActivity.PrivateUse1` (`MUSA`) | PyTorch/MUSA Chrome traces |
+| `CUDA_PROFILER` | `musaProfilerStart/Stop` | msys capture-range control |
+
+This integration targets SGLang v0.5.11 exactly. The MThreads branch of
+`PlatformFL.init_backend` follows SGLang's existing `torch_npu` pattern by
+redirecting the Torch activity and runtime marker APIs instead of replacing
+SGLang's legacy or profile-v2 implementations. A small, version-locked
+compatibility shim adds transactional cleanup to v0.5.11's profiler failure
+paths.
 
 Launch the server under msys, then use SGLang's existing endpoints to delimit
 the steady-state capture:
@@ -556,7 +562,7 @@ SGLANG_PROFILE_V2=0 /data/tools/bin/msys profile \
 
 curl -X POST http://127.0.0.1:30000/start_profile \
   -H 'Content-Type: application/json' \
-  -d '{"activities":["MSYS"]}'
+  -d '{"activities":["CUDA_PROFILER"]}'
 
 # Send the warmed-up representative request(s).
 
@@ -566,8 +572,13 @@ curl -X POST http://127.0.0.1:30000/stop_profile
 SGLang v0.5.11 requires `SGLANG_PROFILE_V2=0` for manual start/stop; V2 only
 supports stage-based triggering. MUSA 4.3 may return error 801 from the
 profiler API even when msys accepts the marker. The plugin clears that sticky
-runtime error so it cannot poison the next TorchMUSA kernel. Treat the
-generated `.msys-rep` as the source of truth. Moore Perf System 1.8.0 was
+runtime error and treats only error 801 as the observed msys compatibility
+case; every other non-zero result raises an error after cleanup. On the first
+`CUDA_PROFILER` marker, the plugin verifies the required symbols in the active
+`libmusart.so`; marker-error diagnostics include the runtime version when that
+API is available. This path was validated with MUSA Runtime 4.3.x,
+Torch/TorchMUSA 2.9.0, and Moore Perf System 1.8.0. Treat
+the generated `.msys-rep` as the source of truth; Moore Perf System 1.8.0 was
 observed to finalize the report after the wrapped server exits.
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ The plugin scans `dispatch/backends/vendor/*/register_ops.py` at startup. If `is
 
 ### Moore Threads (MUSA)
 
-#### Performance profiling with msys and mcu
+#### Performance profiling with msys
 
 The MThreads backend replaces the CUDA assumptions in SGLang v0.5.11's
 existing profiling endpoint:
@@ -569,26 +569,6 @@ profiler API even when msys accepts the marker. The plugin clears that sticky
 runtime error so it cannot poison the next TorchMUSA kernel. Treat the
 generated `.msys-rep` as the source of truth. Moore Perf System 1.8.0 was
 observed to finalize the report after the wrapped server exits.
-
-`mcu` is a launch-only, application-replay kernel profiler and cannot attach
-to a live server, so mapping it to `/start_profile` would have incorrect
-semantics. Run it against a deterministic offline workload or minimal kernel
-reproducer instead:
-
-```bash
-/data/tools/bin/mcu \
-  --devices 0 \
-  -k regex:"hot_kernel|gemm" \
-  --launch-skip 0 --launch-count 1 \
-  --sections SpeedOfLight,LaunchStats,MemoryWorkloadAnalysis \
-  -o hot-kernel.mcu-rep \
-  python examples/qwen3_6_27b_offline_inference.py
-```
-
-Use msys to identify cumulative hotspots first, then narrow mcu collection to
-one to three kernels. Full sections relaunch the whole application repeatedly,
-so inputs, launch order, and random seeds must be deterministic. Use an
-equivalent eager reproducer for workloads that normally execute under Graph.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -322,67 +322,6 @@ SGLANG_FL_CONFIG=./my_config.yaml SGLANG_FL_PREFER=reference \
 
 ## Debugging & Diagnostics
 
-### MUSA profiling with msys and mcu
-
-On Moore Threads devices, the plugin replaces the CUDA assumptions in
-SGLang v0.5.11's existing profiling endpoint:
-
-| SGLang activity | MUSA behavior | Purpose |
-|---|---|---|
-| `GPU` or `MUSA` | `torch.profiler.ProfilerActivity.MUSA` | PyTorch/MUSA Chrome traces |
-| `MSYS` or `MUSA_PROFILER` | `musaProfilerStart/Stop` | msys capture-range control |
-| `CUDA_PROFILER` | Mapped to `musaProfilerStart/Stop` on MUSA | Backward-compatible clients |
-
-Launch the server under msys, then use SGLang's existing endpoints to delimit
-the steady-state capture:
-
-```bash
-SGLANG_PROFILE_V2=0 /data/tools/bin/msys profile \
-  --trace=musa \
-  --capture-range=musaProfilerApi \
-  --capture-range-end=stop-shutdown \
-  -o sglang.msys-rep \
-  python -m sglang.launch_server \
-    --model-path /path/to/model \
-    --port 30000 \
-    --disable-piecewise-cuda-graph
-
-curl -X POST http://127.0.0.1:30000/start_profile \
-  -H 'Content-Type: application/json' \
-  -d '{"activities":["MSYS"]}'
-
-# Send the warmed-up representative request(s).
-
-curl -X POST http://127.0.0.1:30000/stop_profile
-```
-
-SGLang v0.5.11 requires `SGLANG_PROFILE_V2=0` for manual start/stop; V2 only
-supports stage-based triggering. MUSA 4.3 may return error 801 from the
-profiler API even when msys accepts the marker. The plugin clears that sticky
-runtime error so it cannot poison the next TorchMUSA kernel. Treat the
-generated `.msys-rep` as the source of truth. Moore Perf System 1.8.0 was
-observed to finalize the report after the wrapped server exits.
-
-`mcu` is a launch-only, application-replay kernel profiler and cannot attach
-to a live server, so mapping it to `/start_profile` would have incorrect
-semantics. Run it against a deterministic offline workload or minimal kernel
-reproducer instead:
-
-```bash
-/data/tools/bin/mcu \
-  --devices 0 \
-  -k regex:"hot_kernel|gemm" \
-  --launch-skip 0 --launch-count 1 \
-  --sections SpeedOfLight,LaunchStats,MemoryWorkloadAnalysis \
-  -o hot-kernel.mcu-rep \
-  python examples/qwen3_6_27b_offline_inference.py
-```
-
-Use msys to identify cumulative hotspots first, then narrow mcu collection to
-one to three kernels. Full sections relaunch the whole application repeatedly,
-so inputs, launch order, and random seeds must be deterministic. Use an
-equivalent eager reproducer for workloads that normally execute under Graph.
-
 ### Dispatch Log
 
 See which backend each fused op resolved to (written at server startup):
@@ -585,7 +524,71 @@ The plugin scans `dispatch/backends/vendor/*/register_ops.py` at startup. If `is
 |--------|-----------|-------------------|
 | NVIDIA CUDA | `vendor/cuda/` | `sgl_kernel` importable |
 | Huawei Ascend | `vendor/ascend/` | `torch_npu` importable |
+| Moore Threads MUSA | `vendor/mthreads/` | `torch.musa` available |
 | Template | `vendor/template/` | Always False (reference only) |
+
+### Moore Threads (MUSA)
+
+#### Performance profiling with msys and mcu
+
+The MThreads backend replaces the CUDA assumptions in SGLang v0.5.11's
+existing profiling endpoint:
+
+| SGLang activity | MUSA behavior | Purpose |
+|---|---|---|
+| `GPU` or `MUSA` | `torch.profiler.ProfilerActivity.MUSA` | PyTorch/MUSA Chrome traces |
+| `MSYS` or `MUSA_PROFILER` | `musaProfilerStart/Stop` | msys capture-range control |
+| `CUDA_PROFILER` | Mapped to `musaProfilerStart/Stop` on MUSA | Backward-compatible clients |
+
+Launch the server under msys, then use SGLang's existing endpoints to delimit
+the steady-state capture:
+
+```bash
+SGLANG_PROFILE_V2=0 /data/tools/bin/msys profile \
+  --trace=musa \
+  --capture-range=musaProfilerApi \
+  --capture-range-end=stop-shutdown \
+  -o sglang.msys-rep \
+  python -m sglang.launch_server \
+    --model-path /path/to/model \
+    --port 30000 \
+    --disable-piecewise-cuda-graph
+
+curl -X POST http://127.0.0.1:30000/start_profile \
+  -H 'Content-Type: application/json' \
+  -d '{"activities":["MSYS"]}'
+
+# Send the warmed-up representative request(s).
+
+curl -X POST http://127.0.0.1:30000/stop_profile
+```
+
+SGLang v0.5.11 requires `SGLANG_PROFILE_V2=0` for manual start/stop; V2 only
+supports stage-based triggering. MUSA 4.3 may return error 801 from the
+profiler API even when msys accepts the marker. The plugin clears that sticky
+runtime error so it cannot poison the next TorchMUSA kernel. Treat the
+generated `.msys-rep` as the source of truth. Moore Perf System 1.8.0 was
+observed to finalize the report after the wrapped server exits.
+
+`mcu` is a launch-only, application-replay kernel profiler and cannot attach
+to a live server, so mapping it to `/start_profile` would have incorrect
+semantics. Run it against a deterministic offline workload or minimal kernel
+reproducer instead:
+
+```bash
+/data/tools/bin/mcu \
+  --devices 0 \
+  -k regex:"hot_kernel|gemm" \
+  --launch-skip 0 --launch-count 1 \
+  --sections SpeedOfLight,LaunchStats,MemoryWorkloadAnalysis \
+  -o hot-kernel.mcu-rep \
+  python examples/qwen3_6_27b_offline_inference.py
+```
+
+Use msys to identify cumulative hotspots first, then narrow mcu collection to
+one to three kernels. Full sections relaunch the whole application repeatedly,
+so inputs, launch order, and random seeds must be deterministic. Use an
+equivalent eager reproducer for workloads that normally execute under Graph.
 
 ## Project Structure
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -341,54 +341,6 @@ SGLANG_FL_CONFIG=./my_config.yaml SGLANG_FL_PREFER=reference \
 
 ## 调试与诊断
 
-### MUSA 性能分析（msys / mcu）
-
-在摩尔线程平台上，插件会补齐 SGLang v0.5.11 profiling 实现中的 CUDA 假设：
-
-| SGLang activity | MUSA 行为 | 用途 |
-|---|---|---|
-| `GPU` 或 `MUSA` | `torch.profiler.ProfilerActivity.MUSA` | 生成 PyTorch/MUSA Chrome trace |
-| `MSYS` 或 `MUSA_PROFILER` | `musaProfilerStart/Stop` | 控制 msys capture range |
-| `CUDA_PROFILER` | 在 MUSA 上兼容映射到 `musaProfilerStart/Stop` | 兼容已有 SGLang 客户端 |
-
-用 msys 包住服务进程，再通过 SGLang 原有端点控制采集窗口：
-
-```bash
-SGLANG_PROFILE_V2=0 /data/tools/bin/msys profile \
-  --trace=musa \
-  --capture-range=musaProfilerApi \
-  --capture-range-end=stop-shutdown \
-  -o sglang.msys-rep \
-  python -m sglang.launch_server \
-    --model-path /path/to/model \
-    --port 30000 \
-    --disable-piecewise-cuda-graph
-
-curl -X POST http://127.0.0.1:30000/start_profile \
-  -H 'Content-Type: application/json' \
-  -d '{"activities":["MSYS"]}'
-
-# 发送需要采集的、已经完成 warmup 的代表性请求
-
-curl -X POST http://127.0.0.1:30000/stop_profile
-```
-
-`SGLANG_PROFILE_V2=0` 是 SGLang v0.5.11 手动 start/stop 端点的要求；V2 当前只支持按 stage 触发。MUSA 4.3 的 runtime 可能让 profiler API 返回错误码 801，但 msys 仍接受 range marker；插件会立即清除 sticky runtime error，避免下一次 TorchMUSA kernel 被误报为失败。以生成的 `.msys-rep` 为最终判断依据。Moore Perf System 1.8.0 在实测环境中会等被包裹的服务进程退出后完成报告落盘。
-
-`mcu` 是启动式、application-replay kernel profiler，不支持 attach 到已运行服务，因此不能实现有正确语义的 `/start_profile`。应对确定性离线脚本或最小 kernel 复现使用：
-
-```bash
-/data/tools/bin/mcu \
-  --devices 0 \
-  -k regex:"hot_kernel|gemm" \
-  --launch-skip 0 --launch-count 1 \
-  --sections SpeedOfLight,LaunchStats,MemoryWorkloadAnalysis \
-  -o hot-kernel.mcu-rep \
-  python examples/qwen3_6_27b_offline_inference.py
-```
-
-完整 section 需要多次重启整个应用。输入、kernel 顺序和随机种子必须确定；先由 msys 找到累计热点，再用 kernel filter 缩到 1–3 个候选。Graph 工作负载应准备等价 eager 复现后再交给当前版本的 mcu。
-
 ### Dispatch 日志
 
 查看每个融合算子解析到了哪个后端（服务启动时写入）：
@@ -591,7 +543,58 @@ def register_builtins(registry) -> None:
 |------|------|---------|
 | NVIDIA CUDA | `vendor/cuda/` | `sgl_kernel` 可导入 |
 | 华为昇腾 | `vendor/ascend/` | `torch_npu` 可导入 |
+| 摩尔线程 MUSA | `vendor/mthreads/` | `torch.musa` 可用 |
 | 模板 | `vendor/template/` | 始终 False（仅供参考） |
+
+### 摩尔线程（MUSA）
+
+#### 性能分析（msys / mcu）
+
+MThreads 后端会补齐 SGLang v0.5.11 profiling 实现中的 CUDA 假设：
+
+| SGLang activity | MUSA 行为 | 用途 |
+|---|---|---|
+| `GPU` 或 `MUSA` | `torch.profiler.ProfilerActivity.MUSA` | 生成 PyTorch/MUSA Chrome trace |
+| `MSYS` 或 `MUSA_PROFILER` | `musaProfilerStart/Stop` | 控制 msys capture range |
+| `CUDA_PROFILER` | 在 MUSA 上兼容映射到 `musaProfilerStart/Stop` | 兼容已有 SGLang 客户端 |
+
+用 msys 包住服务进程，再通过 SGLang 原有端点控制采集窗口：
+
+```bash
+SGLANG_PROFILE_V2=0 /data/tools/bin/msys profile \
+  --trace=musa \
+  --capture-range=musaProfilerApi \
+  --capture-range-end=stop-shutdown \
+  -o sglang.msys-rep \
+  python -m sglang.launch_server \
+    --model-path /path/to/model \
+    --port 30000 \
+    --disable-piecewise-cuda-graph
+
+curl -X POST http://127.0.0.1:30000/start_profile \
+  -H 'Content-Type: application/json' \
+  -d '{"activities":["MSYS"]}'
+
+# 发送需要采集的、已经完成 warmup 的代表性请求
+
+curl -X POST http://127.0.0.1:30000/stop_profile
+```
+
+`SGLANG_PROFILE_V2=0` 是 SGLang v0.5.11 手动 start/stop 端点的要求；V2 当前只支持按 stage 触发。MUSA 4.3 的 runtime 可能让 profiler API 返回错误码 801，但 msys 仍接受 range marker；插件会立即清除 sticky runtime error，避免下一次 TorchMUSA kernel 被误报为失败。以生成的 `.msys-rep` 为最终判断依据。Moore Perf System 1.8.0 在实测环境中会等被包裹的服务进程退出后完成报告落盘。
+
+`mcu` 是启动式、application-replay kernel profiler，不支持 attach 到已运行服务，因此不能实现有正确语义的 `/start_profile`。应对确定性离线脚本或最小 kernel 复现使用：
+
+```bash
+/data/tools/bin/mcu \
+  --devices 0 \
+  -k regex:"hot_kernel|gemm" \
+  --launch-skip 0 --launch-count 1 \
+  --sections SpeedOfLight,LaunchStats,MemoryWorkloadAnalysis \
+  -o hot-kernel.mcu-rep \
+  python examples/qwen3_6_27b_offline_inference.py
+```
+
+完整 section 需要多次重启整个应用。输入、kernel 顺序和随机种子必须确定；先由 msys 找到累计热点，再用 kernel filter 缩到 1–3 个候选。Graph 工作负载应准备等价 eager 复现后再交给当前版本的 mcu。
 
 ## 项目结构
 
@@ -601,7 +604,6 @@ sglang_fl/
 └── sglang_fl/
     ├── __init__.py                   # 插件入口：FlagGems + dispatch 初始化 + communicator hooks
     ├── platform.py                   # PlatformFL（设备标识、内存、graph capture）
-    ├── profiler.py                   # MUSA torch profiler + msys capture-range 适配
     ├── distributed/                  # 通信模块（与 vllm-plugin-FL 对齐）
     │   ├── __init__.py
     │   ├── communicator.py           # CommunicatorFL（FlagCX / torch.distributed 封装）
@@ -639,6 +641,10 @@ sglang_fl/
             └── vendor/               # VENDOR 后端（自动发现）
                 ├── ascend/           # 华为昇腾 NPU (torch_npu)
                 ├── cuda/             # NVIDIA CUDA (sgl_kernel)
+                ├── mthreads/         # 摩尔线程 MUSA
+                │   ├── patch.py      # MUSA patch 统一入口
+                │   └── patches/
+                │       └── profiler.py # TorchMUSA + msys capture-range 适配
                 └── template/         # 新厂商模板
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -550,13 +550,18 @@ def register_builtins(registry) -> None:
 
 #### 性能分析（msys）
 
-MThreads 后端会补齐 SGLang v0.5.11 profiling 实现中的 CUDA 假设：
+MThreads 后端让 SGLang v0.5.11 继续管理 profiler 生命周期，只在 MUSA
+worker 中重定向两个依赖 CUDA 的末端接口：
 
 | SGLang activity | MUSA 行为 | 用途 |
 |---|---|---|
-| `GPU` 或 `MUSA` | `torch.profiler.ProfilerActivity.MUSA` | 生成 PyTorch/MUSA Chrome trace |
-| `MSYS` 或 `MUSA_PROFILER` | `musaProfilerStart/Stop` | 控制 msys capture range |
-| `CUDA_PROFILER` | 在 MUSA 上兼容映射到 `musaProfilerStart/Stop` | 兼容已有 SGLang 客户端 |
+| `GPU` | `torch.profiler.ProfilerActivity.PrivateUse1`（`MUSA`） | 生成 PyTorch/MUSA Chrome trace |
+| `CUDA_PROFILER` | `musaProfilerStart/Stop` | 控制 msys capture range |
+
+该适配严格面向 SGLang v0.5.11。`PlatformFL.init_backend` 的 MThreads 分支
+沿用 SGLang 已有的 `torch_npu` 模式，重定向 Torch activity 和 runtime
+marker API，不替换 legacy 或 profile-v2 实现；另有一个带版本保护的小型
+兼容层，为 v0.5.11 的 profiler 失败路径补充事务式清理。
 
 用 msys 包住服务进程，再通过 SGLang 原有端点控制采集窗口：
 
@@ -573,14 +578,14 @@ SGLANG_PROFILE_V2=0 /data/tools/bin/msys profile \
 
 curl -X POST http://127.0.0.1:30000/start_profile \
   -H 'Content-Type: application/json' \
-  -d '{"activities":["MSYS"]}'
+  -d '{"activities":["CUDA_PROFILER"]}'
 
 # 发送需要采集的、已经完成 warmup 的代表性请求
 
 curl -X POST http://127.0.0.1:30000/stop_profile
 ```
 
-`SGLANG_PROFILE_V2=0` 是 SGLang v0.5.11 手动 start/stop 端点的要求；V2 当前只支持按 stage 触发。MUSA 4.3 的 runtime 可能让 profiler API 返回错误码 801，但 msys 仍接受 range marker；插件会立即清除 sticky runtime error，避免下一次 TorchMUSA kernel 被误报为失败。以生成的 `.msys-rep` 为最终判断依据。Moore Perf System 1.8.0 在实测环境中会等被包裹的服务进程退出后完成报告落盘。
+`SGLANG_PROFILE_V2=0` 是 SGLang v0.5.11 手动 start/stop 端点的要求；V2 当前只支持按 stage 触发。MUSA 4.3 的 runtime 可能让 profiler API 返回错误码 801，但 msys 仍接受 range marker；插件会立即清除 sticky runtime error，并且只把 801 作为已验证的 msys 兼容情况继续执行，其他非零错误在清理后抛出。首次使用 `CUDA_PROFILER` marker 时，插件会检查当前 `libmusart.so` 的必需符号；marker 报错时，如果接口可用，诊断信息会包含 runtime 版本。该路径已在 MUSA Runtime 4.3.x、Torch/TorchMUSA 2.9.0 和 Moore Perf System 1.8.0 上验证。以生成的 `.msys-rep` 为最终判断依据；Moore Perf System 1.8.0 在实测环境中会等被包裹的服务进程退出后完成报告落盘。
 
 ## 项目结构
 
@@ -630,7 +635,8 @@ sglang_fl/
                 ├── mthreads/         # 摩尔线程 MUSA
                 │   ├── patch.py      # MUSA patch 统一入口
                 │   └── patches/
-                │       └── profiler.py # TorchMUSA + msys capture-range 适配
+                │       ├── profiler.py # TorchMUSA + msys API 重定向
+                │       └── sglang_0_5_11_profiler_lifecycle.py # 失败回滚兼容层
                 └── template/         # 新厂商模板
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -341,6 +341,54 @@ SGLANG_FL_CONFIG=./my_config.yaml SGLANG_FL_PREFER=reference \
 
 ## 调试与诊断
 
+### MUSA 性能分析（msys / mcu）
+
+在摩尔线程平台上，插件会补齐 SGLang v0.5.11 profiling 实现中的 CUDA 假设：
+
+| SGLang activity | MUSA 行为 | 用途 |
+|---|---|---|
+| `GPU` 或 `MUSA` | `torch.profiler.ProfilerActivity.MUSA` | 生成 PyTorch/MUSA Chrome trace |
+| `MSYS` 或 `MUSA_PROFILER` | `musaProfilerStart/Stop` | 控制 msys capture range |
+| `CUDA_PROFILER` | 在 MUSA 上兼容映射到 `musaProfilerStart/Stop` | 兼容已有 SGLang 客户端 |
+
+用 msys 包住服务进程，再通过 SGLang 原有端点控制采集窗口：
+
+```bash
+SGLANG_PROFILE_V2=0 /data/tools/bin/msys profile \
+  --trace=musa \
+  --capture-range=musaProfilerApi \
+  --capture-range-end=stop-shutdown \
+  -o sglang.msys-rep \
+  python -m sglang.launch_server \
+    --model-path /path/to/model \
+    --port 30000 \
+    --disable-piecewise-cuda-graph
+
+curl -X POST http://127.0.0.1:30000/start_profile \
+  -H 'Content-Type: application/json' \
+  -d '{"activities":["MSYS"]}'
+
+# 发送需要采集的、已经完成 warmup 的代表性请求
+
+curl -X POST http://127.0.0.1:30000/stop_profile
+```
+
+`SGLANG_PROFILE_V2=0` 是 SGLang v0.5.11 手动 start/stop 端点的要求；V2 当前只支持按 stage 触发。MUSA 4.3 的 runtime 可能让 profiler API 返回错误码 801，但 msys 仍接受 range marker；插件会立即清除 sticky runtime error，避免下一次 TorchMUSA kernel 被误报为失败。以生成的 `.msys-rep` 为最终判断依据。Moore Perf System 1.8.0 在实测环境中会等被包裹的服务进程退出后完成报告落盘。
+
+`mcu` 是启动式、application-replay kernel profiler，不支持 attach 到已运行服务，因此不能实现有正确语义的 `/start_profile`。应对确定性离线脚本或最小 kernel 复现使用：
+
+```bash
+/data/tools/bin/mcu \
+  --devices 0 \
+  -k regex:"hot_kernel|gemm" \
+  --launch-skip 0 --launch-count 1 \
+  --sections SpeedOfLight,LaunchStats,MemoryWorkloadAnalysis \
+  -o hot-kernel.mcu-rep \
+  python examples/qwen3_6_27b_offline_inference.py
+```
+
+完整 section 需要多次重启整个应用。输入、kernel 顺序和随机种子必须确定；先由 msys 找到累计热点，再用 kernel filter 缩到 1–3 个候选。Graph 工作负载应准备等价 eager 复现后再交给当前版本的 mcu。
+
 ### Dispatch 日志
 
 查看每个融合算子解析到了哪个后端（服务启动时写入）：
@@ -553,6 +601,7 @@ sglang_fl/
 └── sglang_fl/
     ├── __init__.py                   # 插件入口：FlagGems + dispatch 初始化 + communicator hooks
     ├── platform.py                   # PlatformFL（设备标识、内存、graph capture）
+    ├── profiler.py                   # MUSA torch profiler + msys capture-range 适配
     ├── distributed/                  # 通信模块（与 vllm-plugin-FL 对齐）
     │   ├── __init__.py
     │   ├── communicator.py           # CommunicatorFL（FlagCX / torch.distributed 封装）

--- a/README_zh.md
+++ b/README_zh.md
@@ -548,7 +548,7 @@ def register_builtins(registry) -> None:
 
 ### 摩尔线程（MUSA）
 
-#### 性能分析（msys / mcu）
+#### 性能分析（msys）
 
 MThreads 后端会补齐 SGLang v0.5.11 profiling 实现中的 CUDA 假设：
 
@@ -581,20 +581,6 @@ curl -X POST http://127.0.0.1:30000/stop_profile
 ```
 
 `SGLANG_PROFILE_V2=0` 是 SGLang v0.5.11 手动 start/stop 端点的要求；V2 当前只支持按 stage 触发。MUSA 4.3 的 runtime 可能让 profiler API 返回错误码 801，但 msys 仍接受 range marker；插件会立即清除 sticky runtime error，避免下一次 TorchMUSA kernel 被误报为失败。以生成的 `.msys-rep` 为最终判断依据。Moore Perf System 1.8.0 在实测环境中会等被包裹的服务进程退出后完成报告落盘。
-
-`mcu` 是启动式、application-replay kernel profiler，不支持 attach 到已运行服务，因此不能实现有正确语义的 `/start_profile`。应对确定性离线脚本或最小 kernel 复现使用：
-
-```bash
-/data/tools/bin/mcu \
-  --devices 0 \
-  -k regex:"hot_kernel|gemm" \
-  --launch-skip 0 --launch-count 1 \
-  --sections SpeedOfLight,LaunchStats,MemoryWorkloadAnalysis \
-  -o hot-kernel.mcu-rep \
-  python examples/qwen3_6_27b_offline_inference.py
-```
-
-完整 section 需要多次重启整个应用。输入、kernel 顺序和随机种子必须确定；先由 msys 找到累计热点，再用 kernel filter 缩到 1–3 个候选。Graph 工作负载应准备等价 eager 复现后再交给当前版本的 mcu。
 
 ## 项目结构
 

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import logging
 from functools import wraps
 
+from .patches.profiler import apply_musa_profiler_patches
+
 logger = logging.getLogger(__name__)
 
 _patches_applied = False
@@ -112,8 +114,6 @@ def apply_musa_patches() -> None:
 
     _patch_pp_send_recv_order()
     _patch_pp_launch_batch_add_sync()
-
-    from sglang_fl.profiler import apply_musa_profiler_patches
 
     apply_musa_profiler_patches()
     _patches_applied = True

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
@@ -104,6 +104,7 @@ def _patch_pp_launch_batch_add_sync() -> None:
     SchedulerPPMixin._pp_launch_batch = pp_launch_batch_with_forward_stream_sync
     logger.info("MUSA PP launch forward_stream sync patch applied")
 
+
 def apply_musa_patches() -> None:
     global _patches_applied
     if _patches_applied:
@@ -111,8 +112,12 @@ def apply_musa_patches() -> None:
 
     _patch_pp_send_recv_order()
     _patch_pp_launch_batch_add_sync()
+
+    from sglang_fl.profiler import apply_musa_profiler_patches
+
+    apply_musa_profiler_patches()
     _patches_applied = True
-    logger.info("All MUSA PP patches applied successfully")
+    logger.info("All MUSA runtime patches applied successfully")
 
 
 apply_musa_patches()

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
@@ -17,8 +17,6 @@ from __future__ import annotations
 import logging
 from functools import wraps
 
-from .patches.profiler import apply_musa_profiler_patches
-
 logger = logging.getLogger(__name__)
 
 _patches_applied = False
@@ -115,7 +113,6 @@ def apply_musa_patches() -> None:
     _patch_pp_send_recv_order()
     _patch_pp_launch_batch_add_sync()
 
-    apply_musa_profiler_patches()
     _patches_applied = True
     logger.info("All MUSA runtime patches applied successfully")
 

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patches/__init__.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patches/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Moore Threads-specific patches for SGLang internals."""

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patches/profiler.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patches/profiler.py
@@ -23,7 +23,8 @@ implementation in v0.5.11 assumes CUDA in two places:
 TorchMUSA exposes a PrivateUse1/MUSA profiler activity and the MUSA runtime
 provides the equivalent ``musaProfilerStart``/``musaProfilerStop`` markers.
 This module patches those two implementation details without changing the
-HTTP API or SGLang core.
+HTTP API or SGLang core. It lives under the Moore Threads vendor package so
+MUSA-specific runtime dependencies do not appear to be platform-neutral APIs.
 """
 
 from __future__ import annotations

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patches/profiler.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patches/profiler.py
@@ -12,19 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""MUSA profiling integration for SGLang.
+"""MUSA redirects for SGLang v0.5.11's CUDA-oriented profiler APIs.
 
-SGLang's public ``/start_profile`` endpoint is platform neutral, but the
-implementation in v0.5.11 assumes CUDA in two places:
+SGLang v0.5.11 owns the profiler lifecycle and recognizes the public activity
+names ``GPU`` and ``CUDA_PROFILER``. On MUSA workers this module redirects the
+two CUDA-specific leaves used by that implementation:
 
-* ``GPU`` is translated to ``torch.profiler.ProfilerActivity.CUDA``.
-* ``CUDA_PROFILER`` calls ``cudaProfilerStart``/``cudaProfilerStop``.
+* ``ProfilerActivity.CUDA`` becomes TorchMUSA's PrivateUse1/MUSA activity.
+* ``torch.cuda.cudart()`` returns a delegating proxy whose profiler markers
+  call ``musaProfilerStart`` and ``musaProfilerStop``.
 
-TorchMUSA exposes a PrivateUse1/MUSA profiler activity and the MUSA runtime
-provides the equivalent ``musaProfilerStart``/``musaProfilerStop`` markers.
-This module patches those two implementation details without changing the
-HTTP API or SGLang core. It lives under the Moore Threads vendor package so
-MUSA-specific runtime dependencies do not appear to be platform-neutral APIs.
+No SGLang profiler implementation is copied here. The only SGLang-internal
+compatibility patch is a version-locked transactional cleanup shim for failure
+paths that v0.5.11 does not roll back itself.
 """
 
 from __future__ import annotations
@@ -32,61 +32,162 @@ from __future__ import annotations
 import ctypes
 import logging
 from functools import wraps
-from typing import Iterable
+from typing import Callable
 
 import torch
 
+from .sglang_0_5_11_profiler_lifecycle import (
+    apply_sglang_0_5_11_profiler_lifecycle_patch,
+)
+
 logger = logging.getLogger(__name__)
 
-# ``CUDA_PROFILER`` keeps existing SGLang profiling clients working on MUSA.
-# The MUSA-specific names make new configurations self-documenting.
-MUSA_API_ACTIVITIES = frozenset({"CUDA_PROFILER", "MUSA_PROFILER", "MSYS"})
-MUSA_TORCH_ACTIVITIES = frozenset({"GPU", "MUSA"})
+MUSA_SUCCESS = 0
+MUSA_ERROR_NOT_SUPPORTED = 801
+_MUSART_SONAME = "libmusart.so"
+_REQUIRED_MUSART_SYMBOLS = (
+    "musaProfilerStart",
+    "musaProfilerStop",
+    "musaGetLastError",
+)
+
+
+class MusaProfilerError(RuntimeError):
+    """A MUSA profiler runtime or ABI failure."""
 
 
 class MusaProfilerApi:
-    """Call MUSA profiler range markers through the runtime shared library."""
+    """Call MUSA capture-range markers through the runtime shared library.
+
+    The adapter is validated with MUSA Runtime 4.3.x. It intentionally loads
+    the unversioned SONAME so the active MUSA installation controls which ABI
+    is selected, then requires every symbol and declares each C signature used
+    by this module.
+    """
 
     def __init__(self) -> None:
         self._library = None
 
-    def _load_library(self):
-        if self._library is None:
-            try:
-                library = ctypes.CDLL("libmusart.so")
-            except OSError as exc:
-                raise RuntimeError(
-                    "Cannot load libmusart.so; install the MUSA runtime and expose "
-                    "its library directory to the SGLang worker process."
-                ) from exc
+    def validate(self) -> None:
+        """Load the runtime and verify the required profiler ABI."""
+        self._load_library()
 
-            for name in ("musaProfilerStart", "musaProfilerStop"):
+    def _load_library(self):
+        if self._library is not None:
+            return self._library
+
+        try:
+            library = ctypes.CDLL(_MUSART_SONAME)
+        except OSError as exc:
+            raise MusaProfilerError(
+                f"Cannot load {_MUSART_SONAME}; install the MUSA runtime and "
+                "expose its library directory to the SGLang worker process."
+            ) from exc
+
+        missing = [
+            name for name in _REQUIRED_MUSART_SYMBOLS if not hasattr(library, name)
+        ]
+        if missing:
+            raise MusaProfilerError(
+                f"{_MUSART_SONAME} is missing required profiler symbols: "
+                + ", ".join(missing)
+            )
+
+        try:
+            for name in (
+                "musaProfilerStart",
+                "musaProfilerStop",
+                "musaGetLastError",
+            ):
                 function = getattr(library, name)
                 function.argtypes = []
                 function.restype = ctypes.c_int
-            library.musaGetLastError.argtypes = []
-            library.musaGetLastError.restype = ctypes.c_int
-            self._library = library
-        return self._library
+
+            runtime_version = getattr(library, "musaRuntimeGetVersion", None)
+            if runtime_version is not None:
+                runtime_version.argtypes = [ctypes.POINTER(ctypes.c_int)]
+                runtime_version.restype = ctypes.c_int
+
+            error_string = getattr(library, "musaGetErrorString", None)
+            if error_string is not None:
+                error_string.argtypes = [ctypes.c_int]
+                error_string.restype = ctypes.c_char_p
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise MusaProfilerError(
+                f"Cannot configure the required {_MUSART_SONAME} profiler ABI"
+            ) from exc
+
+        self._library = library
+        return library
+
+    @staticmethod
+    def _runtime_version(library) -> str:
+        function = getattr(library, "musaRuntimeGetVersion", None)
+        if function is None:
+            return "unknown"
+
+        version = ctypes.c_int()
+        try:
+            result = int(function(ctypes.byref(version)))
+        except (AttributeError, OSError, TypeError, ValueError):
+            return "unknown"
+        return str(version.value) if result == MUSA_SUCCESS else "unknown"
+
+    @staticmethod
+    def _error_text(library, result: int) -> str:
+        function = getattr(library, "musaGetErrorString", None)
+        if function is None:
+            return "unknown"
+
+        try:
+            value = function(result)
+        except (AttributeError, OSError, TypeError, ValueError):
+            return "unknown"
+        if isinstance(value, bytes):
+            return value.decode(errors="replace")
+        return str(value) if value else "unknown"
 
     def _call(self, name: str) -> int:
         library = self._load_library()
-        result = int(getattr(library, name)())
+        try:
+            result = int(getattr(library, name)())
+        except Exception as exc:
+            raise MusaProfilerError(
+                f"Calling {name} from {_MUSART_SONAME} failed"
+            ) from exc
 
-        # MUSA 4.3 may return musaErrorNotSupported (801) even though msys has
-        # observed and acted on the range marker. Clear the sticky runtime
-        # error immediately; otherwise the next TorchMUSA kernel reports the
-        # profiler error as if the kernel itself had failed.
-        if result != 0:
+        if result == MUSA_SUCCESS:
+            return MUSA_SUCCESS
+
+        try:
             cleared = int(library.musaGetLastError())
+        except Exception as exc:
+            raise MusaProfilerError(
+                f"{name} returned MUSA error {result}, and musaGetLastError "
+                "failed while clearing the sticky runtime error"
+            ) from exc
+
+        runtime_version = self._runtime_version(library)
+        error_text = self._error_text(library, result)
+        if result == MUSA_ERROR_NOT_SUPPORTED:
+            # MUSA 4.3.x returns 801 under msys even after msys has consumed the
+            # marker. Treat only that observed code as success; all other MUSA
+            # errors remain fatal.
             logger.warning(
-                "%s returned MUSA error %d (cleared error %d); Moore Perf may "
-                "still have accepted the capture-range marker",
+                "%s returned MUSA error 801 (%s), cleared error %d, runtime "
+                "version %s; continuing because msys may already have accepted "
+                "the capture-range marker",
                 name,
-                result,
+                error_text,
                 cleared,
+                runtime_version,
             )
-        return result
+            return MUSA_SUCCESS
+
+        raise MusaProfilerError(
+            f"{name} returned MUSA error {result} ({error_text}); cleared error "
+            f"{cleared}; runtime version {runtime_version}"
+        )
 
     def start(self) -> int:
         return self._call("musaProfilerStart")
@@ -95,209 +196,75 @@ class MusaProfilerApi:
         return self._call("musaProfilerStop")
 
 
+class MusaCudartProxy:
+    """Override only CUDA profiler markers and delegate every other symbol."""
+
+    def __init__(
+        self,
+        original_cudart: Callable[[], object],
+        profiler_api: MusaProfilerApi,
+    ) -> None:
+        self._original_cudart = original_cudart
+        self._profiler_api = profiler_api
+
+    def cudaProfilerStart(self) -> int:
+        return self._profiler_api.start()
+
+    def cudaProfilerStop(self) -> int:
+        return self._profiler_api.stop()
+
+    def __getattr__(self, name: str):
+        return getattr(self._original_cudart(), name)
+
+
 _MUSA_PROFILER_API = MusaProfilerApi()
+_MUSA_CUDART_PROXY = None
 _patches_applied = False
 
 
-def _has_activity(activities: Iterable[str], choices: frozenset[str]) -> bool:
-    return not choices.isdisjoint(activities)
-
-
 def _torch_musa_activity():
-    activity = getattr(torch.profiler.ProfilerActivity, "MUSA", None)
+    # TorchMUSA 2.9 registers the MUSA alias for PrivateUse1. Prefer the
+    # underlying enum so the mapping does not depend on the optional alias.
+    activity = getattr(torch.profiler.ProfilerActivity, "PrivateUse1", None)
     if activity is None:
-        # TorchMUSA registers PrivateUse1 as MUSA on supported releases. Keep a
-        # fallback for builds that expose only the generic enum name.
-        activity = getattr(torch.profiler.ProfilerActivity, "PrivateUse1", None)
+        activity = getattr(torch.profiler.ProfilerActivity, "MUSA", None)
     if activity is None:
-        raise RuntimeError(
-            "This PyTorch/TorchMUSA build does not expose ProfilerActivity.MUSA"
+        raise MusaProfilerError(
+            "This PyTorch/TorchMUSA build does not expose "
+            "ProfilerActivity.PrivateUse1 or ProfilerActivity.MUSA"
         )
     return activity
 
 
-def _make_torch_profiler(activities, with_stack, record_shapes):
-    torch_activities = []
-    if "CPU" in activities:
-        torch_activities.append(torch.profiler.ProfilerActivity.CPU)
-    if _has_activity(activities, MUSA_TORCH_ACTIVITIES):
-        torch_activities.append(_torch_musa_activity())
+def _install_torch_profiler_redirects() -> None:
+    global _MUSA_CUDART_PROXY
 
-    return torch.profiler.profile(
-        activities=torch_activities,
-        with_stack=with_stack if with_stack is not None else True,
-        record_shapes=record_shapes if record_shapes is not None else False,
-    )
+    torch.profiler.ProfilerActivity.CUDA = _torch_musa_activity()
 
+    original_cudart = torch.cuda.cudart
+    _MUSA_CUDART_PROXY = MusaCudartProxy(original_cudart, _MUSA_PROFILER_API)
 
-def _is_first_rank_in_node(scheduler) -> bool:
-    from sglang.srt.server_args import get_global_server_args
+    @wraps(original_cudart)
+    def musa_cudart():
+        return _MUSA_CUDART_PROXY
 
-    return scheduler.gpu_id == get_global_server_args().base_gpu_id
-
-
-def _patch_legacy_scheduler_profiler() -> None:
-    """Patch the default (SGLANG_PROFILE_V2=0) profiler implementation."""
-
-    from sglang.srt.managers.scheduler_profiler_mixin import SchedulerProfilerMixin
-
-    _wrap_legacy_scheduler_profiler(SchedulerProfilerMixin)
-
-
-def _wrap_legacy_scheduler_profiler(profiler_mixin) -> None:
-    """Wrap a SchedulerProfilerMixin class (split out for isolated tests)."""
-
-    original_start = profiler_mixin.start_profile
-    original_stop = profiler_mixin.stop_profile
-
-    @wraps(original_start)
-    def start_profile_with_musa(self, stage=None):
-        activities = list(self.profiler_activities or [])
-        use_musa_torch = _has_activity(activities, MUSA_TORCH_ACTIVITIES)
-        use_musa_api = _has_activity(activities, MUSA_API_ACTIVITIES)
-
-        if not use_musa_torch and not use_musa_api:
-            return original_start(self, stage)
-
-        # Prevent the CUDA-specific branches in SGLang core from running. If
-        # GPU profiling is requested, CPU and MUSA must be created as one
-        # torch.profiler session rather than as two independent sessions.
-        filtered = list(activities)
-        if use_musa_torch:
-            filtered = [
-                activity
-                for activity in filtered
-                if activity not in MUSA_TORCH_ACTIVITIES and activity != "CPU"
-            ]
-        if use_musa_api:
-            filtered = [
-                activity for activity in filtered if activity not in MUSA_API_ACTIVITIES
-            ]
-
-        self.profiler_activities = filtered
-        try:
-            result = original_start(self, stage)
-        finally:
-            self.profiler_activities = activities
-
-        api_started = False
-        try:
-            if use_musa_api and _is_first_rank_in_node(self):
-                _MUSA_PROFILER_API.start()
-                api_started = True
-
-            if use_musa_torch:
-                self.torch_profiler = _make_torch_profiler(
-                    activities,
-                    self.torch_profiler_with_stack,
-                    self.torch_profiler_record_shapes,
-                )
-                self.torch_profiler.start()
-
-            self.profile_in_progress = True
-            return result
-        except Exception:
-            if api_started:
-                _MUSA_PROFILER_API.stop()
-            raise
-
-    @wraps(original_stop)
-    def stop_profile_with_musa(self, stage=None):
-        activities = list(self.profiler_activities or [])
-        use_musa_api = _has_activity(activities, MUSA_API_ACTIVITIES)
-        api_error = None
-
-        # Emit the stop marker before SGLang spends time exporting and merging
-        # torch-profiler traces.
-        if use_musa_api and self.profile_in_progress and _is_first_rank_in_node(self):
-            try:
-                _MUSA_PROFILER_API.stop()
-            except Exception as exc:  # still let SGLang stop its other profilers
-                api_error = exc
-
-        self.profiler_activities = [
-            activity for activity in activities if activity not in MUSA_API_ACTIVITIES
-        ]
-        try:
-            result = original_stop(self, stage)
-        finally:
-            self.profiler_activities = activities
-
-        if api_error is not None:
-            raise api_error
-        return result
-
-    profiler_mixin.start_profile = start_profile_with_musa
-    profiler_mixin.stop_profile = stop_profile_with_musa
-
-
-def _patch_profile_v2() -> None:
-    """Patch stage-based profiling used when SGLANG_PROFILE_V2=1."""
-
-    from sglang.srt.utils.profile_utils import (
-        _ProfilerBase,
-        _ProfilerCudart,
-        _ProfilerTorch,
-    )
-
-    _wrap_profile_v2(_ProfilerBase, _ProfilerTorch, _ProfilerCudart)
-
-
-def _wrap_profile_v2(profiler_base, profiler_torch, profiler_cudart) -> None:
-    """Wrap profile-v2 classes (split out for isolated tests)."""
-
-    original_create = profiler_base.create
-    original_torch_start = profiler_torch.start
-
-    def create(activities, with_stack, record_shapes, **kwargs):
-        normalized = []
-        for activity in activities:
-            if activity == "MUSA":
-                activity = "GPU"
-            elif activity in MUSA_API_ACTIVITIES:
-                activity = "CUDA_PROFILER"
-            if activity not in normalized:
-                normalized.append(activity)
-        return original_create(normalized, with_stack, record_shapes, **kwargs)
-
-    @wraps(original_torch_start)
-    def torch_start_with_musa(self):
-        if not _has_activity(self.activities, MUSA_TORCH_ACTIVITIES):
-            return original_torch_start(self)
-        self.torch_profiler = _make_torch_profiler(
-            self.activities,
-            self.with_stack,
-            self.record_shapes,
-        )
-        self.torch_profiler.start()
-
-    def musa_api_start(self):
-        if self.first_rank_in_node:
-            logger.info("Call musaProfilerStart")
-            _MUSA_PROFILER_API.start()
-
-    def musa_api_stop(self):
-        if self.first_rank_in_node:
-            logger.info("Call musaProfilerStop")
-            _MUSA_PROFILER_API.stop()
-
-    profiler_base.create = staticmethod(create)
-    profiler_torch.start = torch_start_with_musa
-    profiler_cudart.start = musa_api_start
-    profiler_cudart.stop = musa_api_stop
+    torch.cuda.cudart = musa_cudart
 
 
 def apply_musa_profiler_patches() -> None:
-    """Install MUSA profiler support once in the current SGLang process."""
+    """Install the version-locked SGLang v0.5.11 profiler adaptation once.
 
+    ``libmusart.so`` remains lazy: workers that never request
+    ``CUDA_PROFILER`` do not need to load the capture-range marker ABI.
+    """
     global _patches_applied
     if _patches_applied:
         return
 
-    _patch_legacy_scheduler_profiler()
-    _patch_profile_v2()
+    apply_sglang_0_5_11_profiler_lifecycle_patch(MusaProfilerError)
+    _install_torch_profiler_redirects()
     _patches_applied = True
     logger.info(
-        "MUSA profiling patches applied: GPU->MUSA and "
-        "MSYS/MUSA_PROFILER/CUDA_PROFILER capture markers enabled"
+        "MUSA profiler redirects applied for SGLang v0.5.11: "
+        "GPU->PrivateUse1 and CUDA_PROFILER->musaProfilerStart/Stop"
     )

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patches/sglang_0_5_11_profiler_lifecycle.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patches/sglang_0_5_11_profiler_lifecycle.py
@@ -1,0 +1,161 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transactional profiler cleanup for the fixed SGLang v0.5.11 target.
+
+This module contains no MUSA behavior. It only closes v0.5.11 failure paths so
+an external profiler-marker error cannot leave already-started profilers or the
+legacy scheduler state active. Keep this shim isolated and version-locked.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import wraps
+from importlib import metadata
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_SGLANG_VERSION = "0.5.11"
+_patches_applied = False
+
+
+def _installed_sglang_version() -> str:
+    try:
+        return metadata.version("sglang")
+    except metadata.PackageNotFoundError:
+        import sglang
+
+        version = getattr(sglang, "__version__", None)
+        return str(version) if version is not None else "unknown"
+
+
+def _base_version(version: str) -> str:
+    return version.split("+", 1)[0].split(".post", 1)[0]
+
+
+def _require_sglang_0_5_11() -> None:
+    installed = _installed_sglang_version()
+    if _base_version(installed) != _SUPPORTED_SGLANG_VERSION:
+        raise RuntimeError(
+            "The MUSA profiler lifecycle compatibility patch requires SGLang "
+            f"{_SUPPORTED_SGLANG_VERSION}, but found {installed}."
+        )
+
+
+def _reset_legacy_state(scheduler) -> None:
+    scheduler.torch_profiler = None
+    scheduler.profile_in_progress = False
+    scheduler.profiler_start_forward_ct = None
+
+
+def _wrap_legacy_profiler_lifecycle(profiler_mixin, marker_error_type: type) -> None:
+    if getattr(profiler_mixin, "_musa_profiler_lifecycle_patched", False):
+        return
+
+    original_start = profiler_mixin.start_profile
+    original_stop = profiler_mixin.stop_profile
+
+    @wraps(original_start)
+    def start_profile_with_rollback(self, *args, **kwargs):
+        try:
+            return original_start(self, *args, **kwargs)
+        except marker_error_type:
+            if getattr(self, "profile_in_progress", False):
+                try:
+                    # Let SGLang stop the profilers it successfully started.
+                    original_stop(self, *args, **kwargs)
+                except Exception:
+                    logger.exception(
+                        "Failed to fully roll back SGLang profilers after a "
+                        "capture-marker start error"
+                    )
+            _reset_legacy_state(self)
+            raise
+
+    @wraps(original_stop)
+    def stop_profile_with_cleanup(self, *args, **kwargs):
+        try:
+            return original_stop(self, *args, **kwargs)
+        except marker_error_type:
+            # The capture marker is the last stop operation in SGLang v0.5.11;
+            # Torch, RPD, and memory profilers have already been stopped here.
+            _reset_legacy_state(self)
+            raise
+
+    profiler_mixin.start_profile = start_profile_with_rollback
+    profiler_mixin.stop_profile = stop_profile_with_cleanup
+    profiler_mixin._musa_profiler_lifecycle_patched = True
+
+
+def _wrap_profiler_list_lifecycle(profiler_list) -> None:
+    if getattr(profiler_list, "_musa_profiler_lifecycle_patched", False):
+        return
+
+    def start_transactionally(self):
+        started = []
+        try:
+            for inner in self.inners:
+                inner.start()
+                started.append(inner)
+        except Exception:
+            for inner in reversed(started):
+                try:
+                    inner.stop()
+                except Exception:
+                    logger.exception(
+                        "Failed to stop a profiler while rolling back profiler startup"
+                    )
+            raise
+
+    def stop_all(self):
+        first_error = None
+        first_traceback = None
+        for inner in self.inners:
+            try:
+                inner.stop()
+            except Exception as exc:
+                if first_error is None:
+                    first_error = exc
+                    first_traceback = exc.__traceback__
+                else:
+                    logger.exception(
+                        "Additional profiler stop failed while cleaning up",
+                        exc_info=exc,
+                    )
+        if first_error is not None:
+            raise first_error.with_traceback(first_traceback)
+
+    profiler_list.start = start_transactionally
+    profiler_list.stop = stop_all
+    profiler_list._musa_profiler_lifecycle_patched = True
+
+
+def apply_sglang_0_5_11_profiler_lifecycle_patch(
+    marker_error_type: type,
+) -> None:
+    """Apply only the cleanup SGLang v0.5.11 is missing."""
+    global _patches_applied
+    if _patches_applied:
+        return
+
+    _require_sglang_0_5_11()
+
+    from sglang.srt.managers.scheduler_profiler_mixin import SchedulerProfilerMixin
+    from sglang.srt.utils.profile_utils import _ProfilerList
+
+    _wrap_legacy_profiler_lifecycle(SchedulerProfilerMixin, marker_error_type)
+    _wrap_profiler_list_lifecycle(_ProfilerList)
+    _patches_applied = True
+    logger.info("SGLang v0.5.11 profiler transactional cleanup patch applied")

--- a/sglang_fl/platform.py
+++ b/sglang_fl/platform.py
@@ -62,6 +62,10 @@ _ATTN_BACKEND_MAP = {
     "iluvatar": "triton",
 }
 
+_MTHREADS_PROFILER_MODULE = (
+    "sglang_fl.dispatch.backends.vendor.mthreads.patches.profiler"
+)
+
 
 def _get_device_detector():
     """Lazy import DeviceDetector to avoid import errors when flag_gems not installed."""
@@ -339,6 +343,11 @@ class PlatformFL(SRTPlatform):
             status = "loaded"
         except ImportError:
             status = "absent"
+
+        if self._vendor_name == "mthreads":
+            profiler_module = importlib.import_module(_MTHREADS_PROFILER_MODULE)
+            profiler_module.apply_musa_profiler_patches()
+
         logger.info(
             "PlatformFL init_backend: vendor=%s, device=%s, vendor_module=%s",
             self._vendor_name,

--- a/sglang_fl/profiler.py
+++ b/sglang_fl/profiler.py
@@ -1,0 +1,302 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MUSA profiling integration for SGLang.
+
+SGLang's public ``/start_profile`` endpoint is platform neutral, but the
+implementation in v0.5.11 assumes CUDA in two places:
+
+* ``GPU`` is translated to ``torch.profiler.ProfilerActivity.CUDA``.
+* ``CUDA_PROFILER`` calls ``cudaProfilerStart``/``cudaProfilerStop``.
+
+TorchMUSA exposes a PrivateUse1/MUSA profiler activity and the MUSA runtime
+provides the equivalent ``musaProfilerStart``/``musaProfilerStop`` markers.
+This module patches those two implementation details without changing the
+HTTP API or SGLang core.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+from functools import wraps
+from typing import Iterable
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+# ``CUDA_PROFILER`` keeps existing SGLang profiling clients working on MUSA.
+# The MUSA-specific names make new configurations self-documenting.
+MUSA_API_ACTIVITIES = frozenset({"CUDA_PROFILER", "MUSA_PROFILER", "MSYS"})
+MUSA_TORCH_ACTIVITIES = frozenset({"GPU", "MUSA"})
+
+
+class MusaProfilerApi:
+    """Call MUSA profiler range markers through the runtime shared library."""
+
+    def __init__(self) -> None:
+        self._library = None
+
+    def _load_library(self):
+        if self._library is None:
+            try:
+                library = ctypes.CDLL("libmusart.so")
+            except OSError as exc:
+                raise RuntimeError(
+                    "Cannot load libmusart.so; install the MUSA runtime and expose "
+                    "its library directory to the SGLang worker process."
+                ) from exc
+
+            for name in ("musaProfilerStart", "musaProfilerStop"):
+                function = getattr(library, name)
+                function.argtypes = []
+                function.restype = ctypes.c_int
+            library.musaGetLastError.argtypes = []
+            library.musaGetLastError.restype = ctypes.c_int
+            self._library = library
+        return self._library
+
+    def _call(self, name: str) -> int:
+        library = self._load_library()
+        result = int(getattr(library, name)())
+
+        # MUSA 4.3 may return musaErrorNotSupported (801) even though msys has
+        # observed and acted on the range marker. Clear the sticky runtime
+        # error immediately; otherwise the next TorchMUSA kernel reports the
+        # profiler error as if the kernel itself had failed.
+        if result != 0:
+            cleared = int(library.musaGetLastError())
+            logger.warning(
+                "%s returned MUSA error %d (cleared error %d); Moore Perf may "
+                "still have accepted the capture-range marker",
+                name,
+                result,
+                cleared,
+            )
+        return result
+
+    def start(self) -> int:
+        return self._call("musaProfilerStart")
+
+    def stop(self) -> int:
+        return self._call("musaProfilerStop")
+
+
+_MUSA_PROFILER_API = MusaProfilerApi()
+_patches_applied = False
+
+
+def _has_activity(activities: Iterable[str], choices: frozenset[str]) -> bool:
+    return not choices.isdisjoint(activities)
+
+
+def _torch_musa_activity():
+    activity = getattr(torch.profiler.ProfilerActivity, "MUSA", None)
+    if activity is None:
+        # TorchMUSA registers PrivateUse1 as MUSA on supported releases. Keep a
+        # fallback for builds that expose only the generic enum name.
+        activity = getattr(torch.profiler.ProfilerActivity, "PrivateUse1", None)
+    if activity is None:
+        raise RuntimeError(
+            "This PyTorch/TorchMUSA build does not expose ProfilerActivity.MUSA"
+        )
+    return activity
+
+
+def _make_torch_profiler(activities, with_stack, record_shapes):
+    torch_activities = []
+    if "CPU" in activities:
+        torch_activities.append(torch.profiler.ProfilerActivity.CPU)
+    if _has_activity(activities, MUSA_TORCH_ACTIVITIES):
+        torch_activities.append(_torch_musa_activity())
+
+    return torch.profiler.profile(
+        activities=torch_activities,
+        with_stack=with_stack if with_stack is not None else True,
+        record_shapes=record_shapes if record_shapes is not None else False,
+    )
+
+
+def _is_first_rank_in_node(scheduler) -> bool:
+    from sglang.srt.server_args import get_global_server_args
+
+    return scheduler.gpu_id == get_global_server_args().base_gpu_id
+
+
+def _patch_legacy_scheduler_profiler() -> None:
+    """Patch the default (SGLANG_PROFILE_V2=0) profiler implementation."""
+
+    from sglang.srt.managers.scheduler_profiler_mixin import SchedulerProfilerMixin
+
+    _wrap_legacy_scheduler_profiler(SchedulerProfilerMixin)
+
+
+def _wrap_legacy_scheduler_profiler(profiler_mixin) -> None:
+    """Wrap a SchedulerProfilerMixin class (split out for isolated tests)."""
+
+    original_start = profiler_mixin.start_profile
+    original_stop = profiler_mixin.stop_profile
+
+    @wraps(original_start)
+    def start_profile_with_musa(self, stage=None):
+        activities = list(self.profiler_activities or [])
+        use_musa_torch = _has_activity(activities, MUSA_TORCH_ACTIVITIES)
+        use_musa_api = _has_activity(activities, MUSA_API_ACTIVITIES)
+
+        if not use_musa_torch and not use_musa_api:
+            return original_start(self, stage)
+
+        # Prevent the CUDA-specific branches in SGLang core from running. If
+        # GPU profiling is requested, CPU and MUSA must be created as one
+        # torch.profiler session rather than as two independent sessions.
+        filtered = list(activities)
+        if use_musa_torch:
+            filtered = [
+                activity
+                for activity in filtered
+                if activity not in MUSA_TORCH_ACTIVITIES and activity != "CPU"
+            ]
+        if use_musa_api:
+            filtered = [
+                activity for activity in filtered if activity not in MUSA_API_ACTIVITIES
+            ]
+
+        self.profiler_activities = filtered
+        try:
+            result = original_start(self, stage)
+        finally:
+            self.profiler_activities = activities
+
+        api_started = False
+        try:
+            if use_musa_api and _is_first_rank_in_node(self):
+                _MUSA_PROFILER_API.start()
+                api_started = True
+
+            if use_musa_torch:
+                self.torch_profiler = _make_torch_profiler(
+                    activities,
+                    self.torch_profiler_with_stack,
+                    self.torch_profiler_record_shapes,
+                )
+                self.torch_profiler.start()
+
+            self.profile_in_progress = True
+            return result
+        except Exception:
+            if api_started:
+                _MUSA_PROFILER_API.stop()
+            raise
+
+    @wraps(original_stop)
+    def stop_profile_with_musa(self, stage=None):
+        activities = list(self.profiler_activities or [])
+        use_musa_api = _has_activity(activities, MUSA_API_ACTIVITIES)
+        api_error = None
+
+        # Emit the stop marker before SGLang spends time exporting and merging
+        # torch-profiler traces.
+        if use_musa_api and self.profile_in_progress and _is_first_rank_in_node(self):
+            try:
+                _MUSA_PROFILER_API.stop()
+            except Exception as exc:  # still let SGLang stop its other profilers
+                api_error = exc
+
+        self.profiler_activities = [
+            activity for activity in activities if activity not in MUSA_API_ACTIVITIES
+        ]
+        try:
+            result = original_stop(self, stage)
+        finally:
+            self.profiler_activities = activities
+
+        if api_error is not None:
+            raise api_error
+        return result
+
+    profiler_mixin.start_profile = start_profile_with_musa
+    profiler_mixin.stop_profile = stop_profile_with_musa
+
+
+def _patch_profile_v2() -> None:
+    """Patch stage-based profiling used when SGLANG_PROFILE_V2=1."""
+
+    from sglang.srt.utils.profile_utils import (
+        _ProfilerBase,
+        _ProfilerCudart,
+        _ProfilerTorch,
+    )
+
+    _wrap_profile_v2(_ProfilerBase, _ProfilerTorch, _ProfilerCudart)
+
+
+def _wrap_profile_v2(profiler_base, profiler_torch, profiler_cudart) -> None:
+    """Wrap profile-v2 classes (split out for isolated tests)."""
+
+    original_create = profiler_base.create
+    original_torch_start = profiler_torch.start
+
+    def create(activities, with_stack, record_shapes, **kwargs):
+        normalized = []
+        for activity in activities:
+            if activity == "MUSA":
+                activity = "GPU"
+            elif activity in MUSA_API_ACTIVITIES:
+                activity = "CUDA_PROFILER"
+            if activity not in normalized:
+                normalized.append(activity)
+        return original_create(normalized, with_stack, record_shapes, **kwargs)
+
+    @wraps(original_torch_start)
+    def torch_start_with_musa(self):
+        if not _has_activity(self.activities, MUSA_TORCH_ACTIVITIES):
+            return original_torch_start(self)
+        self.torch_profiler = _make_torch_profiler(
+            self.activities,
+            self.with_stack,
+            self.record_shapes,
+        )
+        self.torch_profiler.start()
+
+    def musa_api_start(self):
+        if self.first_rank_in_node:
+            logger.info("Call musaProfilerStart")
+            _MUSA_PROFILER_API.start()
+
+    def musa_api_stop(self):
+        if self.first_rank_in_node:
+            logger.info("Call musaProfilerStop")
+            _MUSA_PROFILER_API.stop()
+
+    profiler_base.create = staticmethod(create)
+    profiler_torch.start = torch_start_with_musa
+    profiler_cudart.start = musa_api_start
+    profiler_cudart.stop = musa_api_stop
+
+
+def apply_musa_profiler_patches() -> None:
+    """Install MUSA profiler support once in the current SGLang process."""
+
+    global _patches_applied
+    if _patches_applied:
+        return
+
+    _patch_legacy_scheduler_profiler()
+    _patch_profile_v2()
+    _patches_applied = True
+    logger.info(
+        "MUSA profiling patches applied: GPU->MUSA and "
+        "MSYS/MUSA_PROFILER/CUDA_PROFILER capture markers enabled"
+    )

--- a/tests/unit_tests/platform/test_init_backend.py
+++ b/tests/unit_tests/platform/test_init_backend.py
@@ -16,6 +16,7 @@
 
 import importlib
 import logging
+from types import SimpleNamespace
 
 import pytest
 
@@ -36,9 +37,7 @@ def _make_platform_stub(vendor_name, device_type="test_device"):
 
 
 class TestInitBackendVendorAutoImport:
-    def test_loaded_when_register_platform_exists(
-        self, caplog, inject_vendor_module
-    ):
+    def test_loaded_when_register_platform_exists(self, caplog, inject_vendor_module):
         inject_vendor_module("fakevendor", "register_platform")
         p = _make_platform_stub("fakevendor")
         with caplog.at_level(logging.INFO, logger="sglang_fl.platform"):
@@ -83,3 +82,22 @@ class TestInitBackendVendorAutoImport:
             p.init_backend()
             p.init_backend()
         assert caplog.text.count("vendor_module=loaded") == 3
+
+    def test_mthreads_initializes_profiler_through_platform_hook(self, monkeypatch):
+        calls = []
+        real_import = importlib.import_module
+
+        def _import(name, *args, **kwargs):
+            if name.endswith(".mthreads.register_platform"):
+                return SimpleNamespace()
+            if name.endswith(".mthreads.patches.profiler"):
+                return SimpleNamespace(
+                    apply_musa_profiler_patches=lambda: calls.append("profiler")
+                )
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(importlib, "import_module", _import)
+
+        _make_platform_stub("mthreads", device_type="musa").init_backend()
+
+        assert calls == ["profiler"]

--- a/tests/unit_tests/platform/test_musa_profiler.py
+++ b/tests/unit_tests/platform/test_musa_profiler.py
@@ -13,34 +13,66 @@
 # limitations under the License.
 
 import logging
+from types import SimpleNamespace
+
+import pytest
 
 from sglang_fl.dispatch.backends.vendor.mthreads.patches import (
     profiler as musa_profiler,
 )
+from sglang_fl.dispatch.backends.vendor.mthreads.patches import (
+    sglang_0_5_11_profiler_lifecycle as lifecycle,
+)
 
 
 class _FakeFunction:
-    def __init__(self, name, calls, result):
+    def __init__(self, name, calls, result=0, callback=None):
         self.name = name
         self.calls = calls
         self.result = result
+        self.callback = callback
         self.argtypes = None
         self.restype = None
 
-    def __call__(self):
+    def __call__(self, *args):
         self.calls.append(self.name)
+        if self.callback is not None:
+            return self.callback(*args)
         return self.result
 
 
 class _FakeMusart:
-    def __init__(self, result=801):
+    def __init__(self, result=801, cleared_result=None, include_stop=True):
         self.calls = []
-        self.musaProfilerStart = _FakeFunction("musaProfilerStart", self.calls, result)
-        self.musaProfilerStop = _FakeFunction("musaProfilerStop", self.calls, result)
-        self.musaGetLastError = _FakeFunction("musaGetLastError", self.calls, result)
+        cleared_result = result if cleared_result is None else cleared_result
+        self.musaProfilerStart = _FakeFunction(
+            "musaProfilerStart", self.calls, result=result
+        )
+        if include_stop:
+            self.musaProfilerStop = _FakeFunction(
+                "musaProfilerStop", self.calls, result=result
+            )
+        self.musaGetLastError = _FakeFunction(
+            "musaGetLastError", self.calls, result=cleared_result
+        )
+        self.musaRuntimeGetVersion = _FakeFunction(
+            "musaRuntimeGetVersion",
+            self.calls,
+            callback=self._set_runtime_version,
+        )
+        self.musaGetErrorString = _FakeFunction(
+            "musaGetErrorString",
+            self.calls,
+            callback=lambda _result: b"fake MUSA error",
+        )
+
+    @staticmethod
+    def _set_runtime_version(version_pointer):
+        version_pointer._obj.value = 40305
+        return 0
 
 
-def test_musa_profiler_api_clears_sticky_runtime_error(monkeypatch, caplog):
+def test_musa_profiler_api_special_cases_801(monkeypatch, caplog):
     library = _FakeMusart()
     monkeypatch.setattr(musa_profiler.ctypes, "CDLL", lambda _name: library)
 
@@ -49,157 +81,206 @@ def test_musa_profiler_api_clears_sticky_runtime_error(monkeypatch, caplog):
         logging.WARNING,
         logger="sglang_fl.dispatch.backends.vendor.mthreads.patches.profiler",
     ):
-        assert controller.start() == 801
-        assert controller.stop() == 801
+        assert controller.start() == 0
+        assert controller.stop() == 0
 
-    assert library.calls == [
-        "musaProfilerStart",
-        "musaGetLastError",
-        "musaProfilerStop",
-        "musaGetLastError",
-    ]
-    assert caplog.text.count("cleared error 801") == 2
+    assert library.calls.count("musaGetLastError") == 2
+    assert caplog.text.count("returned MUSA error 801") == 2
+    assert "runtime version 40305" in caplog.text
 
 
-def test_legacy_profile_endpoint_maps_gpu_and_msys_to_musa(monkeypatch):
+def test_musa_profiler_api_raises_other_errors_after_clearing(monkeypatch):
+    library = _FakeMusart(result=700, cleared_result=700)
+    monkeypatch.setattr(musa_profiler.ctypes, "CDLL", lambda _name: library)
+
+    with pytest.raises(musa_profiler.MusaProfilerError, match="MUSA error 700"):
+        musa_profiler.MusaProfilerApi().start()
+
+    assert library.calls.index("musaGetLastError") == (
+        library.calls.index("musaProfilerStart") + 1
+    )
+
+
+def test_musa_profiler_api_rejects_missing_runtime_symbols(monkeypatch):
+    library = _FakeMusart(include_stop=False)
+    monkeypatch.setattr(musa_profiler.ctypes, "CDLL", lambda _name: library)
+
+    with pytest.raises(
+        musa_profiler.MusaProfilerError,
+        match="missing required profiler symbols: musaProfilerStop",
+    ):
+        musa_profiler.MusaProfilerApi().validate()
+
+
+def test_cudart_proxy_redirects_profiler_and_delegates_other_symbols():
     events = []
-
-    class FakeTorchProfiler:
-        def start(self):
-            events.append("torch_start")
-
-        def stop(self):
-            events.append("torch_stop")
-
-    captured_kwargs = {}
-
-    def fake_profile(**kwargs):
-        captured_kwargs.update(kwargs)
-        return FakeTorchProfiler()
 
     class FakeApi:
         def start(self):
-            events.append("api_start")
-            return 801
+            events.append("musa_start")
+            return 0
 
         def stop(self):
-            events.append("api_stop")
-            return 801
+            events.append("musa_stop")
+            return 0
+
+    delegate = SimpleNamespace(cudaHostRegister="original_host_register")
+    proxy = musa_profiler.MusaCudartProxy(lambda: delegate, FakeApi())
+
+    assert proxy.cudaProfilerStart() == 0
+    assert proxy.cudaProfilerStop() == 0
+    assert proxy.cudaHostRegister == "original_host_register"
+    assert events == ["musa_start", "musa_stop"]
+
+
+def test_torch_redirects_reuse_sglang_gpu_and_cuda_profiler_paths(monkeypatch):
+    original_cudart = lambda: SimpleNamespace(cudaHostRegister="host_register")
+    fake_activity = SimpleNamespace(CUDA="cuda", PrivateUse1="privateuse1")
+    fake_torch = SimpleNamespace(
+        profiler=SimpleNamespace(ProfilerActivity=fake_activity),
+        cuda=SimpleNamespace(cudart=original_cudart),
+    )
+    monkeypatch.setattr(musa_profiler, "torch", fake_torch)
+
+    musa_profiler._install_torch_profiler_redirects()
+
+    assert fake_activity.CUDA == "privateuse1"
+    assert fake_torch.cuda.cudart().cudaHostRegister == "host_register"
+    assert isinstance(fake_torch.cuda.cudart(), musa_profiler.MusaCudartProxy)
+
+
+def test_patch_install_keeps_musart_loading_lazy(monkeypatch):
+    library_loads = []
+    monkeypatch.setattr(musa_profiler, "_patches_applied", False)
+    monkeypatch.setattr(
+        musa_profiler,
+        "apply_sglang_0_5_11_profiler_lifecycle_patch",
+        lambda _error_type: None,
+    )
+    monkeypatch.setattr(
+        musa_profiler, "_install_torch_profiler_redirects", lambda: None
+    )
+    monkeypatch.setattr(
+        musa_profiler.ctypes,
+        "CDLL",
+        lambda name: library_loads.append(name),
+    )
+
+    musa_profiler.apply_musa_profiler_patches()
+
+    assert library_loads == []
+
+
+def test_legacy_marker_start_failure_uses_sglang_stop_for_rollback():
+    events = []
+
+    class MarkerError(RuntimeError):
+        pass
 
     class FakeSchedulerProfilerMixin:
         def start_profile(self, stage=None):
-            self.activities_seen_by_original_start = list(self.profiler_activities)
-            return "start-result"
+            events.extend(["rpd_start", "mem_start", "marker_start"])
+            self.profile_in_progress = True
+            raise MarkerError("marker failed")
 
         def stop_profile(self, stage=None):
-            self.activities_seen_by_original_stop = list(self.profiler_activities)
-            if self.torch_profiler is not None:
-                self.torch_profiler.stop()
+            events.extend(["rpd_stop", "mem_stop", "marker_stop"])
             self.profile_in_progress = False
-            return "stop-result"
+            self.torch_profiler = None
 
-    monkeypatch.setattr(musa_profiler.torch.profiler, "profile", fake_profile)
-    monkeypatch.setattr(musa_profiler, "_MUSA_PROFILER_API", FakeApi())
-    monkeypatch.setattr(musa_profiler, "_is_first_rank_in_node", lambda _self: True)
-    musa_profiler._wrap_legacy_scheduler_profiler(FakeSchedulerProfilerMixin)
-
+    lifecycle._wrap_legacy_profiler_lifecycle(FakeSchedulerProfilerMixin, MarkerError)
     scheduler = FakeSchedulerProfilerMixin()
-    scheduler.profiler_activities = ["CPU", "GPU", "MSYS"]
-    scheduler.torch_profiler_with_stack = False
-    scheduler.torch_profiler_record_shapes = True
-    scheduler.torch_profiler = None
+    scheduler.torch_profiler = object()
     scheduler.profile_in_progress = False
+    scheduler.profiler_start_forward_ct = 10
 
-    assert scheduler.start_profile() == "start-result"
-    assert scheduler.activities_seen_by_original_start == []
-    assert scheduler.profiler_activities == ["CPU", "GPU", "MSYS"]
-    assert captured_kwargs["activities"] == [
-        musa_profiler.torch.profiler.ProfilerActivity.CPU,
-        musa_profiler._torch_musa_activity(),
+    with pytest.raises(MarkerError, match="marker failed"):
+        scheduler.start_profile()
+
+    assert events == [
+        "rpd_start",
+        "mem_start",
+        "marker_start",
+        "rpd_stop",
+        "mem_stop",
+        "marker_stop",
     ]
-    assert captured_kwargs["with_stack"] is False
-    assert captured_kwargs["record_shapes"] is True
-    assert scheduler.profile_in_progress is True
-    assert events == ["api_start", "torch_start"]
-
-    assert scheduler.stop_profile() == "stop-result"
-    assert scheduler.activities_seen_by_original_stop == ["CPU", "GPU"]
-    assert scheduler.profiler_activities == ["CPU", "GPU", "MSYS"]
-    assert events == ["api_start", "torch_start", "api_stop", "torch_stop"]
+    assert scheduler.torch_profiler is None
+    assert scheduler.profile_in_progress is False
+    assert scheduler.profiler_start_forward_ct is None
 
 
-def test_profile_v2_maps_musa_activities(monkeypatch):
+def test_profile_v2_list_rolls_back_started_profilers_in_reverse_order():
     events = []
-    captured_create = {}
-    captured_torch = {}
 
-    class FakeTorchProfiler:
+    class FakeProfiler:
+        def __init__(self, name, fail_start=False):
+            self.name = name
+            self.fail_start = fail_start
+
         def start(self):
-            events.append("torch_start")
-
-    def fake_profile(**kwargs):
-        captured_torch.update(kwargs)
-        return FakeTorchProfiler()
-
-    class FakeProfilerBase:
-        @staticmethod
-        def create(activities, with_stack, record_shapes, **kwargs):
-            captured_create.update(
-                activities=activities,
-                with_stack=with_stack,
-                record_shapes=record_shapes,
-                kwargs=kwargs,
-            )
-            return "create-result"
-
-    class FakeProfilerTorch:
-        def start(self):
-            events.append("original_torch_start")
-
-    class FakeProfilerCudart:
-        pass
-
-    class FakeApi:
-        def start(self):
-            events.append("api_start")
+            events.append(f"{self.name}_start")
+            if self.fail_start:
+                raise RuntimeError(f"{self.name} failed")
 
         def stop(self):
-            events.append("api_stop")
+            events.append(f"{self.name}_stop")
 
-    monkeypatch.setattr(musa_profiler.torch.profiler, "profile", fake_profile)
-    monkeypatch.setattr(musa_profiler, "_MUSA_PROFILER_API", FakeApi())
-    musa_profiler._wrap_profile_v2(
-        FakeProfilerBase, FakeProfilerTorch, FakeProfilerCudart
-    )
+    class FakeProfilerList:
+        pass
 
-    assert (
-        FakeProfilerBase.create(
-            ["CPU", "MUSA", "GPU", "MSYS", "MUSA_PROFILER"],
-            False,
-            True,
-            output_dir="/tmp/profile",
-        )
-        == "create-result"
-    )
-    assert captured_create == {
-        "activities": ["CPU", "GPU", "CUDA_PROFILER"],
-        "with_stack": False,
-        "record_shapes": True,
-        "kwargs": {"output_dir": "/tmp/profile"},
-    }
-
-    torch_profiler = FakeProfilerTorch()
-    torch_profiler.activities = ["CPU", "GPU"]
-    torch_profiler.with_stack = False
-    torch_profiler.record_shapes = True
-    torch_profiler.start()
-    assert captured_torch["activities"] == [
-        musa_profiler.torch.profiler.ProfilerActivity.CPU,
-        musa_profiler._torch_musa_activity(),
+    lifecycle._wrap_profiler_list_lifecycle(FakeProfilerList)
+    profiler_list = FakeProfilerList()
+    profiler_list.inners = [
+        FakeProfiler("torch"),
+        FakeProfiler("mem"),
+        FakeProfiler("marker", fail_start=True),
     ]
 
-    api_profiler = FakeProfilerCudart()
-    api_profiler.first_rank_in_node = True
-    api_profiler.start()
-    api_profiler.stop()
-    assert events == ["torch_start", "api_start", "api_stop"]
+    with pytest.raises(RuntimeError, match="marker failed"):
+        profiler_list.start()
+
+    assert events == [
+        "torch_start",
+        "mem_start",
+        "marker_start",
+        "mem_stop",
+        "torch_stop",
+    ]
+
+
+def test_profile_v2_list_attempts_every_stop_before_raising():
+    events = []
+
+    class FakeProfiler:
+        def __init__(self, name, fail_stop=False):
+            self.name = name
+            self.fail_stop = fail_stop
+
+        def stop(self):
+            events.append(f"{self.name}_stop")
+            if self.fail_stop:
+                raise RuntimeError(f"{self.name} failed")
+
+    class FakeProfilerList:
+        pass
+
+    lifecycle._wrap_profiler_list_lifecycle(FakeProfilerList)
+    profiler_list = FakeProfilerList()
+    profiler_list.inners = [
+        FakeProfiler("torch"),
+        FakeProfiler("marker", fail_stop=True),
+        FakeProfiler("rpd"),
+    ]
+
+    with pytest.raises(RuntimeError, match="marker failed"):
+        profiler_list.stop()
+
+    assert events == ["torch_stop", "marker_stop", "rpd_stop"]
+
+
+def test_sglang_profiler_lifecycle_patch_rejects_other_versions(monkeypatch):
+    monkeypatch.setattr(lifecycle, "_installed_sglang_version", lambda: "0.5.12")
+
+    with pytest.raises(RuntimeError, match="requires SGLang 0.5.11"):
+        lifecycle._require_sglang_0_5_11()

--- a/tests/unit_tests/platform/test_musa_profiler.py
+++ b/tests/unit_tests/platform/test_musa_profiler.py
@@ -1,0 +1,200 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import sglang_fl.profiler as musa_profiler
+
+
+class _FakeFunction:
+    def __init__(self, name, calls, result):
+        self.name = name
+        self.calls = calls
+        self.result = result
+        self.argtypes = None
+        self.restype = None
+
+    def __call__(self):
+        self.calls.append(self.name)
+        return self.result
+
+
+class _FakeMusart:
+    def __init__(self, result=801):
+        self.calls = []
+        self.musaProfilerStart = _FakeFunction("musaProfilerStart", self.calls, result)
+        self.musaProfilerStop = _FakeFunction("musaProfilerStop", self.calls, result)
+        self.musaGetLastError = _FakeFunction("musaGetLastError", self.calls, result)
+
+
+def test_musa_profiler_api_clears_sticky_runtime_error(monkeypatch, caplog):
+    library = _FakeMusart()
+    monkeypatch.setattr(musa_profiler.ctypes, "CDLL", lambda _name: library)
+
+    controller = musa_profiler.MusaProfilerApi()
+    with caplog.at_level(logging.WARNING, logger="sglang_fl.profiler"):
+        assert controller.start() == 801
+        assert controller.stop() == 801
+
+    assert library.calls == [
+        "musaProfilerStart",
+        "musaGetLastError",
+        "musaProfilerStop",
+        "musaGetLastError",
+    ]
+    assert caplog.text.count("cleared error 801") == 2
+
+
+def test_legacy_profile_endpoint_maps_gpu_and_msys_to_musa(monkeypatch):
+    events = []
+
+    class FakeTorchProfiler:
+        def start(self):
+            events.append("torch_start")
+
+        def stop(self):
+            events.append("torch_stop")
+
+    captured_kwargs = {}
+
+    def fake_profile(**kwargs):
+        captured_kwargs.update(kwargs)
+        return FakeTorchProfiler()
+
+    class FakeApi:
+        def start(self):
+            events.append("api_start")
+            return 801
+
+        def stop(self):
+            events.append("api_stop")
+            return 801
+
+    class FakeSchedulerProfilerMixin:
+        def start_profile(self, stage=None):
+            self.activities_seen_by_original_start = list(self.profiler_activities)
+            return "start-result"
+
+        def stop_profile(self, stage=None):
+            self.activities_seen_by_original_stop = list(self.profiler_activities)
+            if self.torch_profiler is not None:
+                self.torch_profiler.stop()
+            self.profile_in_progress = False
+            return "stop-result"
+
+    monkeypatch.setattr(musa_profiler.torch.profiler, "profile", fake_profile)
+    monkeypatch.setattr(musa_profiler, "_MUSA_PROFILER_API", FakeApi())
+    monkeypatch.setattr(musa_profiler, "_is_first_rank_in_node", lambda _self: True)
+    musa_profiler._wrap_legacy_scheduler_profiler(FakeSchedulerProfilerMixin)
+
+    scheduler = FakeSchedulerProfilerMixin()
+    scheduler.profiler_activities = ["CPU", "GPU", "MSYS"]
+    scheduler.torch_profiler_with_stack = False
+    scheduler.torch_profiler_record_shapes = True
+    scheduler.torch_profiler = None
+    scheduler.profile_in_progress = False
+
+    assert scheduler.start_profile() == "start-result"
+    assert scheduler.activities_seen_by_original_start == []
+    assert scheduler.profiler_activities == ["CPU", "GPU", "MSYS"]
+    assert captured_kwargs["activities"] == [
+        musa_profiler.torch.profiler.ProfilerActivity.CPU,
+        musa_profiler._torch_musa_activity(),
+    ]
+    assert captured_kwargs["with_stack"] is False
+    assert captured_kwargs["record_shapes"] is True
+    assert scheduler.profile_in_progress is True
+    assert events == ["api_start", "torch_start"]
+
+    assert scheduler.stop_profile() == "stop-result"
+    assert scheduler.activities_seen_by_original_stop == ["CPU", "GPU"]
+    assert scheduler.profiler_activities == ["CPU", "GPU", "MSYS"]
+    assert events == ["api_start", "torch_start", "api_stop", "torch_stop"]
+
+
+def test_profile_v2_maps_musa_activities(monkeypatch):
+    events = []
+    captured_create = {}
+    captured_torch = {}
+
+    class FakeTorchProfiler:
+        def start(self):
+            events.append("torch_start")
+
+    def fake_profile(**kwargs):
+        captured_torch.update(kwargs)
+        return FakeTorchProfiler()
+
+    class FakeProfilerBase:
+        @staticmethod
+        def create(activities, with_stack, record_shapes, **kwargs):
+            captured_create.update(
+                activities=activities,
+                with_stack=with_stack,
+                record_shapes=record_shapes,
+                kwargs=kwargs,
+            )
+            return "create-result"
+
+    class FakeProfilerTorch:
+        def start(self):
+            events.append("original_torch_start")
+
+    class FakeProfilerCudart:
+        pass
+
+    class FakeApi:
+        def start(self):
+            events.append("api_start")
+
+        def stop(self):
+            events.append("api_stop")
+
+    monkeypatch.setattr(musa_profiler.torch.profiler, "profile", fake_profile)
+    monkeypatch.setattr(musa_profiler, "_MUSA_PROFILER_API", FakeApi())
+    musa_profiler._wrap_profile_v2(
+        FakeProfilerBase, FakeProfilerTorch, FakeProfilerCudart
+    )
+
+    assert (
+        FakeProfilerBase.create(
+            ["CPU", "MUSA", "GPU", "MSYS", "MUSA_PROFILER"],
+            False,
+            True,
+            output_dir="/tmp/profile",
+        )
+        == "create-result"
+    )
+    assert captured_create == {
+        "activities": ["CPU", "GPU", "CUDA_PROFILER"],
+        "with_stack": False,
+        "record_shapes": True,
+        "kwargs": {"output_dir": "/tmp/profile"},
+    }
+
+    torch_profiler = FakeProfilerTorch()
+    torch_profiler.activities = ["CPU", "GPU"]
+    torch_profiler.with_stack = False
+    torch_profiler.record_shapes = True
+    torch_profiler.start()
+    assert captured_torch["activities"] == [
+        musa_profiler.torch.profiler.ProfilerActivity.CPU,
+        musa_profiler._torch_musa_activity(),
+    ]
+
+    api_profiler = FakeProfilerCudart()
+    api_profiler.first_rank_in_node = True
+    api_profiler.start()
+    api_profiler.stop()
+    assert events == ["torch_start", "api_start", "api_stop"]

--- a/tests/unit_tests/platform/test_musa_profiler.py
+++ b/tests/unit_tests/platform/test_musa_profiler.py
@@ -14,7 +14,9 @@
 
 import logging
 
-import sglang_fl.profiler as musa_profiler
+from sglang_fl.dispatch.backends.vendor.mthreads.patches import (
+    profiler as musa_profiler,
+)
 
 
 class _FakeFunction:
@@ -43,7 +45,10 @@ def test_musa_profiler_api_clears_sticky_runtime_error(monkeypatch, caplog):
     monkeypatch.setattr(musa_profiler.ctypes, "CDLL", lambda _name: library)
 
     controller = musa_profiler.MusaProfilerApi()
-    with caplog.at_level(logging.WARNING, logger="sglang_fl.profiler"):
+    with caplog.at_level(
+        logging.WARNING,
+        logger="sglang_fl.dispatch.backends.vendor.mthreads.patches.profiler",
+    ):
         assert controller.start() == 801
         assert controller.stop() == 801
 


### PR DESCRIPTION
## Summary

- target SGLang v0.5.11 exactly and keep its public `GPU` / `CUDA_PROFILER` activities
- install two TorchMUSA redirects from the MThreads branch of `PlatformFL.init_backend`: `ProfilerActivity.CUDA -> PrivateUse1/MUSA` and a delegating `torch.cuda.cudart()` proxy for `musaProfilerStart/Stop`
- let SGLang own the legacy and profile-v2 implementations; keep only an isolated, version-locked transactional cleanup shim for v0.5.11 failure paths
- treat only MUSA error 801 as the observed msys compatibility case; clear and raise every other non-zero result
- lazily load the active `libmusart.so`, validate required symbols, declare the ctypes ABI, and include optional runtime version/error text in failures

## Why

SGLang v0.5.11 has no out-of-tree profiler hook. Its profiler lifecycle is reusable on MUSA, but two leaves assume CUDA: `GPU` maps to `ProfilerActivity.CUDA`, and `CUDA_PROFILER` calls `torch.cuda.cudart().cudaProfilerStart/Stop`.

This follows the existing `torch_npu` direction without copying SGLang profiler implementations. The compatibility shim is deliberately isolated and rejects any SGLang base version other than 0.5.11.

## Public API

| Activity | MUSA behavior |
|---|---|
| `GPU` | `torch.profiler.ProfilerActivity.PrivateUse1` (`MUSA`) |
| `CUDA_PROFILER` | `musaProfilerStart/Stop` for msys capture ranges |

The earlier `MUSA`, `MSYS`, and `MUSA_PROFILER` aliases were removed so the plugin stays on the v0.5.11 API surface.

## Validation

- `ruff check` on the profiler adapter, lifecycle shim, and related tests
- `git diff --check`
- `pytest -q tests/unit_tests/platform`: 23 passed on the profiler-only PR head
- redirect, lazy-load, required-symbol, error-801, non-801, legacy rollback, profile-v2 rollback/stop-all, platform-hook, and version-guard unit coverage
- integration points checked against the exact SGLang v0.5.11 `scheduler_profiler_mixin.py` and `profile_utils.py` sources
- the branch had previously validated the msys capture-range workflow on MTT S5000 with TP=2; the post-review refactor is covered by the unit validation above

## Validated stack

- SGLang 0.5.11
- MUSA Runtime 4.3.x
- Torch / TorchMUSA 2.9.0
- Moore Perf System 1.8.0