### PR TITLE
refactor: DeviceInfo service class + vendor early-patches mechanism

### DIFF
--- a/sglang_fl/__init__.py
+++ b/sglang_fl/__init__.py
@@ -68,6 +68,49 @@ if not logger.handlers:
     logger.setLevel(logging.INFO)
 
 
+# ─── Vendor early (T1) patches — install at plugin-import time ───────────────
+#
+# Must run before ANY sglang module loads on this Python process. sglang's
+# module chain has unguarded top-level `from sgl_kernel_npu.X import Y`
+# imports outside `Engine.__init__`.
+
+
+def _apply_vendor_early_patches() -> None:
+    """Discover the runtime vendor and import its ``patch_early`` module.
+
+    Symmetric to ``_apply_vendor_patches()`` but runs at plugin-import time,
+    before any sglang module is loaded. Vendors that need import-time hooks
+    (Ascend's sgl_kernel_npu stub finder for srt_empty; potentially MUSA)
+    ship a ``patch_early.py`` beside their existing ``patch.py``. Vendors
+    without one are silently skipped.
+    """
+    import importlib
+
+    try:
+        from sglang_fl.utils import get_device_info
+
+        info = get_device_info()
+    except Exception:
+        return  # utils / flag_gems broken — nothing to patch
+
+    if info is None:
+        return
+
+    module = f"sglang_fl.dispatch.backends.vendor.{info.vendor_name}.patch_early"
+    try:
+        importlib.import_module(module)
+        logger.info("vendor early patch loaded: %s", module)
+    except ImportError:
+        logger.debug("vendor early patch absent: %s", module)
+    except Exception as e:
+        # Defensive at module-load time: don't let a broken vendor patch_early
+        # break the entire plugin import.
+        logger.warning("vendor early patch failed to load (%s): %s", module, e)
+
+
+_apply_vendor_early_patches()
+
+
 def _is_rank0() -> bool:
     """Return True if this is the main process (rank 0) — safe to call at any stage."""
     # During load_plugin(): dist not initialized yet, use multiprocessing parent check
@@ -444,20 +487,14 @@ def _apply_vendor_patches() -> None:
     """
     import importlib
 
-    try:
-        try:
-            # FlagGems<=5.0.2: DeviceDetector lives in device.
-            from flag_gems.runtime.backend.device import DeviceDetector
-        except ImportError:
-            # FlagGems>5.0.2: DeviceDetector lives in device_finder.
-            from flag_gems.runtime.backend.device_finder import DeviceDetector
+    from sglang_fl.utils import get_device_info
 
-        vendor = DeviceDetector().vendor_name
-    except Exception as e:
-        logger.warning("vendor patch skipped: DeviceDetector failed (%s)", e)
+    info = get_device_info()
+    if info is None:
+        logger.warning("vendor patch skipped: DeviceDetector unavailable")
         return
 
-    module = f"sglang_fl.dispatch.backends.vendor.{vendor}.patch"
+    module = f"sglang_fl.dispatch.backends.vendor.{info.vendor_name}.patch"
     try:
         importlib.import_module(module)
         logger.info("vendor patch loaded: %s", module)
@@ -714,24 +751,18 @@ def activate_platform() -> str | None:
     Returns the fully-qualified class path of PlatformFL if hardware is detected,
     or None if FlagGems DeviceDetector fails (no supported hardware).
     """
-    try:
-        try:
-            # FlagGems<=5.0.2: DeviceDetector lives in device.
-            from flag_gems.runtime.backend.device import DeviceDetector
-        except ImportError:
-            # FlagGems>5.0.2: DeviceDetector lives in device_finder.
-            from flag_gems.runtime.backend.device_finder import DeviceDetector
+    from sglang_fl.utils import get_device_info
 
-        detector = DeviceDetector()
-        logger.info(
-            "sglang_fl platform activating: vendor=%s, device=%s",
-            detector.vendor_name,
-            detector.name,
-        )
-        return "sglang_fl.platform:PlatformFL"
-    except Exception as e:
-        logger.warning("sglang_fl platform activation failed: %s", e)
+    info = get_device_info()
+    if info is None:
+        logger.warning("sglang_fl platform activation failed: DeviceDetector unavailable")
         return None
+    logger.info(
+        "sglang_fl platform activating: vendor=%s, device=%s",
+        info.vendor_name,
+        info.device_type,
+    )
+    return "sglang_fl.platform:PlatformFL"
 
 
 # ─── General Plugin entry point ──────────────────────────────────────────────
@@ -767,16 +798,16 @@ def load_plugin():
 
     from sglang.srt.plugins.hook_registry import HookRegistry, HookType
 
-    # 0. Build unified config (YAML + env vars)
+    # 1. Build unified config (YAML + env vars) — pure plugin-local, no sglang touch
     config = _build_config()
 
-    # 1. FlagGems ATen ops
+    # 2. FlagGems ATen ops
     _setup_flaggems(config)
 
-    # 2. Initialize dispatch system (OpManager + backends + policy)
+    # 3. Initialize dispatch system (OpManager + backends + policy)
     _init_dispatch(config)
 
-    # 3. Install dispatch AROUND hook (bridge layer → dispatch.call_op)
+    # 4. Install dispatch AROUND hook (bridge layer → dispatch.call_op)
     oot_enabled = _parse_bool(
         os.environ.get("SGLANG_FL_OOT_ENABLED", "1"), default=True
     )
@@ -799,13 +830,13 @@ def load_plugin():
     else:
         logger.info("Layer 2 (Fused Ops) disabled (SGLANG_FL_OOT_ENABLED=0)")
 
-    # 4. Communicator hooks (CommunicatorFL with FlagCX/torch.distributed)
+    # 5. Communicator hooks (CommunicatorFL with FlagCX/torch.distributed)
     _setup_communicator_hooks()
 
-    # 5. Vendor-specific patches — final overlay on top of all sglang_fl layers
+    # 6. Vendor runtime (T2) patches — final overlay on top of all sglang_fl layers
     _apply_vendor_patches()
 
-    # 6. Summary banner — confirm plugin is active (rank 0 only)
+    # 7. Summary banner — confirm plugin is active (rank 0 only)
     if _is_rank0():
         use_fg = _parse_bool(os.environ.get("USE_FLAGGEMS", "1"), default=True)
         aten_status = "OFF" if not use_fg else "ON"

--- a/sglang_fl/__init__.py
+++ b/sglang_fl/__init__.py
@@ -68,49 +68,6 @@ if not logger.handlers:
     logger.setLevel(logging.INFO)
 
 
-# ─── Vendor early (T1) patches — install at plugin-import time ───────────────
-#
-# Must run before ANY sglang module loads on this Python process. sglang's
-# module chain has unguarded top-level `from sgl_kernel_npu.X import Y`
-# imports outside `Engine.__init__`.
-
-
-def _apply_vendor_early_patches() -> None:
-    """Discover the runtime vendor and import its ``patch_early`` module.
-
-    Symmetric to ``_apply_vendor_patches()`` but runs at plugin-import time,
-    before any sglang module is loaded. Vendors that need import-time hooks
-    (Ascend's sgl_kernel_npu stub finder for srt_empty; potentially MUSA)
-    ship a ``patch_early.py`` beside their existing ``patch.py``. Vendors
-    without one are silently skipped.
-    """
-    import importlib
-
-    try:
-        from sglang_fl.utils import get_device_info
-
-        info = get_device_info()
-    except Exception:
-        return  # utils / flag_gems broken — nothing to patch
-
-    if info is None:
-        return
-
-    module = f"sglang_fl.dispatch.backends.vendor.{info.vendor_name}.patch_early"
-    try:
-        importlib.import_module(module)
-        logger.info("vendor early patch loaded: %s", module)
-    except ImportError:
-        logger.debug("vendor early patch absent: %s", module)
-    except Exception as e:
-        # Defensive at module-load time: don't let a broken vendor patch_early
-        # break the entire plugin import.
-        logger.warning("vendor early patch failed to load (%s): %s", module, e)
-
-
-_apply_vendor_early_patches()
-
-
 def _is_rank0() -> bool:
     """Return True if this is the main process (rank 0) — safe to call at any stage."""
     # During load_plugin(): dist not initialized yet, use multiprocessing parent check
@@ -798,16 +755,16 @@ def load_plugin():
 
     from sglang.srt.plugins.hook_registry import HookRegistry, HookType
 
-    # 1. Build unified config (YAML + env vars) — pure plugin-local, no sglang touch
+    # 0. Build unified config (YAML + env vars)
     config = _build_config()
 
-    # 2. FlagGems ATen ops
+    # 1. FlagGems ATen ops
     _setup_flaggems(config)
 
-    # 3. Initialize dispatch system (OpManager + backends + policy)
+    # 2. Initialize dispatch system (OpManager + backends + policy)
     _init_dispatch(config)
 
-    # 4. Install dispatch AROUND hook (bridge layer → dispatch.call_op)
+    # 3. Install dispatch AROUND hook (bridge layer → dispatch.call_op)
     oot_enabled = _parse_bool(
         os.environ.get("SGLANG_FL_OOT_ENABLED", "1"), default=True
     )
@@ -830,13 +787,13 @@ def load_plugin():
     else:
         logger.info("Layer 2 (Fused Ops) disabled (SGLANG_FL_OOT_ENABLED=0)")
 
-    # 5. Communicator hooks (CommunicatorFL with FlagCX/torch.distributed)
+    # 4. Communicator hooks (CommunicatorFL with FlagCX/torch.distributed)
     _setup_communicator_hooks()
 
-    # 6. Vendor runtime (T2) patches — final overlay on top of all sglang_fl layers
+    # 5. Vendor-specific patches — final overlay on top of all sglang_fl layers
     _apply_vendor_patches()
 
-    # 7. Summary banner — confirm plugin is active (rank 0 only)
+    # 6. Summary banner — confirm plugin is active (rank 0 only)
     if _is_rank0():
         use_fg = _parse_bool(os.environ.get("USE_FLAGGEMS", "1"), default=True)
         aten_status = "OFF" if not use_fg else "ON"

--- a/sglang_fl/platform.py
+++ b/sglang_fl/platform.py
@@ -63,18 +63,6 @@ _ATTN_BACKEND_MAP = {
 }
 
 
-def _get_device_detector():
-    """Lazy import DeviceDetector to avoid import errors when flag_gems not installed."""
-    try:
-        # FlagGems<=5.0.2: DeviceDetector lives in device.
-        from flag_gems.runtime.backend.device import DeviceDetector
-    except ImportError:
-        # FlagGems>5.0.2: DeviceDetector lives in device_finder.
-        from flag_gems.runtime.backend.device_finder import DeviceDetector
-
-    return DeviceDetector()
-
-
 class PlatformFL(SRTPlatform):
     """FlagGems-based multi-chip platform for SGLang.
 
@@ -85,31 +73,27 @@ class PlatformFL(SRTPlatform):
 
     def __init__(self):
         super().__init__()
-        detector = _get_device_detector()
+        from sglang_fl.utils import get_device_info
 
-        # Core device identity from FlagGems
-        self._vendor_name: str = detector.vendor_name  # "nvidia", "ascend", ...
-        self._device_type: str = detector.name  # "cuda", "npu", ...
-        self._dispatch_key: str = detector.dispatch_key  # "CUDA", "NPU", ...
-        self._device_count: int = detector.device_count
+        info = get_device_info()
+        if info is None:
+            raise RuntimeError(
+                "PlatformFL cannot initialize: DeviceDetector unavailable "
+                "(flag_gems missing or hardware unrecognised)"
+            )
+        self._info = info
+        self._vendor_name: str = info.vendor_name    # "nvidia", "ascend", ...
+        self._device_type: str = info.device_type    # "cuda", "npu", ...
+        self._dispatch_key: str = info.dispatch_key  # "CUDA", "NPU", ...
+        self._device_count: int = info.device_count
 
         # Set class-level attributes expected by DeviceMixin
         self.device_name = self._device_type
         self.device_type = self._device_type
 
-        # torch device module (e.g. torch.cuda, torch.npu)
-        self._torch_device_mod = getattr(torch, self._device_type, None)
-
         # Resolve distributed backend
         self._dist_backend = self._resolve_dist_backend()
 
-        # Set up torch backend device function
-        try:
-            from flag_gems.runtime import backend
-
-            backend.set_torch_backend_device_fn(self._vendor_name)
-        except Exception:
-            pass
         logger.info(
             "PlatformFL initialized: vendor=%s, device=%s, dist_backend=%s, count=%d",
             self._vendor_name,
@@ -167,18 +151,18 @@ class PlatformFL(SRTPlatform):
 
     def get_device_total_memory(self, device_id: int = 0) -> int:
         """Get total device memory in bytes."""
-        if self._torch_device_mod is None:
+        if self._info.torch_device_fn is None:
             raise RuntimeError(f"No torch.{self._device_type} module available")
-        props = self._torch_device_mod.get_device_properties(device_id)
+        props = self._info.torch_device_fn.get_device_properties(device_id)
         return props.total_memory
 
     def get_current_memory_usage(self, device: Optional[torch.device] = None) -> float:
         """Get current peak memory usage in bytes."""
-        if self._torch_device_mod is None:
+        if self._info.torch_device_fn is None:
             return 0.0
-        self._torch_device_mod.empty_cache()
-        self._torch_device_mod.reset_peak_memory_stats(device)
-        return self._torch_device_mod.max_memory_allocated(device)
+        self._info.torch_device_fn.empty_cache()
+        self._info.torch_device_fn.reset_peak_memory_stats(device)
+        return self._info.torch_device_fn.max_memory_allocated(device)
 
     # ------------------------------------------------------------------
     # Planned methods (provide implementations for future core migration)
@@ -188,8 +172,8 @@ class PlatformFL(SRTPlatform):
         return torch.device(self._device_type, local_rank)
 
     def set_device(self, device: torch.device) -> None:
-        if self._torch_device_mod is not None:
-            self._torch_device_mod.set_device(device)
+        if self._info.torch_device_fn is not None:
+            self._info.torch_device_fn.set_device(device)
 
     def get_device_name(self, device_id: int = 0) -> str:
         return self._device_type
@@ -202,17 +186,17 @@ class PlatformFL(SRTPlatform):
         return None
 
     def empty_cache(self) -> None:
-        if self._torch_device_mod is not None:
-            self._torch_device_mod.empty_cache()
+        if self._info.torch_device_fn is not None:
+            self._info.torch_device_fn.empty_cache()
 
     def synchronize(self) -> None:
-        if self._torch_device_mod is not None:
-            self._torch_device_mod.synchronize()
+        if self._info.torch_device_fn is not None:
+            self._info.torch_device_fn.synchronize()
 
     def get_available_memory(self, device_id: int = 0) -> tuple[int, int]:
-        if self._torch_device_mod is None:
+        if self._info.torch_device_fn is None:
             raise RuntimeError(f"No torch.{self._device_type} module available")
-        return self._torch_device_mod.mem_get_info(device_id)
+        return self._info.torch_device_fn.mem_get_info(device_id)
 
     def get_torch_distributed_backend_str(self) -> str:
         return self._dist_backend

--- a/sglang_fl/utils.py
+++ b/sglang_fl/utils.py
@@ -1,0 +1,110 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Device info and vendor helpers for sglang_fl.
+
+Kept as a low-level module so both ``platform.py`` and the top-level
+``sglang_fl/__init__.py`` can depend on it without circular imports.
+
+``DeviceInfo`` is a live wrapper around FlagGems' ``DeviceDetector`` plus
+its ``runtime.backend`` — it aggregates hardware identity + torch device
+module + backend accessors in a single place. Constructing it has a side
+effect (``set_torch_backend_device_fn``), so callers should go through the
+process-wide singleton returned by ``get_device_info()``.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Optional
+
+_SUPPORTED_VENDORS: frozenset[str] = frozenset({
+    "nvidia", "ascend", "metax", "mthreads",
+    "thead", "gcu", "kunlunxin", "hygon",
+    "iluvatar", "tsingmicro",
+})
+
+
+class DeviceInfo:
+    def __init__(self) -> None:
+        try:
+            # FlagGems<=5.0.2
+            from flag_gems.runtime.backend.device import DeviceDetector
+        except (ImportError, FileNotFoundError):
+            # FlagGems>5.0.2
+            from flag_gems.runtime.backend.device_finder import DeviceDetector
+
+        self.device = DeviceDetector()
+
+        try:
+            from flag_gems.runtime import backend
+
+            backend.set_torch_backend_device_fn(self.device.vendor_name)
+        except Exception:
+            pass
+
+    # ── Identity ──────────────────────────────────────────────────────────
+
+    @property
+    def vendor_name(self) -> str:
+        """e.g. 'nvidia', 'ascend', 'mthreads'."""
+        return self.device.vendor_name
+
+    @property
+    def device_type(self) -> str:
+        """torch device namespace, e.g. 'cuda', 'npu', 'musa'."""
+        return self.device.name
+
+    @property
+    def dispatch_key(self) -> str:
+        """PyTorch dispatch key, e.g. 'CUDA', 'NPU'."""
+        return self.device.dispatch_key
+
+    @property
+    def device_count(self) -> int:
+        return self.device.device_count
+
+    # ── Torch bindings (via flag_gems backend) ───────────────────────────
+
+    @property
+    def torch_device_fn(self):
+        from flag_gems.runtime import backend
+
+        return backend.gen_torch_device_object()
+
+    @property
+    def torch_backend_device(self):
+        from flag_gems.runtime import backend
+
+        return backend.get_torch_backend_device_fn()
+
+    # ── Validation helper ────────────────────────────────────────────────
+
+    def get_supported_device(self) -> bool:
+        if self.vendor_name not in _SUPPORTED_VENDORS:
+            raise NotImplementedError(f"{self.vendor_name} is not supported now!")
+        return True
+
+
+@lru_cache(maxsize=1)
+def get_device_info() -> Optional[DeviceInfo]:
+    try:
+        return DeviceInfo()
+    except Exception as e:
+        # Preserve diagnostic detail: caller-side skip logs won't have access
+        # to the underlying exception, so surface it once from here.
+        import logging
+
+        logging.getLogger(__name__).warning("DeviceDetector unavailable: %s", e)
+        return None

--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -10,11 +10,11 @@ import torch
 
 def _detected_device_type() -> Optional[str]:
     try:
-        from sglang_fl.platform import _get_device_detector
+        from sglang_fl.utils import get_device_info
 
-        detected_name = _get_device_detector().name
-        if detected_name:
-            return str(detected_name).strip().lower()
+        info = get_device_info()
+        if info is not None and info.device_type:
+            return str(info.device_type).strip().lower()
     except Exception:
         pass
 

--- a/tests/unit_tests/platform/conftest.py
+++ b/tests/unit_tests/platform/conftest.py
@@ -31,9 +31,21 @@ def mock_device_detector(monkeypatch):
     The stub goes into ``sys.modules`` so the production ``from
     flag_gems.runtime.backend.device import DeviceDetector`` hits it without
     needing flag_gems installed.
+
+    Also clears the process-wide ``get_device_info`` lru_cache so each test's
+    mock takes effect (otherwise a previous test's cached DeviceInfo would
+    win).
     """
 
     def _make(vendor_name=None, raise_exc=None):
+        # Invalidate the DeviceInfo singleton so the new mock is honoured.
+        try:
+            from sglang_fl.utils import get_device_info
+
+            get_device_info.cache_clear()
+        except Exception:
+            pass
+
         fake_mod = types.ModuleType("flag_gems.runtime.backend.device")
         if raise_exc is not None:
             def _detector_fail(*args, **kwargs):


### PR DESCRIPTION
### Summary
- Consolidate FlagGems.DeviceDetector usage behind a single DeviceInfo accessor.
### Changes
- `sglang_fl/utils.py`: DeviceInfo service class wraps `DeviceDetector` + `set_torch_backend_device_fn`, exposing `vendor_name / device_type / dispatch_key / device_count / torch_device_fn / torch_backend_device. get_device_info()` is `@lru_cache(maxsize=1)` — one detector construction per process.
- `platform.py`: removes inline `_get_device_detector()` + `self._torch_device_mod` + inline `set_torch_backend_device_fn`; routes device module access through `self._info.torch_device_fn`.
### Tests
- Tested on Ascend 910C.
- Ran all examples under examples — all passing.