### PR TITLE
perf(mthreads): optimize S5000 serving schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,20 @@ SGLANG_FL_* env vars > YAML config (SGLANG_FL_CONFIG) > Platform auto-detect YAM
 | `SGLANG_FL_DIST_BACKEND` | `nccl` | Backend: `nccl` / `hccl` / `flagcx` |
 | `FLAGCX_PATH` | — | FlagCX installation path (if set, defaults to `flagcx` backend) |
 
+#### Vendor Kernel Launch Policies
+
+The MThreads backend applies validated launch metadata through a plugin-side
+monkeypatch; the installed SGLang source is not modified. On MTT S5000,
+SGLang's packed GDN decode kernel defaults to `num_warps=8`. Other MUSA devices
+keep SGLang's original launch policy.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SGLANG_FL_MUSA_GDN_PACKED_DECODE_NUM_WARPS` | `auto` | MUSA packed GDN decode launch policy: `auto`, `off`, or `1/2/4/8/16`. `auto` selects `8` only on S5000. |
+
+`SGLANG_MUSA_GDN_PACKED_DECODE_NUM_WARPS` is accepted as a compatibility alias.
+The plugin-prefixed variable takes precedence when both are set.
+
 #### System / Debug
 
 | Variable | Default | Description |

--- a/README_zh.md
+++ b/README_zh.md
@@ -299,6 +299,18 @@ SGLANG_FL_* 环境变量 > YAML 配置 (SGLANG_FL_CONFIG) > 平台自动检测 Y
 | `SGLANG_FL_DIST_BACKEND` | `nccl` | 通信后端：`nccl` / `hccl` / `flagcx` |
 | `FLAGCX_PATH` | — | FlagCX 安装路径（设置后默认使用 `flagcx` 后端） |
 
+#### 厂商 Kernel Launch 策略
+
+摩尔线程后端通过插件侧 monkeypatch 应用已验证的 launch metadata，不修改已安装的
+SGLang 源码。在 MTT S5000 上，SGLang packed GDN decode kernel 默认使用
+`num_warps=8`；其他 MUSA 卡型保持 SGLang 原始策略。
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `SGLANG_FL_MUSA_GDN_PACKED_DECODE_NUM_WARPS` | `auto` | MUSA packed GDN decode launch 策略：`auto`、`off` 或 `1/2/4/8/16`。`auto` 仅在 S5000 上选择 `8`。 |
+
+兼容旧变量 `SGLANG_MUSA_GDN_PACKED_DECODE_NUM_WARPS`；同时设置时，插件前缀变量优先。
+
 #### 系统 / 调试
 
 | 变量 | 默认值 | 说明 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,13 @@ include = ["sglang_fl*"]
 
 [tool.setuptools.package-data]
 "sglang_fl.dispatch.config" = ["*.yaml"]
+"sglang_fl.dispatch.backends.vendor.mthreads.jit_custom_ar" = [
+    "README.md",
+    "csrc/*.h",
+    "csrc/distributed/*.mu",
+    "csrc/distributed/*.cpp",
+    "csrc/norm/*.mu",
+]
 
 [tool.ruff]
 # Folders excluded from lint + format. These hold pre-existing issues that are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ include = ["sglang_fl*"]
     "csrc/distributed/*.cpp",
     "csrc/norm/*.mu",
 ]
+"sglang_fl.dispatch.backends.vendor.mthreads.eventfd_completion" = [
+    "csrc/*.cpp",
+]
 
 [tool.ruff]
 # Folders excluded from lint + format. These hold pre-existing issues that are

--- a/sglang_fl/dispatch/backends/vendor/mthreads/eventfd_completion/__init__.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/eventfd_completion/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MUSA stream-completion helpers backed by Linux eventfd."""
+
+from .provider import (
+    MusaCompletionEventProxy,
+    try_enqueue_musa_completion,
+)
+
+__all__ = ["MusaCompletionEventProxy", "try_enqueue_musa_completion"]

--- a/sglang_fl/dispatch/backends/vendor/mthreads/eventfd_completion/csrc/__init__.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/eventfd_completion/csrc/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sglang_fl/dispatch/backends/vendor/mthreads/eventfd_completion/csrc/musa_eventfd_completion.cpp
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/eventfd_completion/csrc/musa_eventfd_completion.cpp
@@ -1,0 +1,36 @@
+// Copyright 2026 FlagOS Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <musa_runtime_api.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <sys/eventfd.h>
+
+namespace {
+
+void notify_eventfd(void* user_data) {
+  const int event_fd = static_cast<int>(reinterpret_cast<intptr_t>(user_data));
+  while (eventfd_write(event_fd, 1) != 0 && errno == EINTR) {
+  }
+}
+
+}  // namespace
+
+extern "C" int enqueue_musa_eventfd_completion(uintptr_t stream_ptr,
+                                                int event_fd) {
+  return static_cast<int>(musaLaunchHostFunc(
+      reinterpret_cast<musaStream_t>(stream_ptr), notify_eventfd,
+      reinterpret_cast<void*>(static_cast<intptr_t>(event_fd))));
+}

--- a/sglang_fl/dispatch/backends/vendor/mthreads/eventfd_completion/provider.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/eventfd_completion/provider.py
@@ -1,0 +1,271 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bounded MUSA stream completion using ``musaLaunchHostFunc`` and eventfd.
+
+The accelerator Event recorded by SGLang is retained behind a proxy and is the
+correctness fallback for build, enqueue, pool-exhaustion, and wait failures.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import fcntl
+import hashlib
+import logging
+import os
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any, Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+_SOURCE = Path(__file__).resolve().parent / "csrc" / "musa_eventfd_completion.cpp"
+_DEFAULT_CAPACITY = 64
+_POOL: Optional["_MusaEventfdCompletionPool"] | bool = None
+_POOL_LOCK = threading.Lock()
+_ENQUEUE = None
+_ENQUEUE_LOCK = threading.Lock()
+
+
+def _musa_home() -> Path:
+    return Path(os.environ.get("MUSA_HOME", "/usr/local/musa"))
+
+
+def _cache_root() -> Path:
+    explicit = os.environ.get("SGLANG_MUSA_EVENTFD_CACHE_DIR")
+    if explicit:
+        return Path(explicit)
+    jit_root = Path(
+        os.environ.get(
+            "SGLANG_MUSA_JIT_CACHE_DIR",
+            Path.home() / ".cache" / "sglang_musa_jit",
+        )
+    )
+    return jit_root / "eventfd_completion"
+
+
+def _build_provider() -> Path:
+    source_digest = hashlib.sha256(_SOURCE.read_bytes()).hexdigest()[:16]
+    cache_root = _cache_root()
+    cache_root.mkdir(parents=True, exist_ok=True)
+    output = cache_root / f"musa_eventfd_completion_{source_digest}.so"
+    lock_path = cache_root / "build.lock"
+    with lock_path.open("a+") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        if output.is_file():
+            return output
+        temporary = output.with_suffix(f".tmp.{os.getpid()}.so")
+        musa_home = _musa_home()
+        command = [
+            os.environ.get("CXX", "c++"),
+            "-std=c++17",
+            "-O2",
+            "-fPIC",
+            "-shared",
+            str(_SOURCE),
+            f"-I{musa_home / 'include'}",
+            f"-L{musa_home / 'lib'}",
+            "-lmusart",
+            "-o",
+            str(temporary),
+        ]
+        try:
+            subprocess.run(command, check=True, capture_output=True, text=True)
+            os.replace(temporary, output)
+        finally:
+            if temporary.exists():
+                temporary.unlink()
+    return output
+
+
+def _load_enqueue():
+    global _ENQUEUE
+    if _ENQUEUE is not None:
+        return _ENQUEUE
+    with _ENQUEUE_LOCK:
+        if _ENQUEUE is not None:
+            return _ENQUEUE
+        library = ctypes.CDLL(str(_build_provider()))
+        enqueue = library.enqueue_musa_eventfd_completion
+        enqueue.argtypes = [ctypes.c_uint64, ctypes.c_int]
+        enqueue.restype = ctypes.c_int
+        # Keep the library alive until every queued host callback has run.
+        enqueue._musa_eventfd_library = library
+        _ENQUEUE = enqueue
+        return enqueue
+
+
+class _MusaEventfdCompletion:
+    def __init__(self, pool: "_MusaEventfdCompletionPool", slot: int):
+        self._pool = pool
+        self._slot = slot
+        self._lock = threading.Lock()
+        self._done = False
+
+    def wait(self) -> None:
+        # Make repeated synchronize calls safe.  CPython releases the GIL
+        # around eventfd_read, while the native stream callback does not need
+        # the GIL to signal completion.
+        with self._lock:
+            if self._done:
+                return
+            try:
+                payload = os.eventfd_read(self._pool.event_fd(self._slot))
+                if payload != 1:
+                    raise RuntimeError(
+                        f"Invalid MUSA completion eventfd payload: {payload}"
+                    )
+            except Exception:
+                # Do not recycle a descriptor if its callback state is
+                # unknown.  The proxy will synchronize the original Event;
+                # leaking one slot is safer than delivering a late signal to
+                # a later result.
+                self._pool.abandon()
+                self._done = True
+                raise
+            self._done = True
+            self._pool.release(self._slot)
+
+
+class _MusaEventfdCompletionPool:
+    def __init__(self, capacity: int):
+        if capacity <= 0:
+            raise ValueError("MUSA eventfd pool capacity must be positive")
+        if not hasattr(os, "eventfd"):
+            raise RuntimeError("Linux eventfd is unavailable")
+        enqueue = _load_enqueue()
+        event_fds: list[int] = []
+        try:
+            for _ in range(capacity):
+                event_fds.append(os.eventfd(0, os.EFD_CLOEXEC))
+        except Exception:
+            for event_fd in event_fds:
+                os.close(event_fd)
+            raise
+        self._enqueue = enqueue
+        self._event_fds = event_fds
+        self._available = list(range(capacity - 1, -1, -1))
+        self._lock = threading.Lock()
+        self._supported = True
+        self._exhaustion_logged = False
+
+    def event_fd(self, slot: int) -> int:
+        return self._event_fds[slot]
+
+    def enqueue(self, stream: Any) -> Optional[_MusaEventfdCompletion]:
+        with self._lock:
+            if not self._supported or not self._available:
+                if self._supported and not self._exhaustion_logged:
+                    logger.warning(
+                        "MUSA eventfd completion pool exhausted; using Event fallback"
+                    )
+                    self._exhaustion_logged = True
+                return None
+            slot = self._available.pop()
+        try:
+            status = self._enqueue(stream.musa_stream, self._event_fds[slot])
+            if status != 0:
+                raise RuntimeError(f"musaLaunchHostFunc returned {status}")
+        except Exception:
+            with self._lock:
+                self._supported = False
+                self._available.append(slot)
+            logger.exception(
+                "Failed to enqueue MUSA eventfd completion; using Event fallback"
+            )
+            return None
+        return _MusaEventfdCompletion(self, slot)
+
+    def release(self, slot: int) -> None:
+        with self._lock:
+            self._available.append(slot)
+            self._exhaustion_logged = False
+
+    def abandon(self) -> None:
+        with self._lock:
+            self._supported = False
+
+
+def _pool_capacity() -> int:
+    return int(
+        os.environ.get(
+            "SGLANG_MUSA_EVENTFD_COMPLETION_POOL_SIZE", str(_DEFAULT_CAPACITY)
+        )
+    )
+
+
+def _get_pool(device: torch.device) -> Optional[_MusaEventfdCompletionPool]:
+    global _POOL
+    if device.type != "musa" or _POOL is False:
+        return None
+    if _POOL is None:
+        with _POOL_LOCK:
+            if _POOL is None:
+                try:
+                    _POOL = _MusaEventfdCompletionPool(_pool_capacity())
+                except Exception:
+                    _POOL = False
+                    logger.exception(
+                        "Failed to initialize MUSA eventfd completion; "
+                        "using Event fallback"
+                    )
+    return _POOL if isinstance(_POOL, _MusaEventfdCompletionPool) else None
+
+
+def try_enqueue_musa_completion(device: torch.device):
+    pool = _get_pool(device)
+    if pool is None:
+        return None
+    stream = torch.get_device_module(device).current_stream(device)
+    return pool.enqueue(stream)
+
+
+class MusaCompletionEventProxy:
+    """Event-compatible synchronization proxy with an exact Event fallback."""
+
+    def __init__(self, completion: _MusaEventfdCompletion, fallback_event: Any):
+        self._completion = completion
+        self._fallback_event = fallback_event
+        self._lock = threading.Lock()
+        self._done = False
+
+    def synchronize(self) -> None:
+        with self._lock:
+            if self._done:
+                return
+            try:
+                self._completion.wait()
+            except Exception:
+                logger.exception(
+                    "MUSA eventfd completion wait failed; using Event fallback"
+                )
+                self._fallback_event.synchronize()
+            self._done = True
+
+    def __getattr__(self, name: str):
+        return getattr(self._fallback_event, name)
+
+
+def reset_for_test() -> None:
+    """Reset lazy globals; only unit tests should call this helper."""
+    global _POOL, _ENQUEUE
+    _POOL = None
+    _ENQUEUE = None
+
+
+__all__ = ["MusaCompletionEventProxy", "try_enqueue_musa_completion"]

--- a/sglang_fl/dispatch/backends/vendor/mthreads/impl/fla.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/impl/fla.py
@@ -12,16 +12,144 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# MUSA FLA (Flash Linear Attention) operator implementations.
-#
-# TODO: Replace SGLang's original triton kernels with torch_musa native kernel once verified
-# on hardware. Current behavior: SGLang's original triton kernels.
+"""MUSA FLA implementations and safe fallbacks."""
 
 from __future__ import annotations
 
+import inspect
+import logging
+import os
+from collections.abc import Callable
 from typing import Optional, Tuple
 
 import torch
+
+logger = logging.getLogger(__name__)
+
+_MATE_GDN_ENV = "SGLANG_MUSA_MATE_GDN"
+_MATE_GDN_REQUIRED_PARAMETERS = {
+    "q",
+    "k",
+    "v",
+    "state",
+    "A_log",
+    "a",
+    "dt_bias",
+    "b",
+    "state_layout",
+    "state_indices",
+    "scale",
+    "output",
+    "disable_state_update",
+    "use_qk_l2norm",
+}
+_mate_gdn_decode: Optional[Callable] = None
+_mate_gdn_import_attempted = False
+_mate_gdn_match_logged = False
+
+
+def _mate_gdn_enabled() -> bool:
+    return os.environ.get(_MATE_GDN_ENV, "auto").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+        "disable",
+        "disabled",
+    }
+
+
+def _load_mate_gdn_decode() -> Optional[Callable]:
+    """Load a compatible MATE GDN API once, without making MATE mandatory."""
+    global _mate_gdn_decode, _mate_gdn_import_attempted
+    if _mate_gdn_import_attempted:
+        return _mate_gdn_decode
+
+    _mate_gdn_import_attempted = True
+    try:
+        from mate.gdn_decode import gated_delta_rule_decode
+
+        parameters = set(inspect.signature(gated_delta_rule_decode).parameters)
+        missing = _MATE_GDN_REQUIRED_PARAMETERS - parameters
+        if missing:
+            logger.warning(
+                "MATE GDN API is missing required parameters %s; using SGLang fallback",
+                sorted(missing),
+            )
+            return None
+        _mate_gdn_decode = gated_delta_rule_decode
+    except (ImportError, OSError, TypeError, ValueError):
+        logger.info("Compatible MATE GDN decode is unavailable; using SGLang fallback")
+    return _mate_gdn_decode
+
+
+def _is_s5000(device: torch.device) -> bool:
+    try:
+        return "S5000" in str(torch.musa.get_device_name(device)).upper()
+    except (AttributeError, RuntimeError, TypeError):
+        return False
+
+
+def _supports_mate_packed_decode(
+    mixed_qkv: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    initial_state: torch.Tensor,
+    out: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+) -> bool:
+    """Match the MATE VK/FP32-state T=1 contract validated on MP31."""
+    if not _mate_gdn_enabled() or not _is_s5000(mixed_qkv.device):
+        return False
+    if (
+        mixed_qkv.ndim != 2
+        or a.ndim != 2
+        or b.ndim != 2
+        or A_log.ndim != 1
+        or dt_bias.ndim != 1
+        or initial_state.ndim != 4
+        or out.ndim != 4
+        or ssm_state_indices.ndim != 1
+    ):
+        return False
+
+    B = mixed_qkv.shape[0]
+    HV, V, K = initial_state.shape[-3:]
+    qk_dim = mixed_qkv.shape[1] - HV * V
+    if qk_dim <= 0 or qk_dim % 2 or (qk_dim // 2) % K:
+        return False
+    H = (qk_dim // 2) // K
+
+    tensors = (a, b, A_log, dt_bias, initial_state, out, ssm_state_indices)
+    return (
+        K == 128
+        and V == K
+        and H > 0
+        and HV % H == 0
+        and a.shape == (B, HV)
+        and b.shape == (B, HV)
+        and A_log.numel() == HV
+        and dt_bias.numel() == HV
+        and out.shape == (B, 1, HV, V)
+        and ssm_state_indices.shape == (B,)
+        and mixed_qkv.dtype in (torch.float16, torch.bfloat16)
+        and a.dtype == mixed_qkv.dtype
+        and b.dtype == mixed_qkv.dtype
+        and A_log.dtype == torch.float32
+        and dt_bias.dtype in (torch.float32, torch.bfloat16)
+        and initial_state.dtype == torch.float32
+        and out.dtype in (torch.float16, torch.bfloat16, torch.float32)
+        and ssm_state_indices.dtype in (torch.int32, torch.int64)
+        and mixed_qkv.stride(-1) == 1
+        and a.stride(-1) == 1
+        and b.stride(-1) == 1
+        and initial_state.is_contiguous()
+        and out.is_contiguous()
+        and all(t.device == mixed_qkv.device for t in tensors)
+    )
+
 
 def _original(fn_name: str):
     from sglang_fl.dispatch.fla_patch import get_original
@@ -32,6 +160,7 @@ def _original(fn_name: str):
             f"FLA original '{fn_name}' not available — fla_patch not applied yet"
         )
     return fn
+
 
 def chunk_gated_delta_rule_musa(
     q: torch.Tensor,
@@ -48,10 +177,16 @@ def chunk_gated_delta_rule_musa(
 ):
     """chunk_gated_delta_rule — not yet implemented on MUSA. Current behavior: SGLang's original triton kernels."""
     return _original("chunk_gated_delta_rule")(
-        q=q, k=k, v=v, g=g, beta=beta, scale=scale,
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
         initial_state=initial_state,
         initial_state_indices=initial_state_indices,
-        cu_seqlens=cu_seqlens, head_first=head_first,
+        cu_seqlens=cu_seqlens,
+        head_first=head_first,
         use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
     )
 
@@ -72,7 +207,12 @@ def fused_recurrent_gated_delta_rule_musa(
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
     """fused_recurrent_gated_delta_rule — not yet implemented on MUSA. Current behavior: SGLang's original triton kernels."""
     return _original("fused_recurrent_gated_delta_rule")(
-        q=q, k=k, v=v, g=g, beta=beta, scale=scale,
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
         initial_state=initial_state,
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
@@ -94,11 +234,74 @@ def fused_recurrent_gated_delta_rule_packed_decode_musa(
     ssm_state_indices: torch.Tensor,
     use_qk_l2norm_in_kernel: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """fused_recurrent_gated_delta_rule_packed_decode — not yet implemented on MUSA. Current behavior: SGLang's original triton kernels."""
+    """Use MATE's MP31 decode kernel for its validated packed-QKV contract.
+
+    MATE consumes unpacked strided views, so this adapter introduces no QKV
+    materialization.  Unsupported devices, dtypes, layouts, and MATE versions
+    retain SGLang's original packed Triton implementation.  Set
+    ``SGLANG_MUSA_MATE_GDN=off`` to force that fallback.
+    """
+    if _supports_mate_packed_decode(
+        mixed_qkv,
+        a,
+        b,
+        A_log,
+        dt_bias,
+        initial_state,
+        out,
+        ssm_state_indices,
+    ):
+        mate_gdn_decode = _load_mate_gdn_decode()
+        if mate_gdn_decode is not None:
+            global _mate_gdn_match_logged
+            B = mixed_qkv.shape[0]
+            HV, V, K = initial_state.shape[-3:]
+            H = ((mixed_qkv.shape[1] - HV * V) // 2) // K
+
+            q_end = H * K
+            k_end = 2 * H * K
+            q = mixed_qkv[:, :q_end].reshape(B, 1, H, K)
+            k = mixed_qkv[:, q_end:k_end].reshape(B, 1, H, K)
+            v = mixed_qkv[:, k_end:].reshape(B, 1, HV, V)
+
+            if not _mate_gdn_match_logged:
+                logger.info(
+                    "Using MATE GDN packed decode on MTT S5000 "
+                    "(B=%d, H=%d, HV=%d, K=V=%d)",
+                    B,
+                    H,
+                    HV,
+                    K,
+                )
+                _mate_gdn_match_logged = True
+
+            mate_out, _ = mate_gdn_decode(
+                q=q,
+                k=k,
+                v=v,
+                state=initial_state,
+                A_log=A_log,
+                a=a.reshape(B, 1, HV),
+                dt_bias=dt_bias,
+                b=b.reshape(B, 1, HV),
+                state_layout="VK",
+                state_indices=ssm_state_indices,
+                scale=scale,
+                output=out,
+                disable_state_update=False,
+                use_qk_l2norm=use_qk_l2norm_in_kernel,
+            )
+            return mate_out, initial_state
+
     return _original("fused_recurrent_gated_delta_rule_packed_decode")(
-        mixed_qkv=mixed_qkv, a=a, b=b, A_log=A_log,
-        dt_bias=dt_bias, scale=scale,
-        initial_state=initial_state, out=out,
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=scale,
+        initial_state=initial_state,
+        out=out,
         ssm_state_indices=ssm_state_indices,
         use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
     )

--- a/sglang_fl/dispatch/backends/vendor/mthreads/impl/fla.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/impl/fla.py
@@ -27,6 +27,7 @@ import torch
 logger = logging.getLogger(__name__)
 
 _MATE_GDN_ENV = "SGLANG_MUSA_MATE_GDN"
+_MATE_GDN_PREFILL_ENV = "SGLANG_MUSA_MATE_GDN_PREFILL"
 _MATE_GDN_REQUIRED_PARAMETERS = {
     "q",
     "k",
@@ -43,13 +44,42 @@ _MATE_GDN_REQUIRED_PARAMETERS = {
     "disable_state_update",
     "use_qk_l2norm",
 }
+_MATE_GDN_PREFILL_REQUIRED_PARAMETERS = {
+    "q",
+    "k",
+    "v",
+    "g",
+    "beta",
+    "scale",
+    "initial_state",
+    "output_final_state",
+    "cu_seqlens",
+    "use_qk_l2norm_in_kernel",
+    "chunk_size",
+    "is_log_space",
+}
 _mate_gdn_decode: Optional[Callable] = None
 _mate_gdn_import_attempted = False
 _mate_gdn_match_logged = False
+_mate_gdn_prefill: Callable | None = None
+_mate_gdn_prefill_import_attempted = False
+_mate_gdn_prefill_match_logged = False
 
 
 def _mate_gdn_enabled() -> bool:
     return os.environ.get(_MATE_GDN_ENV, "auto").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+        "disable",
+        "disabled",
+    }
+
+
+def _mate_gdn_prefill_enabled() -> bool:
+    value = os.environ.get(_MATE_GDN_PREFILL_ENV, os.environ.get(_MATE_GDN_ENV, "auto"))
+    return value.strip().lower() not in {
         "0",
         "false",
         "no",
@@ -81,6 +111,31 @@ def _load_mate_gdn_decode() -> Optional[Callable]:
     except (ImportError, OSError, TypeError, ValueError):
         logger.info("Compatible MATE GDN decode is unavailable; using SGLang fallback")
     return _mate_gdn_decode
+
+
+def _load_mate_gdn_prefill() -> Callable | None:
+    """Load the matched MATE chunk-prefill API once when it is compatible."""
+    global _mate_gdn_prefill, _mate_gdn_prefill_import_attempted
+    if _mate_gdn_prefill_import_attempted:
+        return _mate_gdn_prefill
+
+    _mate_gdn_prefill_import_attempted = True
+    try:
+        from mate.gdn_prefill import chunk_gated_delta_rule
+
+        parameters = set(inspect.signature(chunk_gated_delta_rule).parameters)
+        missing = _MATE_GDN_PREFILL_REQUIRED_PARAMETERS - parameters
+        if missing:
+            logger.warning(
+                "MATE GDN prefill API is missing required parameters %s; "
+                "using SGLang fallback",
+                sorted(missing),
+            )
+            return None
+        _mate_gdn_prefill = chunk_gated_delta_rule
+    except (ImportError, OSError, TypeError, ValueError):
+        logger.info("Compatible MATE GDN prefill is unavailable; using SGLang fallback")
+    return _mate_gdn_prefill
 
 
 def _is_s5000(device: torch.device) -> bool:
@@ -151,6 +206,82 @@ def _supports_mate_packed_decode(
     )
 
 
+def _mamba_radix_cache_disabled() -> bool:
+    """MATE prefill does not return per-chunk ``h`` for prefix-cache tracking."""
+    try:
+        from sglang.srt.server_args import get_global_server_args
+
+        server_args = get_global_server_args()
+        return bool(server_args is not None and server_args.disable_radix_cache)
+    except (AttributeError, ImportError, RuntimeError):
+        return False
+
+
+def _supports_mate_chunk_prefill(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    initial_state_indices: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    head_first: bool,
+) -> bool:
+    """Match the MP31 varlen chunk-64, FP32 K-last state contract."""
+    if (
+        not _mate_gdn_prefill_enabled()
+        or not _is_s5000(q.device)
+        or not _mamba_radix_cache_disabled()
+        or head_first
+        or initial_state is None
+        or initial_state_indices is None
+        or cu_seqlens is None
+    ):
+        return False
+    if (
+        q.ndim != 4
+        or k.ndim != 4
+        or v.ndim != 4
+        or g.ndim != 3
+        or beta.ndim != 3
+        or initial_state.ndim != 4
+        or initial_state_indices.ndim != 1
+        or cu_seqlens.ndim != 1
+    ):
+        return False
+
+    _, T, H, K = q.shape
+    HV, V, state_k = initial_state.shape[-3:]
+    tensors = (k, v, g, beta, initial_state, initial_state_indices, cu_seqlens)
+    return (
+        q.shape[0] == 1
+        and k.shape == q.shape
+        and v.shape == (1, T, HV, V)
+        and g.shape == (1, T, HV)
+        and beta.shape == g.shape
+        and K == 128
+        and V == K == state_k
+        and HV % H == 0
+        and initial_state_indices.numel() == cu_seqlens.numel() - 1
+        and q.dtype in (torch.float16, torch.bfloat16)
+        and k.dtype == q.dtype
+        and v.dtype == q.dtype
+        and g.dtype == torch.float32
+        and beta.dtype == torch.float32
+        and initial_state.dtype == torch.float32
+        and initial_state_indices.dtype in (torch.int32, torch.int64)
+        and cu_seqlens.dtype in (torch.int32, torch.int64)
+        and q.stride(-1) == 1
+        and k.stride(-1) == 1
+        and v.stride(-1) == 1
+        and g.stride(-1) == 1
+        and beta.stride(-1) == 1
+        and initial_state.is_contiguous()
+        and all(t.device == q.device for t in tensors)
+    )
+
+
 def _original(fn_name: str):
     from sglang_fl.dispatch.fla_patch import get_original
 
@@ -175,7 +306,71 @@ def chunk_gated_delta_rule_musa(
     head_first: bool = False,
     use_qk_l2norm_in_kernel: bool = False,
 ):
-    """chunk_gated_delta_rule — not yet implemented on MUSA. Current behavior: SGLang's original triton kernels."""
+    """Use MATE's fused MP31 chunk-prefill path for its validated contract.
+
+    The adapter mirrors the vendor SGLang backend: gather caller-owned FP32
+    state slots, run MATE's matched L2Norm/KKT/fused recurrence path, then
+    scatter final states back to the pool. MATE does not expose intermediate
+    chunk states ``h``, so auto dispatch is restricted to deployments with the
+    radix cache disabled. Unsupported contracts retain the original SGLang
+    Triton implementation. Set ``SGLANG_MUSA_MATE_GDN_PREFILL=off`` to force
+    the fallback without disabling the independent decode fast path.
+    """
+    if _supports_mate_chunk_prefill(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        initial_state,
+        initial_state_indices,
+        cu_seqlens,
+        head_first,
+    ):
+        mate_gdn_prefill = _load_mate_gdn_prefill()
+        if mate_gdn_prefill is not None:
+            global _mate_gdn_prefill_match_logged
+            T, H, K = q.shape[1:]
+            HV = v.shape[2]
+
+            # Negative padding entries use the final sentinel slot, matching
+            # the vendor backend without a host-side value read or sync.
+            state_indices = torch.where(
+                initial_state_indices >= 0,
+                initial_state_indices,
+                initial_state.shape[0] - 1,
+            ).to(torch.int64)
+            selected_state = initial_state.index_select(0, state_indices)
+
+            if not _mate_gdn_prefill_match_logged:
+                logger.info(
+                    "Using MATE GDN chunk prefill on MTT S5000 "
+                    "(T=%d, H=%d, HV=%d, K=V=%d, sequences=%d)",
+                    T,
+                    H,
+                    HV,
+                    K,
+                    cu_seqlens.numel() - 1,
+                )
+                _mate_gdn_prefill_match_logged = True
+
+            mate_out, final_state = mate_gdn_prefill(
+                q=q[0],
+                k=k[0],
+                v=v[0],
+                g=g[0],
+                beta=beta[0],
+                scale=scale,
+                initial_state=selected_state,
+                output_final_state=True,
+                cu_seqlens=cu_seqlens,
+                use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+                chunk_size=64,
+                is_log_space=True,
+            )
+            initial_state.index_copy_(0, state_indices, final_state)
+            return mate_out.unsqueeze(0), None, None
+
     return _original("chunk_gated_delta_rule")(
         q=q,
         k=k,

--- a/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/README.md
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/README.md
@@ -1,0 +1,11 @@
+# MUSA JIT custom all-reduce sources
+
+These Apache-2.0 sources are vendored from the Moore Threads SGLang 0.5.12
+runtime image used for the MTT S5000 comparison.  The Python integration was
+adapted to remain inside `sglang-plugin-FL`; upstream SGLang is monkeypatched at
+runtime and is not modified.
+
+The compatibility default uses the explicit-input CUDA/MUSA-graph launcher.
+The newer registered-input recapture protocol is opt-in with
+`SGLANG_MUSA_CUSTOM_AR_GRAPH_REGISTERED_INPUT=1` only when the matching SGLang
+graph-runner handshake is present.

--- a/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/__init__.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/__init__.py
@@ -1,0 +1,9 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""MTT S5000 JIT custom all-reduce implementation vendored from MUSA SGLang."""

--- a/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/communicator.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/communicator.py
@@ -1,0 +1,1225 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Adapted from https://github.com/vllm-project/vllm/blob/v0.6.4.post1/vllm/distributed/device_communicators/custom_all_reduce.py
+
+import ctypes
+import logging
+import os
+from contextlib import contextmanager
+from functools import partial
+from typing import Any, List, Optional, Union
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+import sglang.srt.distributed.device_communicators.custom_all_reduce_ops as ops
+from sglang.srt.compilation.piecewise_context_manager import is_in_piecewise_cuda_graph
+from sglang.srt.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
+from sglang.srt.distributed.device_communicators.custom_all_reduce_utils import (
+    can_use_custom_all_reduce_with_nvlink,
+    is_weak_contiguous,
+)
+from sglang.srt.environ import envs
+from sglang_fl.dispatch.backends.vendor.mthreads.jit_custom_ar.fused_rmsnorm import (
+    MusaJitCustomAllreduceRMSNorm,
+)
+from sglang.srt.utils import (
+    get_bool_env_var,
+    is_cuda,
+    is_hip,
+    is_musa,
+    log_info_on_rank0,
+)
+
+_is_cuda = is_cuda()
+_is_hip = is_hip()
+_is_musa = is_musa()
+
+logger = logging.getLogger(__name__)
+
+
+def _env_flag(names: tuple[str, ...], default: bool) -> bool:
+    for name in names:
+        value = os.environ.get(name)
+        if value is not None:
+            return value.lower() in ("1", "true", "yes", "on")
+    return default
+
+
+def _use_jit_all_reduce() -> bool:
+    if _is_cuda:
+        return envs.SGLANG_USE_JIT_ALL_REDUCE.get()
+    if _is_musa:
+        return envs.SGLANG_MUSA_USE_JIT_ALL_REDUCE.get()
+    return False
+
+
+class CustomAllreduce:
+    _SUPPORTED_WORLD_SIZES = [2, 4, 6, 8]
+    _MAX_CAR_SIZE = 8192 * 1024
+    if _is_hip:
+        # crossover is at 16MB buffer size for ROCm
+        _MAX_CAR_SIZE = 2 * 8192 * 1024
+    if _is_musa:
+        # XXX (MUSA): 40k prefill can produce ~252MB TP embedding all-reduce
+        # inputs. Keep a bounded fast path instead of forcing oversized tensors
+        # into the custom kernel without registered buffer space.
+        _MAX_CAR_SIZE = 512 * 1024 * 1024
+
+    # max_size: max supported allreduce size
+    def __init__(
+        self,
+        group: ProcessGroup,
+        device: Union[int, str, torch.device],
+        max_size=_MAX_CAR_SIZE,
+    ) -> None:
+        """
+        Args:
+            group: the process group to work on. If None, it will use the
+                default process group.
+            device: the device to bind the CustomAllreduce to. If None,
+                it will be bind to f"cuda:{local_rank}".
+        It is the caller's responsibility to make sure each communicator
+        is bind to a unique device, and all communicators in this group
+        are in the same node.
+        """
+        self._IS_CAPTURING = False
+        self.disabled = True  # This can be modified in-place by context manager in piecewise cuda graph runner
+        self.original_disabled = True  # To store the original state
+        self.use_amd_deterministic_impl = _use_amd_deterministic_impl()
+
+        if not ops.IS_CUSTOM_AR_AVAILABLE:
+            # disable because of missing custom allreduce library
+            # e.g. in a non-cuda environment
+            return
+
+        rank = dist.get_rank(group=group)
+        world_size = dist.get_world_size(group=group)
+
+        if isinstance(device, int):
+            device = torch.device(f"cuda:{device}")
+        elif isinstance(device, str):
+            device = torch.device(device)
+        # now `device` is a `torch.device` object
+        assert isinstance(device, torch.device)
+        self.device = device
+        full_nvlink = can_use_custom_all_reduce_with_nvlink(
+            group=group,
+            device=device,
+            supported_world_size=self._SUPPORTED_WORLD_SIZES,
+            cls_name="CustomAllreduce",
+        )
+        if full_nvlink is None:
+            return  # fail to get nvlink status
+
+        self.group = group
+        self.max_size = max_size
+        self.rank = rank
+        self.world_size = world_size
+        self.full_nvlink = full_nvlink
+
+        if not _is_hip:
+            # Buffers memory are owned by this Python class and passed to C++.
+            # Meta data composes of two parts: meta data for synchronization and a
+            # temporary buffer for storing intermediate allreduce results.
+            self.meta_ptrs = self.create_shared_buffer(
+                ops.meta_size() + max_size, group=group
+            )
+            # This is a pre-registered IPC buffer. In eager mode, input tensors
+            # are first copied into this buffer before allreduce is performed
+            self.buffer_ptrs = self.create_shared_buffer(max_size, group=group)
+            # This is a buffer for storing the tuples of pointers pointing to
+            # IPC buffers from all ranks. Each registered tuple has size of
+            # 8*world_size bytes where world_size is at most 8. Allocating 8MB
+            # is enough for 131072 such tuples. The largest model I've seen only
+            # needs less than 10000 of registered tuples.
+            self.rank_data = torch.empty(
+                max_size, dtype=torch.uint8, device=self.device
+            )
+            self._ptr = ops.init_custom_ar(
+                self.meta_ptrs, self.rank_data, rank, self.full_nvlink
+            )
+            ops.register_buffer(self._ptr, self.buffer_ptrs)
+        else:
+            # meta data buffers need to be "uncached" for signal on MI200
+            self.meta = ops.allocate_meta_buffer(ops.meta_size() + max_size)
+            self.buffer = torch.empty(max_size, dtype=torch.uint8, device=self.device)
+            handle = ops.get_meta_buffer_ipc_handle(self.meta)
+            shard_data = (
+                bytes(handle),  # ipc handle to base ptr
+                0,  # offset of base ptr
+            )
+            handles, offsets = self._gather_ipc_meta(shard_data)
+            self.rank_data = torch.empty(
+                max_size, dtype=torch.uint8, device=self.device
+            )
+            self._ptr = ops.init_custom_ar(
+                self.meta, self.rank_data, handles, offsets, rank, self.full_nvlink
+            )
+            self.register_buffer(self.buffer)
+
+        self.disabled = False
+        self.original_disabled = False  # Ensure original_disabled == disabled
+        self.tms_cudagraph = envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH.get()
+
+    @staticmethod
+    def create_shared_buffer(
+        size_in_bytes: int, group: Optional[ProcessGroup] = None
+    ) -> List[int]:
+        """
+        Creates a shared buffer and returns a list of pointers
+        representing the buffer on all processes in the group.
+        """
+        lib = CudaRTLibrary()
+        pointer = lib.cudaMalloc(size_in_bytes)
+        if _is_musa:
+            lib.cudaMemset(pointer, 0, size_in_bytes)
+        handle = lib.cudaIpcGetMemHandle(pointer)
+        world_size = dist.get_world_size(group=group)
+        rank = dist.get_rank(group=group)
+        handles = [None] * world_size
+        dist.all_gather_object(handles, handle, group=group)
+
+        pointers: List[int] = []
+        for i, h in enumerate(handles):
+            if i == rank:
+                pointers.append(pointer.value)  # type: ignore
+            else:
+                pointers.append(lib.cudaIpcOpenMemHandle(h).value)  # type: ignore
+
+        return pointers
+
+    @staticmethod
+    def free_shared_buffer(
+        pointers: List[int], group: Optional[ProcessGroup] = None
+    ) -> None:
+        rank = dist.get_rank(group=group)
+        lib = CudaRTLibrary()
+        lib.cudaFree(ctypes.c_void_p(pointers[rank]))
+
+    @contextmanager
+    def capture(self):
+        """
+        The main responsibility of this context manager is the
+        `register_graph_buffers` call at the end of the context.
+        It records all the buffer addresses used in the CUDA graph.
+        """
+        try:
+            self._IS_CAPTURING = True
+            yield
+        finally:
+            self._IS_CAPTURING = False
+            if not self.disabled:
+                self.register_graph_buffers()
+
+    def _get_ipc_meta(self, inp: torch.Tensor):
+        # _share_cuda_() doesn't accept meta buffer not allocated from
+        # PyTorch cache allocator, use direct HIP call to get IPC handle
+        handle = ops.get_meta_buffer_ipc_handle(inp)
+        shard_data = (
+            bytes(handle),  # ipc handle to base ptr
+            0,  # offset of base ptr
+        )
+        return self._gather_ipc_meta(shard_data)
+
+    def _gather_ipc_meta(self, shard_data):
+        # Note: don't use `[[None]] * self.world_size` here
+        # because it will create a list of the same reference
+        all_data: List[Optional[Any]] = [[None] for i in range(self.world_size)]
+        all_data[self.rank][0] = shard_data
+
+        ranks = dist.get_process_group_ranks(group=self.group)
+        ranks.sort()
+        for i, rank in enumerate(ranks):
+            dist.broadcast_object_list(
+                all_data[i], src=rank, group=self.group, device="cpu"
+            )
+
+        # we cannot directly use `dist.all_gather_object` here
+        # because it is incompatible with `gloo` backend under inference mode.
+        # see https://github.com/pytorch/pytorch/issues/126032 for details.
+
+        handles = []
+        offsets = []
+        for i in range(len(all_data)):
+            handles.append(all_data[i][0][0])  # type: ignore
+            offsets.append(all_data[i][0][1])  # type: ignore
+        return handles, offsets
+
+    def register_buffer(self, inp: torch.Tensor):
+        handles, offsets = self._get_ipc_meta(inp)
+        ops.register_buffer(self._ptr, inp, handles, offsets)
+
+    def register_graph_buffers(self):
+        if _is_hip:
+            handle, offset = ops.get_graph_buffer_ipc_meta(self._ptr)
+            handles, offsets = self._gather_ipc_meta((bytes(handle), offset))
+            log_info_on_rank0(logger, f"Registering {len(offset)} cuda graph addresses")
+            ops.register_graph_buffers(self._ptr, handles, offsets)
+        else:
+            handle, offset = ops.get_graph_buffer_ipc_meta(self._ptr)
+            log_info_on_rank0(logger, f"Registering {len(offset)} cuda graph addresses")
+            # We cannot directly use `dist.all_gather_object` here
+            # because it is incompatible with `gloo` backend under inference mode.
+            # see https://github.com/pytorch/pytorch/issues/126032 for details.
+            all_data = [
+                [None, None] for _ in range(dist.get_world_size(group=self.group))
+            ]
+            all_data[self.rank] = [handle, offset]
+            ranks = sorted(dist.get_process_group_ranks(group=self.group))
+            for i, rank in enumerate(ranks):
+                dist.broadcast_object_list(
+                    all_data[i], src=rank, group=self.group, device="cpu"
+                )
+            # Unpack list of tuples to tuple of lists.
+            handles = [d[0] for d in all_data]  # type: ignore
+            offsets = [d[1] for d in all_data]  # type: ignore
+            ops.register_graph_buffers(self._ptr, handles, offsets)
+
+    def should_custom_ar(self, inp: torch.Tensor):
+        if self.disabled:
+            return False
+        inp_size = inp.numel() * inp.element_size()
+        # custom allreduce requires input byte size to be multiples of 16
+        if inp_size % 16 != 0:
+            return False
+        if not is_weak_contiguous(inp):
+            return False
+        # for 4 or more non NVLink-capable GPUs, custom allreduce provides
+        # little performance improvement over NCCL.
+        if not _is_hip:
+            if _is_musa:
+                # XXX (MUSA): MUSA CAR does not use the CUDA NVLink topology
+                # gate; rely on registered-buffer size support instead.
+                return inp_size <= self.max_size
+            if self.world_size == 2 or self.full_nvlink:
+                return inp_size <= self.max_size
+            return False
+
+        if _is_hip:
+            if self.use_amd_deterministic_impl:
+                return True
+            if self.full_nvlink:
+                return inp_size <= self.max_size
+            return False
+
+        return False
+
+    def _all_reduce_impl(self, inp: torch.Tensor, registered: bool):
+        out = torch.empty_like(inp)
+        if not _is_hip:  # CUDA-like
+            if registered:
+                ops.all_reduce(self._ptr, inp, out, 0, 0)
+            else:
+                ops.all_reduce(
+                    self._ptr, inp, out, self.buffer_ptrs[self.rank], self.max_size
+                )
+        elif self.use_amd_deterministic_impl:
+            inp_size = inp.numel() * inp.element_size()
+            if inp_size < self.max_size:
+                reg_buffer = self.buffer.view(inp.dtype)[: inp.numel()]
+                ops.deterministic_all_reduce_unreg(self._ptr, inp, reg_buffer, out)
+            else:
+                self.register_buffer(inp)
+                ops.deterministic_all_reduce_reg(self._ptr, inp, out)
+        else:  # normal AMD ROCm path
+            if registered:
+                ops.all_reduce_reg(self._ptr, inp, out)
+            else:
+                ops.all_reduce_unreg(self._ptr, inp, self.buffer, out)
+        return out
+
+    def custom_all_reduce(self, input: torch.Tensor) -> Optional[torch.Tensor]:
+        """The main allreduce API that provides support for cuda graph."""
+        # When custom allreduce is disabled, this will be None.
+        if self.disabled or not self.should_custom_ar(input):
+            return None
+        if self._IS_CAPTURING:
+            if torch.get_device_module().is_current_stream_capturing():
+                return self._all_reduce_impl(input, registered=not self.tms_cudagraph)
+            else:
+                # Could be warmup OR piecewise cuda graph split op execution.
+                # In piecewise cuda graph, split ops run eagerly outside the graph
+                # but _IS_CAPTURING is still True. We need to do real all-reduce.
+                if is_in_piecewise_cuda_graph():
+                    # Split op execution - do real all-reduce
+                    return self._all_reduce_impl(input, registered=False)
+                else:
+                    # True warmup - mimic the allocation pattern since custom
+                    # allreduce is out-of-place.
+                    return torch.zeros_like(input)
+        else:
+            return self._all_reduce_impl(input, registered=False)
+
+    def close(self):
+        if not self.disabled and self._ptr:
+            ops.dispose(self._ptr)
+            if _is_cuda:
+                self.free_shared_buffer(self.meta_ptrs)
+                self.free_shared_buffer(self.buffer_ptrs)
+            self._ptr = 0
+
+    def __del__(self):
+        self.close()
+
+
+class MusaJitCustomAllreduce:
+    _SUPPORTED_WORLD_SIZES = [2, 4, 6, 8]
+    _MAX_CAR_SIZE = 512 * 1024 * 1024
+    _RANK_DATA_WIDTH = 8
+    _RANK_DATA_ELEMENT_SIZE = ctypes.sizeof(ctypes.c_int64)
+    requires_graph_capture_registration_recapture = False
+
+    @classmethod
+    def _graph_rank_data_slot_capacity(cls, max_size: int) -> int:
+        # Match sgl-kernel's rank-data allocation: max_size bytes are divided
+        # into RankData records, each containing eight 64-bit rank pointers.
+        return max_size // (cls._RANK_DATA_WIDTH * cls._RANK_DATA_ELEMENT_SIZE)
+
+    def __init__(
+        self,
+        group: ProcessGroup,
+        device: Union[int, str, torch.device],
+        max_size=_MAX_CAR_SIZE,
+    ) -> None:
+        self.disabled = True
+        self.original_disabled = True
+        self.group = group
+        self.max_size = max_size
+        self._IS_CAPTURING = False
+        self._rank_data_cache: dict[int, torch.Tensor] = {}
+        self._rank_data_context_cache: dict[tuple[int, int], int] = {}
+        self._unregistered_context_cache: dict[tuple[int, int], int] = {}
+        self._opened_ipc_ptrs: dict[bytes, int] = {}
+        self._musa_lib = None
+        self._mu_pointer_get_attribute = None
+        self._last_input_ptr: Optional[int] = None
+        self._last_rank_data: Optional[torch.Tensor] = None
+        self._graph_inputs: list[tuple[torch.Tensor, Optional[int]]] = []
+        self._graph_registered_input_sequence: list[
+            tuple[tuple[object, ...], torch.Tensor, torch.Tensor]
+        ] = []
+        self._graph_registered_sequence_signature: tuple[
+            tuple[tuple[object, ...], tuple[int, ...]], ...
+        ] = ()
+        self._graph_registered_cursor = 0
+        self._graph_registered_miss = False
+        self._graph_registered_input_enabled = False
+        self._shot_decision_cache: dict[tuple[int, bool, bool], int] = {}
+        self._context_on_record_graph_input = _env_flag(
+            (
+                "SGLANG_CUSTOM_AR_CONTEXT_ON_RECORD_GRAPH_INPUT",
+                "SGL_CUSTOM_AR_CONTEXT_ON_RECORD_GRAPH_INPUT",
+            ),
+            False,
+        )
+        self._launch_context_enabled = _env_flag(
+            ("SGLANG_CUSTOM_AR_LAUNCH_CONTEXT", "SGL_CUSTOM_AR_LAUNCH_CONTEXT"),
+            True,
+        )
+
+        if isinstance(device, int):
+            device = torch.device(f"musa:{device}")
+        elif isinstance(device, str):
+            device = torch.device(device)
+        assert isinstance(device, torch.device)
+        self.device = device
+
+        self.rank = dist.get_rank(group=group)
+        self.world_size = dist.get_world_size(group=group)
+        if self.world_size not in self._SUPPORTED_WORLD_SIZES:
+            return
+
+        from sglang_fl.dispatch.backends.vendor.mthreads.jit_custom_ar.csrc import (
+            allreduce as jit_ar,
+        )
+
+        self._jit_ar = jit_ar
+        self.meta_ptrs = CustomAllreduce.create_shared_buffer(
+            jit_ar.meta_size(self.world_size) + max_size, group=group
+        )
+        self.buffer_ptrs = CustomAllreduce.create_shared_buffer(max_size, group=group)
+        jit_ar.ensure_compiled(self.world_size)
+        self._registered_launchers = {}
+        self._context_launchers = {}
+        self._context_pybind_launchers = {}
+        self._context_torchop_launchers = {}
+        self._unregistered_launchers = {}
+        self._unregistered_pybind_launchers = {}
+        self._unregistered_context_pybind_launchers = {}
+        self._unregistered_context_pybind_creators = {}
+        self._unregistered_context_pybind_disposers = {}
+        self._fused_rmsnorm = MusaJitCustomAllreduceRMSNorm(self)
+        self._torchop_context_enabled = _env_flag(
+            ("SGLANG_CUSTOM_AR_TORCHOP_CONTEXT", "SGL_CUSTOM_AR_TORCHOP_CONTEXT"),
+            False,
+        )
+        self._pybind_context_enabled = _env_flag(
+            ("SGLANG_CUSTOM_AR_PYBIND_CONTEXT", "SGL_CUSTOM_AR_PYBIND_CONTEXT"),
+            True,
+        )
+        self._pybind_unregistered_enabled = _env_flag(
+            (
+                "SGLANG_CUSTOM_AR_PYBIND_UNREGISTERED",
+                "SGL_CUSTOM_AR_PYBIND_UNREGISTERED",
+            ),
+            True,
+        )
+        self._pybind_unregistered_context_enabled = _env_flag(
+            (
+                "SGLANG_CUSTOM_AR_PYBIND_UNREGISTERED_CONTEXT",
+                "SGL_CUSTOM_AR_PYBIND_UNREGISTERED_CONTEXT",
+            ),
+            False,
+        )
+        self._graph_registered_input_enabled = _env_flag(
+            (
+                "SGLANG_MUSA_CUSTOM_AR_GRAPH_REGISTERED_INPUT",
+                "SGL_CUSTOM_AR_GRAPH_REGISTERED_INPUT",
+            ),
+            # SGLang <=0.5.11 does not have the vendor runtime's graph
+            # registration/recapture handshake.  The explicit-input launcher
+            # is graph safe and is therefore the compatibility default here.
+            False,
+        )
+        self.requires_graph_capture_registration_recapture = (
+            self._graph_registered_input_enabled
+        )
+        self.rank_data = torch.tensor(
+            self.buffer_ptrs + [0] * (8 - self.world_size), dtype=torch.int64
+        )
+        self.signal_ptrs_cpu = torch.tensor(self.meta_ptrs, dtype=torch.int64)
+        # Match sgl-kernel's rank-data capacity. The graph captures a stable
+        # RankData* and replay reads the registered pointers from the slot
+        # content filled after buffer registration.
+        graph_rank_data_slot_capacity = self._graph_rank_data_slot_capacity(max_size)
+        if graph_rank_data_slot_capacity == 0:
+            raise ValueError(
+                "MUSA JIT custom allreduce max_size must fit at least one "
+                "rank-data slot (64 bytes)."
+            )
+        self._graph_rank_data_slots = torch.empty(
+            (graph_rank_data_slot_capacity, self._RANK_DATA_WIDTH),
+            dtype=torch.int64,
+            device=self.device,
+        )
+        self._graph_rank_data_slot_next = 0
+        self._graph_capture_slot_base: Optional[int] = None
+        self._graph_capture_slot_count = 0
+        self.disabled = False
+        self.original_disabled = False
+
+    @contextmanager
+    def capture(self):
+        try:
+            self._graph_inputs.clear()
+            self._graph_registered_cursor = 0
+            self._graph_registered_miss = False
+            self._IS_CAPTURING = True
+            yield
+        finally:
+            self._IS_CAPTURING = False
+            if not self._graph_registered_input_enabled:
+                self._graph_inputs.clear()
+
+    def should_custom_ar(self, inp: torch.Tensor):
+        if self.disabled:
+            return False
+        if inp.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+            return False
+        inp_size = inp.numel() * inp.element_size()
+        if inp_size % 16 != 0 or inp_size > self.max_size:
+            return False
+        return is_weak_contiguous(inp)
+
+    def _should_fused_rmsnorm_custom_ar(self, inp: torch.Tensor):
+        return self._fused_rmsnorm._should_fused_rmsnorm_custom_ar(inp)
+
+    def _get_base_ptr_and_offset(self, inp: torch.Tensor) -> tuple[int, int]:
+        ptr_value = int(inp.data_ptr())
+        if self._mu_pointer_get_attribute is None:
+            self._musa_lib = ctypes.CDLL("libmusa.so")
+            self._mu_pointer_get_attribute = self._musa_lib.muPointerGetAttribute
+            self._mu_pointer_get_attribute.restype = ctypes.c_int
+            self._mu_pointer_get_attribute.argtypes = [
+                ctypes.c_void_p,
+                ctypes.c_int,
+                ctypes.c_ulonglong,
+            ]
+        base_ptr = ctypes.c_void_p()
+        err = self._mu_pointer_get_attribute(
+            ctypes.byref(base_ptr),
+            11,  # MU_POINTER_ATTRIBUTE_RANGE_START_ADDR
+            ctypes.c_ulonglong(ptr_value),
+        )
+        if err != 0:
+            raise RuntimeError(f"muPointerGetAttribute failed: {err}")
+        base_value = int(base_ptr.value)
+        return base_value, ptr_value - base_value
+
+    def _gather_ipc_meta(self, shard_data):
+        handle, offset = shard_data
+        handle_tensor = torch.tensor(list(handle), dtype=torch.uint8, device="cpu")
+        offset_tensor = torch.tensor([offset], dtype=torch.int64, device="cpu")
+        handle_list = [torch.empty_like(handle_tensor) for _ in range(self.world_size)]
+        offset_list = [torch.empty_like(offset_tensor) for _ in range(self.world_size)]
+        dist.all_gather(handle_list, handle_tensor, group=self.group)
+        dist.all_gather(offset_list, offset_tensor, group=self.group)
+        handles = [bytes(t.tolist()) for t in handle_list]
+        offsets = [int(t.item()) for t in offset_list]
+        return handles, offsets
+
+    def _local_ipc_record_for_input(self, inp: torch.Tensor) -> tuple[int, bytes, int]:
+        ptr_value = int(inp.data_ptr())
+        base_value, offset = self._get_base_ptr_and_offset(inp)
+        lib = CudaRTLibrary()
+        handle = lib.cudaIpcGetMemHandle(ctypes.c_void_p(base_value))
+        return ptr_value, bytes(handle), offset
+
+    def _rank_data_from_ipc_records(
+        self, ptr_value: int, records: list[tuple[int, bytes, int]]
+    ) -> torch.Tensor:
+        lib = CudaRTLibrary()
+        ptrs: List[int] = []
+        for i, (_, h, off) in enumerate(records):
+            if i == self.rank:
+                ptrs.append(ptr_value)
+            else:
+                opened_base = self._opened_ipc_ptrs.get(h)
+                if opened_base is None:
+                    from sglang.srt.distributed.device_communicators.cuda_wrapper import (
+                        cudaIpcMemHandle_t,
+                    )
+
+                    ipc_handle = cudaIpcMemHandle_t.from_buffer_copy(h)
+                    opened_base = lib.cudaIpcOpenMemHandle(ipc_handle).value
+                    self._opened_ipc_ptrs[h] = opened_base
+                ptrs.append(opened_base + int(off))
+        ptrs += [0] * (8 - self.world_size)
+        return torch.tensor(ptrs, dtype=torch.int64)
+
+    @staticmethod
+    def _rank_data_ptr_tuple(rank_data: torch.Tensor) -> tuple[int, ...]:
+        return tuple(int(value) for value in rank_data.tolist())
+
+    def _rank_data_for_input(
+        self, inp: torch.Tensor, refresh: bool = False
+    ) -> torch.Tensor:
+        ptr_value = int(inp.data_ptr())
+        if (
+            not refresh
+            and ptr_value == self._last_input_ptr
+            and self._last_rank_data is not None
+        ):
+            return self._last_rank_data
+        if not refresh:
+            cached = self._rank_data_cache.get(ptr_value)
+            if cached is not None:
+                self._last_input_ptr = ptr_value
+                self._last_rank_data = cached
+                return cached
+
+        _, handle, offset = self._local_ipc_record_for_input(inp)
+        handles, offsets = self._gather_ipc_meta((handle, offset))
+        rank_data = self._rank_data_from_ipc_records(
+            ptr_value,
+            [(0, h, off) for h, off in zip(handles, offsets)],
+        )
+        self._rank_data_cache[ptr_value] = rank_data
+        self._last_input_ptr = ptr_value
+        self._last_rank_data = rank_data
+        return rank_data
+
+    def _context_for_rank_data(
+        self, ptr_value: int, shot: int, rank_data: torch.Tensor
+    ) -> int:
+        key = (ptr_value, int(shot))
+        cached = self._rank_data_context_cache.get(key)
+        if cached is not None:
+            return cached
+        context_ptr = self._jit_ar.create_context(
+            rank_data,
+            self.signal_ptrs_cpu,
+            int(self.meta_ptrs[self.rank]),
+            self.rank,
+            self.world_size,
+            shot,
+        )
+        self._rank_data_context_cache[key] = context_ptr
+        return context_ptr
+
+    def _rank_data_for_registered_input(
+        self,
+        inp: torch.Tensor,
+        shot: Optional[int] = None,
+    ) -> Optional[torch.Tensor]:
+        is_graph_launch = (
+            self._IS_CAPTURING
+            and torch.get_device_module().is_current_stream_capturing()
+        )
+        if is_graph_launch:
+            self._record_graph_input(inp, shot)
+            signature = self._graph_input_signature(inp, shot)
+            cursor = self._graph_registered_cursor
+            self._graph_registered_cursor += 1
+            if cursor < len(self._graph_registered_input_sequence):
+                cached_signature, rank_data, rank_data_slot = (
+                    self._graph_registered_input_sequence[cursor]
+                )
+                if cached_signature == signature and self._rank_data_ptr_tuple(
+                    rank_data
+                )[self.rank] == int(inp.data_ptr()):
+                    return rank_data_slot
+            if self._graph_registered_input_sequence:
+                self._graph_registered_miss = True
+            return None
+        # Registered graph launchers always consume the stable device slot.
+        # Eager and SHOT_PUSH paths use their explicit-input launchers instead.
+        return None
+
+    @staticmethod
+    def _graph_input_signature(
+        inp: torch.Tensor, shot: Optional[int]
+    ) -> tuple[object, ...]:
+        return (
+            tuple(int(dim) for dim in inp.shape),
+            str(inp.dtype),
+            int(inp.numel()),
+            int(inp.element_size()),
+            shot,
+        )
+
+    def _record_graph_input(self, inp: torch.Tensor, shot: Optional[int]) -> None:
+        self._graph_inputs.append((inp, int(shot) if shot is not None else None))
+        if shot is not None and self._context_on_record_graph_input:
+            if self._use_launch_context(shot):
+                self._context_for_input(inp, int(shot))
+
+    def _graph_object_broadcast_device(self) -> Union[str, torch.device]:
+        try:
+            backend = str(dist.get_backend(group=self.group)).lower()
+        except Exception:
+            backend = ""
+        if "gloo" in backend:
+            return "cpu"
+        return self.device
+
+    def register_graph_buffers(self) -> int:
+        if not self._graph_registered_input_enabled:
+            self._graph_inputs.clear()
+            self._graph_registered_input_sequence.clear()
+            self._graph_registered_sequence_signature = ()
+            self._graph_registered_cursor = 0
+            return 0
+
+        entries = []
+        try:
+            for inp, shot in tuple(self._graph_inputs):
+                ptr_value = int(inp.data_ptr())
+                if not self.should_custom_ar(
+                    inp
+                ) and not self._should_fused_rmsnorm_custom_ar(inp):
+                    continue
+                signature = self._graph_input_signature(inp, shot)
+                ptr_value, handle, offset = self._local_ipc_record_for_input(inp)
+                entries.append((ptr_value, handle, offset, shot, signature))
+
+            all_entries = [None for _ in range(self.world_size)]
+            all_entries[self.rank] = entries
+            ranks = dist.get_process_group_ranks(group=self.group)
+            broadcast_device = self._graph_object_broadcast_device()
+            for i, rank in enumerate(ranks):
+                holder = [all_entries[i]]
+                dist.broadcast_object_list(
+                    holder, src=rank, group=self.group, device=broadcast_device
+                )
+                all_entries[i] = holder[0]
+
+            entry_counts = [len(rank_entries or ()) for rank_entries in all_entries]
+            if len(set(entry_counts)) != 1:
+                raise RuntimeError(
+                    "MUSA JIT custom allreduce graph input registration mismatch: "
+                    f"rank entry counts are {entry_counts}."
+                )
+
+            registered = 0
+            new_sequence = []
+            new_sequence_signature = []
+            slot_base = (
+                self._graph_capture_slot_base
+                if self._graph_capture_slot_base is not None
+                else self._graph_rank_data_slot_next
+            )
+            for idx, (ptr_value, handle, offset, shot, signature) in enumerate(entries):
+                slot_index = slot_base + idx
+                if slot_index >= self._graph_rank_data_slots.size(0):
+                    raise RuntimeError(
+                        "MUSA JIT custom allreduce graph input registration "
+                        "exceeds device rank-data slot capacity "
+                        f"({self._graph_rank_data_slots.size(0)})."
+                    )
+                rank_records = []
+                rank_signatures = []
+                for rank_entries in all_entries:
+                    peer_ptr, peer_handle, peer_offset, _, peer_signature = (
+                        rank_entries[idx]
+                    )
+                    rank_records.append((peer_ptr, peer_handle, peer_offset))
+                    rank_signatures.append(peer_signature)
+
+                if any(
+                    peer_signature != signature for peer_signature in rank_signatures
+                ):
+                    raise RuntimeError(
+                        "MUSA JIT custom allreduce graph input registration "
+                        f"order mismatch at entry {idx}: {rank_signatures}."
+                    )
+
+                rank_data = self._rank_data_from_ipc_records(ptr_value, rank_records)
+                graph_signature = (
+                    signature,
+                    self._rank_data_ptr_tuple(rank_data),
+                )
+                rank_data_slot = self._graph_rank_data_slots[slot_index]
+                rank_data_slot.copy_(
+                    rank_data.to(device=self.device, non_blocking=False)
+                )
+                new_sequence.append((signature, rank_data, rank_data_slot))
+                new_sequence_signature.append(graph_signature)
+                self._rank_data_cache[ptr_value] = rank_data
+                self._last_input_ptr = ptr_value
+                self._last_rank_data = rank_data
+            new_sequence_signature = tuple(new_sequence_signature)
+            if self._graph_registered_sequence_signature != new_sequence_signature:
+                registered += 1
+                self._graph_registered_sequence_signature = new_sequence_signature
+            elif self._graph_registered_miss:
+                registered += 1
+            torch.get_device_module().synchronize()
+            if self._graph_capture_slot_base is not None:
+                self._graph_capture_slot_count = max(
+                    self._graph_capture_slot_count, len(new_sequence)
+                )
+            self._graph_registered_input_sequence = new_sequence
+            self._graph_registered_cursor = 0
+            self._graph_registered_miss = False
+            return registered
+        finally:
+            self._graph_inputs.clear()
+
+    def begin_graph_capture_registration(self) -> None:
+        if not self._graph_registered_input_enabled:
+            return
+        self._graph_registered_input_sequence.clear()
+        self._graph_registered_sequence_signature = ()
+        self._graph_registered_cursor = 0
+        self._graph_registered_miss = False
+        self._graph_capture_slot_base = self._graph_rank_data_slot_next
+        self._graph_capture_slot_count = 0
+
+    def end_graph_capture_registration(self) -> None:
+        if not self._graph_registered_input_enabled:
+            return
+        if self._graph_capture_slot_base is not None:
+            self._graph_rank_data_slot_next = max(
+                self._graph_rank_data_slot_next,
+                self._graph_capture_slot_base + self._graph_capture_slot_count,
+            )
+        self._graph_capture_slot_base = None
+        self._graph_capture_slot_count = 0
+        self._graph_registered_input_sequence.clear()
+        self._graph_registered_sequence_signature = ()
+        self._graph_registered_cursor = 0
+        self._graph_registered_miss = False
+
+    def prepare_graph_capture(self) -> None:
+        if self._graph_registered_input_enabled:
+            self._graph_registered_cursor = 0
+            self._graph_registered_miss = False
+
+    def prepare_graph_replay(self) -> None:
+        if self._graph_registered_input_enabled:
+            self._graph_registered_cursor = 0
+
+    def fused_allreduce_rmsnorm(
+        self,
+        input_: torch.Tensor,
+        residual_inp_: torch.Tensor,
+        weight_: torch.Tensor,
+        eps: float,
+    ) -> Optional[tuple[torch.Tensor, torch.Tensor]]:
+        return self._fused_rmsnorm.fused_allreduce_rmsnorm(
+            input_, residual_inp_, weight_, eps
+        )
+
+    def _launch_registered(
+        self, rank_data: torch.Tensor, out: torch.Tensor, shot: int
+    ) -> None:
+        launcher = self._registered_launchers.get(shot)
+        if launcher is None:
+            launcher = self._jit_ar.launch_registered_func(self.world_size, shot)
+            self._registered_launchers[shot] = launcher
+        launcher(
+            rank_data,
+            self.signal_ptrs_cpu,
+            out,
+            self.meta_ptrs[self.rank],
+            self.rank,
+            self.world_size,
+            shot,
+        )
+
+    def _context_for_input(self, inp: torch.Tensor, shot: int) -> int:
+        key = (int(inp.data_ptr()), int(shot))
+        cached = self._rank_data_context_cache.get(key)
+        if cached is not None:
+            return cached
+        rank_data = self._rank_data_for_input(inp)
+        context_ptr = self._jit_ar.create_context(
+            rank_data,
+            self.signal_ptrs_cpu,
+            self.meta_ptrs[self.rank],
+            self.rank,
+            self.world_size,
+            shot,
+        )
+        self._rank_data_context_cache[key] = context_ptr
+        return context_ptr
+
+    def _launch_registered_context(
+        self, context_ptr: int, out: torch.Tensor, shot: int
+    ) -> None:
+        launcher = self._context_launchers.get(shot)
+        if launcher is None:
+            launcher = self._jit_ar.launch_context_func(self.world_size, shot)
+            self._context_launchers[shot] = launcher
+        launcher(int(context_ptr), out, shot)
+
+    def _launch_registered_context_pybind(
+        self, context_ptr: int, out: torch.Tensor, shot: int
+    ) -> None:
+        launcher = self._context_pybind_launchers.get(shot)
+        if launcher is None:
+            launcher = self._jit_ar.launch_context_pybind_func(self.world_size, shot)
+            self._context_pybind_launchers[shot] = launcher
+        launcher(int(context_ptr), out, int(shot))
+
+    def _launch_registered_context_torchop(
+        self, context_ptr: int, out: torch.Tensor, shot: int
+    ) -> None:
+        launcher = self._context_torchop_launchers.get(shot)
+        if launcher is None:
+            launcher = self._jit_ar.launch_context_torchop_func(self.world_size, shot)
+            self._context_torchop_launchers[shot] = launcher
+        launcher(int(context_ptr), out, int(shot))
+
+    def _use_launch_context(self, shot: int) -> bool:
+        if not self._launch_context_enabled:
+            return False
+        return shot in (
+            self._jit_ar.SHOT_TWO_STAGE,
+            self._jit_ar.SHOT_TWO_STAGE_512,
+        )
+
+    def _use_pybind_context(self, shot: int) -> bool:
+        if not self._pybind_context_enabled:
+            return False
+        return self._use_launch_context(shot)
+
+    def _use_torchop_context(self, shot: int) -> bool:
+        if not self._torchop_context_enabled:
+            return False
+        return self._use_launch_context(shot)
+
+    def _preferred_shot_cached(
+        self, input_bytes: int, is_capturing: bool, is_graph_launch: bool
+    ) -> int:
+        key = (int(input_bytes), bool(is_capturing), bool(is_graph_launch))
+        cached = self._shot_decision_cache.get(key)
+        if cached is not None:
+            return cached
+        if (
+            is_capturing
+            and not self._jit_ar.is_shot_forced()
+            and not self._jit_ar.use_push_in_graph()
+        ):
+            shot = self._jit_ar.preferred_graph_fallback_shot(
+                self.world_size, input_bytes
+            )
+        else:
+            shot = self._jit_ar.preferred_shot(self.world_size, input_bytes)
+        if (
+            shot in (self._jit_ar.SHOT_PUSH, self._jit_ar.SHOT_PUSH_WIDE)
+            and is_graph_launch
+            and not self._jit_ar.use_push_in_graph()
+        ):
+            shot = self._jit_ar.preferred_graph_fallback_shot(
+                self.world_size, input_bytes
+            )
+        if (
+            shot in (self._jit_ar.SHOT_PUSH, self._jit_ar.SHOT_PUSH_WIDE)
+            and self._jit_ar.push_buffer_bytes(input_bytes, self.world_size)
+            > self.max_size
+        ):
+            if self._jit_ar.is_shot_forced():
+                raise RuntimeError(
+                    "MUSA custom AR push requires "
+                    f"{self._jit_ar.push_buffer_bytes(input_bytes, self.world_size)} "
+                    f"bytes of staging buffer, but max_size is {self.max_size}"
+                )
+            shot = self._jit_ar.preferred_fallback_shot(self.world_size, input_bytes)
+        self._shot_decision_cache[key] = shot
+        return shot
+
+    def _launch_unregistered(
+        self, input: torch.Tensor, out: torch.Tensor, shot: int
+    ) -> None:
+        launcher = self._unregistered_launchers.get(shot)
+        if launcher is None:
+            launcher = self._jit_ar.launch_unregistered_func(self.world_size, shot)
+            self._unregistered_launchers[shot] = launcher
+        launcher(
+            self.rank_data,
+            self.signal_ptrs_cpu,
+            input,
+            out,
+            self.meta_ptrs[self.rank],
+            self.buffer_ptrs[self.rank],
+            self.max_size,
+            self.rank,
+            self.world_size,
+            shot,
+        )
+
+    def _launch_unregistered_pybind(
+        self, input: torch.Tensor, out: torch.Tensor, shot: int
+    ) -> None:
+        launcher = self._unregistered_pybind_launchers.get(shot)
+        if launcher is None:
+            launcher = self._jit_ar.launch_unregistered_pybind_func(
+                self.world_size, shot
+            )
+            self._unregistered_pybind_launchers[shot] = launcher
+        launcher(
+            self.rank_data,
+            self.signal_ptrs_cpu,
+            input,
+            out,
+            int(self.meta_ptrs[self.rank]),
+            int(self.buffer_ptrs[self.rank]),
+            int(self.rank),
+            int(self.world_size),
+            int(shot),
+        )
+
+    def _unregistered_context_for_input(self, input: torch.Tensor, shot: int) -> int:
+        key = (int(input.data_ptr()), int(shot))
+        cached = self._unregistered_context_cache.get(key)
+        if cached is not None:
+            return cached
+        creator = self._unregistered_context_pybind_creators.get(shot)
+        if creator is None:
+            creator = self._jit_ar.create_unregistered_context_pybind_func(
+                self.world_size, shot
+            )
+            self._unregistered_context_pybind_creators[shot] = creator
+        context_ptr = int(
+            creator(
+                self.rank_data,
+                self.signal_ptrs_cpu,
+                input,
+                int(self.meta_ptrs[self.rank]),
+                int(self.buffer_ptrs[self.rank]),
+                int(self.rank),
+                int(self.world_size),
+            )
+        )
+        self._unregistered_context_cache[key] = context_ptr
+        return context_ptr
+
+    def _launch_unregistered_context_pybind(
+        self, context_ptr: int, out: torch.Tensor, shot: int
+    ) -> None:
+        launcher = self._unregistered_context_pybind_launchers.get(shot)
+        if launcher is None:
+            launcher = self._jit_ar.launch_unregistered_context_pybind_func(
+                self.world_size, shot
+            )
+            self._unregistered_context_pybind_launchers[shot] = launcher
+        launcher(int(context_ptr), out, int(shot))
+
+    def custom_all_reduce(self, input: torch.Tensor) -> Optional[torch.Tensor]:
+        if not self.should_custom_ar(input):
+            return None
+        input_bytes = input.numel() * input.element_size()
+        is_graph_launch = (
+            self._IS_CAPTURING
+            and torch.get_device_module().is_current_stream_capturing()
+        )
+        shot = self._preferred_shot_cached(
+            input_bytes, self._IS_CAPTURING, is_graph_launch
+        )
+
+        if shot in (self._jit_ar.SHOT_PUSH, self._jit_ar.SHOT_PUSH_WIDE):
+            out = torch.empty_like(input)
+            if not self._IS_CAPTURING and self._pybind_unregistered_enabled:
+                if self._pybind_unregistered_context_enabled:
+                    context_ptr = self._unregistered_context_for_input(input, shot)
+                    self._launch_unregistered_context_pybind(context_ptr, out, shot)
+                else:
+                    self._launch_unregistered_pybind(input, out, shot)
+            else:
+                self._launch_unregistered(input, out, shot)
+            return out
+
+        out = None
+        if self._IS_CAPTURING:
+            out = torch.empty_like(input)
+            if is_graph_launch:
+                if self._graph_registered_input_enabled:
+                    rank_data = self._rank_data_for_registered_input(input, shot)
+                    if rank_data is not None:
+                        self._launch_registered(rank_data, out, shot)
+                    else:
+                        # A registration miss must not silently turn the
+                        # all-reduce into zeros.  Keep correctness during a
+                        # recapture mismatch by using the explicit-input
+                        # launcher; registered replay remains the fast path.
+                        self._launch_unregistered(input, out, shot)
+                else:
+                    self._launch_unregistered(input, out, shot)
+            else:
+                if is_in_piecewise_cuda_graph():
+                    self._launch_unregistered(input, out, shot)
+                else:
+                    # Run the real eager-style path during graph warmup so the
+                    # JIT module is built before stream capture. The first
+                    # actual capture can still record a placeholder while IPC
+                    # rank data is registered for the recapture.
+                    self._launch_unregistered(input, out, shot)
+        else:
+            out = torch.empty_like(input)
+            # Match the sgl custom AR eager path: stage through the shared
+            # buffer instead of launching from an opaque registered input
+            # pointer. The unregistered launch takes `input` as an explicit
+            # tensor argument and orders a same-stream D2D copy before AR,
+            # preserving producer/lifetime dependencies under serving buffer
+            # reuse. Graph capture uses registered inputs by default and can
+            # disable them via SGLANG_MUSA_CUSTOM_AR_GRAPH_REGISTERED_INPUT=0.
+            if self._pybind_unregistered_enabled:
+                self._launch_unregistered_pybind(input, out, shot)
+            else:
+                self._launch_unregistered(input, out, shot)
+        return out
+
+    def close(self):
+        if not self.disabled and dist.is_initialized():
+            for (_, shot), context_ptr in tuple(self._rank_data_context_cache.items()):
+                self._jit_ar.dispose_context(context_ptr, self.world_size, shot)
+            self._rank_data_context_cache.clear()
+            for (_, shot), context_ptr in tuple(
+                self._unregistered_context_cache.items()
+            ):
+                disposer = self._unregistered_context_pybind_disposers.get(shot)
+                if disposer is None:
+                    disposer = self._jit_ar.dispose_unregistered_context_pybind_func(
+                        self.world_size, shot
+                    )
+                    self._unregistered_context_pybind_disposers[shot] = disposer
+                disposer(int(context_ptr))
+            self._unregistered_context_cache.clear()
+            lib = CudaRTLibrary()
+            for ptr in self._opened_ipc_ptrs.values():
+                lib.cudaIpcCloseMemHandle(ctypes.c_void_p(ptr))
+            self._opened_ipc_ptrs.clear()
+            self._rank_data_cache.clear()
+            self._graph_registered_input_sequence.clear()
+            self._graph_registered_sequence_signature = ()
+            self._graph_registered_cursor = 0
+            self._last_input_ptr = None
+            self._last_rank_data = None
+            CustomAllreduce.free_shared_buffer(self.buffer_ptrs, group=self.group)
+            CustomAllreduce.free_shared_buffer(self.meta_ptrs, group=self.group)
+        self.disabled = True
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+def dispatch_custom_allreduce():
+    """Return the CustomAllreduce class to use (aiter on ROCm if enabled).
+
+    On AMD with 1-stage AR enabled, use sglang's CustomAllreduce.
+    Otherwise use AiterCustomAllreduce if available.
+
+    Set SGLANG_USE_JIT_ALL_REDUCE=1 for CUDA or
+    SGLANG_MUSA_USE_JIT_ALL_REDUCE=1 for MUSA to use the JIT-compiled implementation.
+    """
+    if _use_jit_all_reduce():
+        if _is_cuda:
+            from .custom_all_reduce_v2 import CustomAllReduceV2
+
+            logger.debug("[AR] Using CustomAllReduceV2 (JIT-compiled)")
+            return CustomAllReduceV2
+        if _is_musa:
+            logger.debug("[AR] Using MusaJitCustomAllreduce (JIT-compiled)")
+            return MusaJitCustomAllreduce
+
+    if _is_cuda:
+        return CustomAllreduce
+
+    assert _is_hip
+
+    if envs.SGLANG_USE_1STAGE_ALLREDUCE.is_set():
+        if envs.SGLANG_USE_1STAGE_ALLREDUCE.get():
+            logger.debug(
+                "[AR] All-reduce: 1-stage kernel (SGLANG_USE_1STAGE_ALLREDUCE=1)"
+            )
+        else:
+            logger.debug("[AR] All-reduce: default (SGLANG_USE_1STAGE_ALLREDUCE=0)")
+    elif envs.SGLANG_ENABLE_DETERMINISTIC_INFERENCE.get():
+        logger.debug(
+            "[AR] All-reduce: 1-stage kernel (deterministic inference enabled)"
+        )
+    else:
+        logger.debug("[AR] All-reduce: default")
+
+    # On AMD with 1-stage AR, use sglang's CustomAllreduce
+    # (AiterCustomAllreduce doesn't have deterministic_all_reduce method)
+    if _use_amd_deterministic_impl():
+        return CustomAllreduce
+
+    if get_bool_env_var("SGLANG_USE_AITER_AR", default="true"):
+        try:
+            from aiter.dist.device_communicators.custom_all_reduce import (
+                CustomAllreduce as AiterCustomAllreduce,
+            )
+
+            logger.info("[AR] Using AiterCustomAllreduce (AMD default)")
+            tms_cudagraph = envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH.get()
+            return partial(
+                AiterCustomAllreduce,
+                enable_register_for_capturing=not tms_cudagraph,
+            )
+        except ImportError as e:
+            logger.warning(
+                "[AR] Aiter custom all-reduce not available; "
+                "falling back to sglang CustomAllreduce. Details: %s",
+                e,
+            )
+            return CustomAllreduce
+
+    return CustomAllreduce
+
+
+def _use_amd_deterministic_impl() -> bool:
+    if not _is_hip:  # CUDA is always deterministic
+        return False
+    if envs.SGLANG_USE_1STAGE_ALLREDUCE.is_set():
+        return envs.SGLANG_USE_1STAGE_ALLREDUCE.get()
+    else:
+        return envs.SGLANG_ENABLE_DETERMINISTIC_INFERENCE.get()

--- a/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/__init__.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/__init__.py
@@ -1,0 +1,1 @@
+"""JIT compiler and launchers for the MUSA custom all-reduce kernels."""

--- a/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/allreduce.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/allreduce.py
@@ -1,0 +1,1156 @@
+from __future__ import annotations
+
+import functools
+import os
+from dataclasses import dataclass, replace
+
+import torch
+
+from sglang_fl.dispatch.backends.vendor.mthreads.jit_custom_ar.csrc.jit import (
+    load_musa_jit,
+    load_musa_pybind,
+)
+
+SHOT_PUSH = 0
+SHOT_ONE_STAGE = 1
+SHOT_TWO_STAGE = 2
+SHOT_PUSH_WIDE = 3
+SHOT_TWO_STAGE_512 = 4
+
+
+@dataclass(frozen=True)
+class CompileConfig:
+    threads: int
+    blocks: int
+    vector_load: int
+    atomic_barrier: int
+    max_blocks: int
+    dynamic_blocks: int
+    push_polling: int
+    push_16b_asm: int
+    double_store_2shot: int
+    one_shot_2rank_special: int
+    push_skip_start_barrier: int
+    push_16b_asm_forced: bool
+
+
+def _env_int(names: tuple[str, ...], default: int) -> int:
+    for name in names:
+        value = os.environ.get(name)
+        if value is not None:
+            return int(value)
+    return default
+
+
+def _env_auto_bool(names: tuple[str, ...], default: bool) -> tuple[bool, bool]:
+    for name in names:
+        value = os.environ.get(name)
+        if value is None:
+            continue
+        normalized = value.lower()
+        if normalized == "auto":
+            return True, False
+        if normalized in ("1", "true", "yes", "on"):
+            return True, True
+        if normalized in ("0", "false", "no", "off"):
+            return False, True
+        raise ValueError(f"Unsupported boolean/auto value for {name}: {value}")
+    return default, False
+
+
+def _has_env(names: tuple[str, ...]) -> bool:
+    return any(name in os.environ for name in names)
+
+
+def _force_shot() -> int | None:
+    value = os.environ.get("SGLANG_CUSTOM_AR_FORCE_SHOT") or os.environ.get(
+        "SGL_CUSTOM_AR_FORCE_SHOT"
+    )
+    if value is None:
+        return None
+    normalized = value.lower()
+    aliases = {
+        "push": SHOT_PUSH,
+        "one_shot_push": SHOT_PUSH,
+        "0": SHOT_PUSH,
+        "push_wide": SHOT_PUSH_WIDE,
+        "wide_push": SHOT_PUSH_WIDE,
+        "3": SHOT_PUSH_WIDE,
+        "one_shot": SHOT_ONE_STAGE,
+        "1": SHOT_ONE_STAGE,
+        "two_shot": SHOT_TWO_STAGE,
+        "2": SHOT_TWO_STAGE,
+        "two_shot_512": SHOT_TWO_STAGE_512,
+        "2_512": SHOT_TWO_STAGE_512,
+        "4": SHOT_TWO_STAGE_512,
+    }
+    if normalized not in aliases:
+        raise ValueError(f"Unsupported MUSA custom AR shot: {value}")
+    return aliases[normalized]
+
+
+def is_shot_forced() -> bool:
+    return _force_shot() is not None
+
+
+def push_buffer_bytes(nbytes: int, world_size: int) -> int:
+    # Push data uses a v2-style 2-stage ring: stages * source-rank slots.
+    return int(nbytes) * (2 * int(world_size))
+
+
+def _push_threshold_bytes() -> int:
+    return int(
+        os.environ.get(
+            "SGLANG_CUSTOM_AR_PUSH_THRESHOLD_BYTES",
+            os.environ.get("SGL_CUSTOM_AR_PUSH_THRESHOLD_BYTES", str(256 * 1024)),
+        )
+    )
+
+
+def _push_wide_threshold_bytes() -> int:
+    return int(
+        os.environ.get(
+            "SGLANG_CUSTOM_AR_PUSH_WIDE_THRESHOLD_BYTES",
+            os.environ.get("SGL_CUSTOM_AR_PUSH_WIDE_THRESHOLD_BYTES", "0"),
+        )
+    )
+
+
+def _push_wide_min_bytes() -> int:
+    return int(
+        os.environ.get(
+            "SGLANG_CUSTOM_AR_PUSH_WIDE_MIN_BYTES",
+            os.environ.get("SGL_CUSTOM_AR_PUSH_WIDE_MIN_BYTES", str(1024 * 1024)),
+        )
+    )
+
+
+def use_push_in_graph() -> bool:
+    value = os.environ.get("SGLANG_CUSTOM_AR_PUSH_IN_GRAPH") or os.environ.get(
+        "SGL_CUSTOM_AR_PUSH_IN_GRAPH", "0"
+    )
+    return value.lower() in ("1", "true", "yes", "on")
+
+
+def _default_threads_blocks(world_size: int, shot: int) -> tuple[int, int]:
+    if shot == SHOT_PUSH:
+        return 512, 14
+    if shot == SHOT_PUSH_WIDE:
+        return 512, 36
+    if shot == SHOT_TWO_STAGE_512:
+        if world_size == 4:
+            return 512, 120
+        if world_size == 8:
+            return 512, 120
+        return 512, 48
+    if world_size == 2:
+        if shot == SHOT_ONE_STAGE:
+            return 512, 56
+        if shot == SHOT_TWO_STAGE:
+            return 1024, 56
+        return 512, 36
+    if world_size == 4:
+        if shot == SHOT_TWO_STAGE:
+            return 1024, 40
+        return 1024, 60
+    if world_size == 8:
+        return 768, 80
+    return 512, 36
+
+
+def preferred_shot(world_size: int, nbytes: int) -> int:
+    force_shot = _force_shot()
+    if force_shot is not None:
+        return force_shot
+
+    if world_size == 2 and 256 * 1024 < nbytes <= 512 * 1024:
+        return SHOT_TWO_STAGE
+    if world_size == 4 and nbytes <= 512 * 1024:
+        return SHOT_TWO_STAGE_512
+    push_threshold = _push_threshold_bytes()
+    if world_size <= 4 and push_threshold > 0 and nbytes <= push_threshold:
+        return SHOT_PUSH
+    if world_size == 2 and 512 * 1024 < nbytes <= 2 * 1024 * 1024:
+        return SHOT_ONE_STAGE
+    push_wide_threshold = _push_wide_threshold_bytes()
+    if (
+        push_wide_threshold > 0
+        and nbytes >= _push_wide_min_bytes()
+        and nbytes <= push_wide_threshold
+    ):
+        return SHOT_PUSH_WIDE
+
+    return preferred_fallback_shot(world_size, nbytes)
+
+
+def preferred_fallback_shot(world_size: int, nbytes: int) -> int:
+    one_shot_threshold = int(
+        os.environ.get(
+            "SGLANG_CUSTOM_AR_1SHOT_THRESHOLD_BYTES",
+            os.environ.get("SGL_CUSTOM_AR_1SHOT_THRESHOLD_BYTES", str(4 * 1024 * 1024)),
+        )
+    )
+    if world_size == 2 and nbytes >= one_shot_threshold:
+        return SHOT_ONE_STAGE
+    return SHOT_TWO_STAGE
+
+
+def preferred_graph_fallback_shot(world_size: int, nbytes: int) -> int:
+    if world_size == 2 and 256 * 1024 < nbytes <= 512 * 1024:
+        return SHOT_TWO_STAGE
+    if world_size == 4 and 512 * 1024 < nbytes <= 1024 * 1024:
+        return SHOT_TWO_STAGE_512
+    if world_size == 8 and nbytes <= 256 * 1024:
+        return SHOT_TWO_STAGE_512
+    one_shot_threshold = int(
+        os.environ.get(
+            "SGLANG_CUSTOM_AR_GRAPH_1SHOT_THRESHOLD_BYTES",
+            os.environ.get(
+                "SGL_CUSTOM_AR_GRAPH_1SHOT_THRESHOLD_BYTES", str(256 * 1024)
+            ),
+        )
+    )
+    if world_size == 2 and nbytes >= one_shot_threshold:
+        return SHOT_ONE_STAGE
+    return preferred_fallback_shot(world_size, nbytes)
+
+
+def _compile_config(world_size: int, shot: int) -> CompileConfig:
+    default_threads, default_blocks = _default_threads_blocks(world_size, shot)
+    threads = _env_int(
+        (
+            f"SGLANG_CUSTOM_AR_{shot}SHOT_THREADS",
+            f"SGL_CUSTOM_AR_{shot}SHOT_THREADS",
+            "SGLANG_CUSTOM_AR_THREADS",
+            "SGL_CUSTOM_AR_THREADS",
+        ),
+        default_threads,
+    )
+    block_env_names = (
+        f"SGLANG_CUSTOM_AR_{shot}SHOT_BLOCKS",
+        f"SGL_CUSTOM_AR_{shot}SHOT_BLOCKS",
+        "SGLANG_CUSTOM_AR_BLOCKS",
+        "SGL_CUSTOM_AR_BLOCKS",
+    )
+    blocks = _env_int(
+        block_env_names,
+        default_blocks,
+    )
+    vector_load = _env_int(
+        (
+            "SGLANG_CUSTOM_AR_VECTOR_LOAD",
+            "SGL_CUSTOM_AR_VECTOR_LOAD",
+        ),
+        0,
+    )
+    default_atomic_barrier = 0 if shot in (SHOT_PUSH, SHOT_ONE_STAGE) else 1
+    atomic_barrier = _env_int(
+        (
+            f"SGLANG_CUSTOM_AR_{shot}SHOT_ATOMIC_BARRIER",
+            f"SGL_CUSTOM_AR_{shot}SHOT_ATOMIC_BARRIER",
+            "SGLANG_CUSTOM_AR_ATOMIC_BARRIER",
+            "SGL_CUSTOM_AR_ATOMIC_BARRIER",
+        ),
+        default_atomic_barrier,
+    )
+    max_blocks = _env_int(
+        (
+            f"SGLANG_CUSTOM_AR_{shot}SHOT_MAX_BLOCKS",
+            f"SGL_CUSTOM_AR_{shot}SHOT_MAX_BLOCKS",
+            "SGLANG_CUSTOM_AR_MAX_BLOCKS",
+            "SGL_CUSTOM_AR_MAX_BLOCKS",
+        ),
+        max(120, blocks),
+    )
+    default_dynamic_blocks = (
+        0
+        if shot in (SHOT_PUSH, SHOT_PUSH_WIDE)
+        or (
+            world_size == 2
+            and shot in (SHOT_ONE_STAGE, SHOT_TWO_STAGE, SHOT_TWO_STAGE_512)
+        )
+        or (world_size == 4 and shot in (SHOT_TWO_STAGE, SHOT_TWO_STAGE_512))
+        or _has_env(block_env_names)
+        else 1
+    )
+    dynamic_blocks = _env_int(
+        (
+            f"SGLANG_CUSTOM_AR_{shot}SHOT_DYNAMIC_BLOCKS",
+            f"SGL_CUSTOM_AR_{shot}SHOT_DYNAMIC_BLOCKS",
+            "SGLANG_CUSTOM_AR_DYNAMIC_BLOCKS",
+            "SGL_CUSTOM_AR_DYNAMIC_BLOCKS",
+        ),
+        default_dynamic_blocks,
+    )
+    push_polling = _env_int(
+        (
+            "SGLANG_CUSTOM_AR_PUSH_POLLING",
+            "SGL_CUSTOM_AR_PUSH_POLLING",
+        ),
+        0,
+    )
+    push_16b_asm, push_16b_asm_forced = _env_auto_bool(
+        (
+            "SGLANG_CUSTOM_AR_PUSH_16B_ASM",
+            "SGL_CUSTOM_AR_PUSH_16B_ASM",
+        ),
+        True,
+    )
+    if shot not in (SHOT_PUSH, SHOT_PUSH_WIDE) or push_polling == 0:
+        push_16b_asm = False
+        push_16b_asm_forced = False
+    double_store_2shot = _env_int(
+        (
+            "SGLANG_CUSTOM_AR_2SHOT_DOUBLE_STORE",
+            "SGL_CUSTOM_AR_2SHOT_DOUBLE_STORE",
+        ),
+        0,
+    )
+    one_shot_2rank_special = _env_int(
+        (
+            "SGLANG_CUSTOM_AR_1SHOT_2RANK_SPECIAL",
+            "SGL_CUSTOM_AR_1SHOT_2RANK_SPECIAL",
+        ),
+        1,
+    )
+    push_skip_start_barrier = _env_int(
+        (
+            "SGLANG_CUSTOM_AR_PUSH_SKIP_START_BARRIER",
+            "SGL_CUSTOM_AR_PUSH_SKIP_START_BARRIER",
+        ),
+        0,
+    )
+    return CompileConfig(
+        threads=threads,
+        blocks=blocks,
+        vector_load=vector_load,
+        atomic_barrier=atomic_barrier,
+        max_blocks=max_blocks,
+        dynamic_blocks=dynamic_blocks,
+        push_polling=push_polling,
+        push_16b_asm=int(push_16b_asm),
+        double_store_2shot=double_store_2shot,
+        one_shot_2rank_special=one_shot_2rank_special,
+        push_skip_start_barrier=push_skip_start_barrier,
+        push_16b_asm_forced=push_16b_asm_forced,
+    )
+
+
+def _load_custom_ar_module(
+    world_size: int,
+    shot: int,
+    config: CompileConfig,
+):
+    name = _compile_name(shot, config)
+    return load_musa_jit(
+        name,
+        ("distributed/custom_all_reduce.mu",),
+        extra_musa_cflags=_musa_cflags(config),
+    )
+
+
+def _fused_rmsnorm_token_2stage(
+    world_size: int, row_hidden: int = 0, override: int = -1
+) -> int:
+    default = 1 if world_size in (4, 8) else 0
+    if override >= 0:
+        default = int(override)
+    return default
+
+
+def _fused_rmsnorm_default_blocks(
+    world_size: int,
+    token_2stage: int,
+    config: CompileConfig,
+    short_rows: bool = False,
+    row_hidden: int = 0,
+    small_rows: bool = False,
+) -> int:
+    if world_size == 2 and row_hidden == 1024 and not short_rows:
+        return 80
+    if world_size == 8 and token_2stage:
+        if row_hidden == 1536:
+            return 180
+        if row_hidden == 3072:
+            return 120
+        return 120
+    if world_size == 4 and token_2stage:
+        if row_hidden % 8 != 0:
+            return 40
+        if row_hidden == 1536:
+            return 120
+        if row_hidden == 1024 and short_rows:
+            return 240
+        if row_hidden == 4096 and short_rows:
+            return 80
+        if row_hidden == 4096:
+            return 56
+        if row_hidden in (1024, 2048, 4096, 8192) and not short_rows:
+            return 80
+        return 56
+    if world_size == 8 and row_hidden == 1536 and not short_rows:
+        return 60
+    return config.blocks
+
+
+def _fused_rmsnorm_abi_max_blocks(
+    world_size: int, token_2stage: int, config: CompileConfig
+) -> int:
+    blocks = [
+        config.max_blocks,
+        _fused_rmsnorm_default_blocks(world_size, token_2stage, config),
+    ]
+    for row_hidden in (512, 1024, 2048, 4096, 8192):
+        for short_rows in (False, True):
+            for small_rows in (False, True):
+                blocks.append(
+                    _fused_rmsnorm_default_blocks(
+                        world_size,
+                        token_2stage,
+                        config,
+                        short_rows=short_rows,
+                        row_hidden=row_hidden,
+                        small_rows=small_rows,
+                    )
+                )
+    return max(blocks)
+
+
+def _is_power_of_2(value: int) -> bool:
+    return value > 0 and (value & (value - 1)) == 0
+
+
+def _fused_rmsnorm_config(
+    world_size: int,
+    config: CompileConfig,
+    token_2stage: int,
+    short_rows: bool = False,
+    row_hidden: int = 0,
+    small_rows: bool = False,
+) -> CompileConfig:
+    fused_vector_load = config.vector_load
+    fused_threads = (
+        (row_hidden // 8)
+        if small_rows
+        and world_size in (2, 4, 8)
+        and (world_size == 2 or token_2stage)
+        and row_hidden in (512, 1024, 2048, 4096)
+        else (
+            (row_hidden // 8)
+            if world_size == 2
+            and short_rows
+            and 512 <= row_hidden <= 8192
+            and row_hidden % 8 == 0
+            and not _is_power_of_2(row_hidden)
+            else (
+                512
+                if world_size == 2
+                and 6144 <= row_hidden <= 8192
+                and row_hidden % 8 == 0
+                and not _is_power_of_2(row_hidden)
+                else (
+                    256
+                    if world_size == 2 and row_hidden == 512
+                    else (
+                        512
+                        if world_size == 4 and row_hidden % 8 != 0
+                        else (
+                            512
+                            if world_size == 2 and (row_hidden == 1024 and short_rows)
+                            else (
+                                1024
+                                if world_size == 4
+                                and token_2stage
+                                and row_hidden in (4096, 8192)
+                                else (
+                                    512
+                                    if world_size == 8
+                                    and row_hidden == 1536
+                                    and not token_2stage
+                                    and not short_rows
+                                    else (
+                                        (row_hidden // 8)
+                                        if world_size == 2
+                                        and row_hidden in (1024, 2048)
+                                        else (
+                                            512
+                                            if short_rows and world_size == 2
+                                            else (
+                                                1024
+                                                if world_size == 2
+                                                else (
+                                                    512
+                                                    if world_size in (4, 8)
+                                                    and token_2stage
+                                                    else config.threads
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    )
+    fused_blocks = _fused_rmsnorm_default_blocks(
+        world_size, token_2stage, config, short_rows, row_hidden, small_rows
+    )
+    fused_dynamic_blocks = (
+        0
+        if (
+            (world_size == 8 and token_2stage)
+            or (
+                world_size == 8
+                and row_hidden == 1536
+                and not token_2stage
+                and not short_rows
+            )
+        )
+        else config.dynamic_blocks
+    )
+    fused_max_blocks = _fused_rmsnorm_abi_max_blocks(world_size, token_2stage, config)
+    fused_max_blocks = max(fused_max_blocks, fused_blocks)
+    return replace(
+        config,
+        threads=fused_threads,
+        blocks=fused_blocks,
+        vector_load=fused_vector_load,
+        max_blocks=fused_max_blocks,
+        dynamic_blocks=fused_dynamic_blocks,
+    )
+
+
+def _load_custom_ar_fused_rmsnorm_module(
+    world_size: int,
+    config: CompileConfig,
+    short_rows: bool = False,
+    row_hidden: int = 0,
+    small_rows: bool = False,
+    cache_policy: int = 0,
+    row_skip_end_barrier_override: int = -1,
+    push_polling_override: int = -1,
+    lamport_push_override: int = -1,
+    token_2stage_override: int = -1,
+    row_warp_inv_rms_override: int = -1,
+):
+    token_2stage = _fused_rmsnorm_token_2stage(
+        world_size, row_hidden, token_2stage_override
+    )
+    config = _fused_rmsnorm_config(
+        world_size, config, token_2stage, short_rows, row_hidden, small_rows
+    )
+    shfl_2stage = 0
+    packed_1stage = (
+        1 if world_size == 2 and row_hidden == 8192 and not token_2stage else 0
+    )
+    safe_packed_1stage = 0
+    vec2rank_1stage = 1
+    partial_packed_non8 = 1
+    vec2_non8 = 0
+    vec4_non8 = 0
+    regcache_2rank = 1 if short_rows and world_size == 2 else 0
+    no_cache_policy = cache_policy == 1
+    cache_hidden_limit_default = (
+        0
+        if no_cache_policy
+        else (
+            1536
+            if world_size == 8
+            and row_hidden == 1536
+            and not token_2stage
+            and not short_rows
+            else (
+                8192
+                if (
+                    world_size == 4
+                    and token_2stage
+                    and row_hidden > 4096
+                    and row_hidden % 8 != 0
+                )
+                else (
+                    4096
+                    if world_size == 2 or (world_size in (4, 8) and token_2stage)
+                    else 2048
+                )
+            )
+        )
+    )
+    cache_hidden_limit = cache_hidden_limit_default
+    typed_cache_hidden_limit = 0 if no_cache_policy else 8192
+    h8192_blocks = 16
+    weight_cache_hidden_limit = (
+        0
+        if (
+            (
+                world_size == 8
+                and row_hidden == 1536
+                and not token_2stage
+                and not short_rows
+            )
+            or (world_size == 4 and row_hidden == 8192 and (short_rows or small_rows))
+        )
+        else 8192
+    )
+    row_weight_cache = (
+        1 if world_size == 8 and token_2stage and row_hidden == 6144 else 0
+    )
+    row_weight_cache_min_rows = (
+        4096
+        if world_size == 8 and token_2stage and row_hidden == 6144
+        else 512 if world_size == 8 and token_2stage else 2048
+    )
+    row_shared_inv_rms = (
+        1 if world_size == 8 and token_2stage and row_hidden == 1024 else 0
+    )
+    row_warp_inv_rms = 0
+    if row_warp_inv_rms_override >= 0:
+        row_warp_inv_rms = int(row_warp_inv_rms_override)
+    row_skip_end_barrier = 0
+    if row_skip_end_barrier_override >= 0:
+        row_skip_end_barrier = int(row_skip_end_barrier_override)
+    use_row_bypass_load = (
+        (world_size == 4 and token_2stage)
+        or (world_size == 8 and token_2stage and row_hidden == 1536)
+        or (world_size == 8 and token_2stage and row_hidden == 8192)
+    )
+    sums_bypass_load = 3 if use_row_bypass_load else 0
+    tmp_with_residual = (
+        1
+        if token_2stage
+        and (
+            (
+                world_size == 4
+                and (
+                    row_hidden in (512, 1024) or (row_hidden == 4096 and not short_rows)
+                )
+            )
+            or (
+                world_size == 8
+                and (row_hidden == 1536 or (row_hidden in (1024, 2048) and small_rows))
+            )
+        )
+        else 0
+    )
+    warp_rows = 0
+    push_polling = 0
+    if push_polling_override >= 0:
+        push_polling = int(push_polling_override)
+    push_slots = 2
+    push_skip_end_barrier = 0
+    lamport_push = 0
+    if lamport_push_override >= 0:
+        lamport_push = int(lamport_push_override)
+    push_min_rows = 128 if lamport_push else 1
+    push_max_rows = 128
+    lamport_end_barrier = 1
+    small_rows_flag = (
+        1
+        if small_rows
+        and world_size in (2, 4, 8)
+        and (world_size == 2 or token_2stage)
+        and row_hidden in (512, 1024, 2048, 4096)
+        else 0
+    )
+    name = (
+        "sgl_musa_ar_rn_"
+        + _compile_name_short(SHOT_ONE_STAGE, config)
+        + (
+            f"_r2{token_2stage}_s2{shfl_2stage}_p1{packed_1stage}"
+            f"_sp{safe_packed_1stage}_v2{vec2rank_1stage}"
+            f"_rc{regcache_2rank}"
+            f"_c{cache_hidden_limit}_tc{typed_cache_hidden_limit}"
+            f"_cp{cache_policy}"
+            f"_h8{h8192_blocks}"
+            f"_wc{weight_cache_hidden_limit}_rw{row_weight_cache}"
+            f"_rm{row_weight_cache_min_rows}"
+            f"_si{row_shared_inv_rms}_wi{row_warp_inv_rms}"
+            f"_eb{row_skip_end_barrier}"
+            f"_pn8{partial_packed_non8}"
+            f"_vn8{vec2_non8}"
+            f"_v4n8{vec4_non8}"
+            f"_sb{sums_bypass_load}"
+            f"_tr{tmp_with_residual}"
+            f"_wr{warp_rows}"
+            f"_pp{push_polling}"
+            f"_pm{push_min_rows}"
+            f"_px{push_max_rows}"
+            f"_psl{push_slots}"
+            f"_pse{push_skip_end_barrier}"
+            f"_lp{lamport_push}"
+            f"_leb{lamport_end_barrier}"
+            f"_sr{small_rows_flag}"
+            f"_m2_r2s"
+        )
+    )
+    return load_musa_jit(
+        name,
+        ("distributed/custom_all_reduce_rmsnorm.mu",),
+        extra_musa_cflags=_musa_cflags(config)
+        + (
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_TOKEN_2STAGE={token_2stage}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_SHFL_2STAGE={shfl_2stage}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_PACKED_1STAGE={packed_1stage}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_SAFE_PACKED_1STAGE={safe_packed_1stage}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_VEC2RANK_1STAGE={vec2rank_1stage}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_PARTIAL_PACKED_NON8={partial_packed_non8}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_VEC2_NON8={vec2_non8}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_VEC4_NON8={vec4_non8}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_REGCACHE_2RANK={regcache_2rank}",
+            f"-DSGL_CUSTOM_AR_RMSNORM_CACHE_HIDDEN_LIMIT={cache_hidden_limit}",
+            f"-DSGL_CUSTOM_AR_RMSNORM_T_CACHE_HIDDEN_LIMIT={typed_cache_hidden_limit}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_H8192_BLOCKS={h8192_blocks}",
+            f"-DSGL_CUSTOM_AR_RMSNORM_WEIGHT_CACHE_HIDDEN_LIMIT={weight_cache_hidden_limit}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_ROW_WEIGHT_CACHE={row_weight_cache}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_ROW_WEIGHT_CACHE_MIN_ROWS={row_weight_cache_min_rows}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_ROW_SHARED_INV_RMS={row_shared_inv_rms}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_ROW_WARP_INV_RMS={row_warp_inv_rms}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_ROW_SKIP_END_BARRIER={row_skip_end_barrier}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_SUMS_BYPASS_LOAD={sums_bypass_load}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_TMP_WITH_RESIDUAL={tmp_with_residual}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_WARP_ROWS={warp_rows}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_POLLING={push_polling}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_MIN_ROWS={push_min_rows}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_MAX_ROWS={push_max_rows}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_SLOTS={push_slots}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_SKIP_END_BARRIER={push_skip_end_barrier}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_LAMPORT_PUSH={lamport_push}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_LAMPORT_END_BARRIER={lamport_end_barrier}",
+            f"-DSGL_CUSTOM_AR_FUSED_RMSNORM_SMALL_ROWS={small_rows_flag}",
+        ),
+    )
+
+
+def _compile_name(shot: int, config: CompileConfig) -> str:
+    return (
+        f"sglang_musa_custom_all_reduce_s{shot}_t{config.threads}_b{config.blocks}"
+        f"_v{config.vector_load}_ab{config.atomic_barrier}"
+        f"_mb{config.max_blocks}_db{config.dynamic_blocks}"
+        f"_pp{config.push_polling}_p16{config.push_16b_asm}"
+        f"_ds{config.double_store_2shot}_r2s{config.one_shot_2rank_special}"
+        f"_psb{config.push_skip_start_barrier}"
+    )
+
+
+def _compile_name_short(shot: int, config: CompileConfig) -> str:
+    return (
+        f"s{shot}_t{config.threads}_b{config.blocks}"
+        f"_v{config.vector_load}_a{config.atomic_barrier}"
+        f"_m{config.max_blocks}_d{config.dynamic_blocks}"
+        f"_q{config.push_polling}_p{config.push_16b_asm}"
+        f"_ds{config.double_store_2shot}_r{config.one_shot_2rank_special}"
+        f"_ps{config.push_skip_start_barrier}"
+    )
+
+
+def _musa_cflags(config: CompileConfig) -> tuple[str, ...]:
+    return (
+        "-Wno-error=address-of-temporary",
+        "-fmusa-flush-denormals-to-zero",
+        "-fno-signed-zeros",
+        "-D__MUSA_ARCH_LIST__=310",
+        f"-DSGL_CUSTOM_AR_THREADS={config.threads}",
+        f"-DSGL_CUSTOM_AR_BLOCKS={config.blocks}",
+        f"-DSGL_CUSTOM_AR_VECTOR_LOAD={config.vector_load}",
+        f"-DSGL_CUSTOM_AR_ATOMIC_BARRIER={config.atomic_barrier}",
+        f"-DSGL_CUSTOM_AR_MAX_BLOCKS={config.max_blocks}",
+        f"-DSGL_CUSTOM_AR_DYNAMIC_BLOCKS={config.dynamic_blocks}",
+        f"-DSGL_CUSTOM_AR_PUSH_POLLING={config.push_polling}",
+        f"-DSGL_CUSTOM_AR_PUSH_16B_ASM={config.push_16b_asm}",
+        f"-DSGL_CUSTOM_AR_2SHOT_DOUBLE_STORE={config.double_store_2shot}",
+        f"-DSGL_CUSTOM_AR_1SHOT_2RANK_SPECIAL={config.one_shot_2rank_special}",
+        f"-DSGL_CUSTOM_AR_PUSH_SKIP_START_BARRIER={config.push_skip_start_barrier}",
+        "-mllvm",
+        "-mtgpu-opt-level=1",
+        "-mllvm",
+        "-mtgpu-load-store-opt=1",
+        "-mllvm",
+        "-mtgpu-fold-global-ldst=1",
+    )
+
+
+@functools.lru_cache(maxsize=32)
+def _custom_ar_module(world_size: int, shot: int):
+    config = _compile_config(world_size, shot)
+    try:
+        return _load_custom_ar_module(world_size, shot, config)
+    except Exception:
+        if config.push_16b_asm == 0 or config.push_16b_asm_forced:
+            raise
+        return _load_custom_ar_module(world_size, shot, replace(config, push_16b_asm=0))
+
+
+@functools.lru_cache(maxsize=96)
+def _custom_ar_fused_rmsnorm_module(
+    world_size: int,
+    short_rows: bool = False,
+    row_hidden: int = 0,
+    small_rows: bool = False,
+    cache_policy: int = 0,
+    row_skip_end_barrier: bool = False,
+    push_polling: int = -1,
+    lamport_push: int = -1,
+    token_2stage_override: int = -1,
+    row_warp_inv_rms_override: int = -1,
+):
+    token_2stage = _fused_rmsnorm_token_2stage(
+        world_size, row_hidden, token_2stage_override
+    )
+    forced_shot = _force_shot()
+    if forced_shot in (SHOT_ONE_STAGE, SHOT_TWO_STAGE, SHOT_TWO_STAGE_512):
+        shot = forced_shot
+    else:
+        shot = SHOT_TWO_STAGE if token_2stage else SHOT_ONE_STAGE
+    config = _compile_config(world_size, shot)
+    try:
+        return _load_custom_ar_fused_rmsnorm_module(
+            world_size,
+            config,
+            short_rows,
+            row_hidden,
+            small_rows,
+            int(cache_policy),
+            int(bool(row_skip_end_barrier)),
+            int(push_polling),
+            int(lamport_push),
+            int(token_2stage_override),
+            int(row_warp_inv_rms_override),
+        )
+    except Exception:
+        if config.push_16b_asm == 0 or config.push_16b_asm_forced:
+            raise
+        return _load_custom_ar_fused_rmsnorm_module(
+            world_size,
+            replace(config, push_16b_asm=0),
+            short_rows,
+            row_hidden,
+            small_rows,
+            int(cache_policy),
+            int(bool(row_skip_end_barrier)),
+            int(push_polling),
+            int(lamport_push),
+            int(token_2stage_override),
+            int(row_warp_inv_rms_override),
+        )
+
+
+@functools.lru_cache(maxsize=32)
+def _custom_ar_pybind_module(world_size: int, shot: int):
+    config = _compile_config(world_size, shot)
+
+    def load(config: CompileConfig):
+        name = _compile_name(shot, config)
+        torch_namespace = "sglang_musa_jit_ar_" + name
+        return load_musa_pybind(
+            name + "_pybind",
+            (
+                "distributed/custom_all_reduce.mu",
+                "distributed/custom_all_reduce_pybind.cpp",
+            ),
+            extra_cflags=(f"-DSGL_CUSTOM_AR_TORCH_NS={torch_namespace}",),
+            extra_musa_cflags=_musa_cflags(config),
+        )
+
+    try:
+        return load(config)
+    except Exception:
+        if config.push_16b_asm == 0 or config.push_16b_asm_forced:
+            raise
+        return load(replace(config, push_16b_asm=0))
+
+
+def _custom_ar_torch_namespace(world_size: int, shot: int) -> str:
+    return "sglang_musa_jit_ar_" + _compile_name(
+        int(shot), _compile_config(int(world_size), int(shot))
+    )
+
+
+def _module_shots(world_size: int) -> tuple[int, ...]:
+    world_size = int(world_size)
+    forced_shot = _force_shot()
+    if world_size == 2:
+        shots = [SHOT_ONE_STAGE, SHOT_TWO_STAGE, SHOT_TWO_STAGE_512]
+    elif world_size == 4:
+        shots = [SHOT_TWO_STAGE, SHOT_TWO_STAGE_512]
+    else:
+        shots = [SHOT_TWO_STAGE]
+    if forced_shot in (SHOT_PUSH, SHOT_PUSH_WIDE) or (
+        world_size <= 4 and _push_threshold_bytes() > 0
+    ):
+        shots.insert(0, SHOT_PUSH)
+    if (
+        forced_shot == SHOT_PUSH_WIDE
+        or _push_wide_threshold_bytes() > _push_threshold_bytes()
+    ):
+        shots.insert(1 if SHOT_PUSH in shots else 0, SHOT_PUSH_WIDE)
+    return tuple(shots)
+
+
+def ensure_compiled(world_size: int) -> None:
+    world_size = int(world_size)
+    for shot in _module_shots(world_size):
+        _custom_ar_module(world_size, shot)
+
+
+def meta_size(world_size: int = 8) -> int:
+    # Keep this in sync with distributed/custom_all_reduce.mu::Signal.
+    # Avoid loading every JIT module during communicator initialization; the
+    # actual launch module is loaded lazily on first use.
+    world_size = int(world_size)
+    max_blocks = max(
+        _compile_config(world_size, shot).max_blocks
+        for shot in _module_shots(world_size)
+    )
+    if world_size in (2, 4, 8):
+        token_2stage = _fused_rmsnorm_token_2stage(world_size)
+        forced_shot = _force_shot()
+        if forced_shot in (SHOT_ONE_STAGE, SHOT_TWO_STAGE, SHOT_TWO_STAGE_512):
+            fused_shot = forced_shot
+        else:
+            fused_shot = SHOT_TWO_STAGE if token_2stage else SHOT_ONE_STAGE
+        base_fused_config = _compile_config(world_size, fused_shot)
+        # The fused RMSNorm kernels compute their scratch base as `signal + 1`,
+        # so every shape-specific fused module in a communicator must agree on
+        # the Signal ABI size.  Otherwise a smaller module writes scratch into
+        # the larger module's counter area during graph replay.
+        max_blocks = max(
+            max_blocks,
+            _fused_rmsnorm_abi_max_blocks(world_size, token_2stage, base_fused_config),
+        )
+
+    def align(value: int, alignment: int = 128) -> int:
+        return ((value + alignment - 1) // alignment) * alignment
+
+    flag_bytes = 4
+    max_ranks = 8
+    offset = 0
+    offset = align(offset) + flag_bytes * max_blocks * max_ranks
+    offset = align(offset) + 2 * flag_bytes * max_blocks * max_ranks
+    offset = align(offset) + flag_bytes * max_blocks
+    offset = align(offset) + flag_bytes
+    offset = align(offset) + flag_bytes
+    offset = align(offset) + flag_bytes
+    return align(offset)
+
+
+def launch_registered(
+    rank_data: torch.Tensor,
+    signal_ptrs_cpu: torch.Tensor,
+    out: torch.Tensor,
+    self_signal_ptr: int,
+    rank: int,
+    world_size: int,
+    shot: int,
+) -> None:
+    _custom_ar_module(int(world_size), int(shot)).sgl_musa_custom_ar_launch(
+        rank_data,
+        signal_ptrs_cpu,
+        out,
+        int(self_signal_ptr),
+        int(rank),
+        int(world_size),
+        int(shot),
+    )
+
+
+def launch_registered_func(world_size: int, shot: int):
+    return _custom_ar_module(int(world_size), int(shot)).sgl_musa_custom_ar_launch
+
+
+def launch_empty_func(world_size: int, shot: int):
+    return _custom_ar_module(int(world_size), int(shot)).sgl_musa_custom_ar_launch_empty
+
+
+def create_context(
+    rank_data: torch.Tensor,
+    signal_ptrs_cpu: torch.Tensor,
+    self_signal_ptr: int,
+    rank: int,
+    world_size: int,
+    shot: int,
+) -> int:
+    return int(
+        _custom_ar_module(int(world_size), int(shot)).sgl_musa_custom_ar_create_context(
+            rank_data,
+            signal_ptrs_cpu,
+            int(self_signal_ptr),
+            int(rank),
+            int(world_size),
+        )
+    )
+
+
+def dispose_context(context_ptr: int, world_size: int, shot: int) -> None:
+    _custom_ar_module(int(world_size), int(shot)).sgl_musa_custom_ar_dispose_context(
+        int(context_ptr)
+    )
+
+
+def launch_context_func(world_size: int, shot: int):
+    return _custom_ar_module(
+        int(world_size), int(shot)
+    ).sgl_musa_custom_ar_launch_context
+
+
+def launch_context_pybind_func(world_size: int, shot: int):
+    return _custom_ar_pybind_module(int(world_size), int(shot)).launch_context
+
+
+def launch_unregistered_pybind_func(world_size: int, shot: int):
+    return _custom_ar_pybind_module(int(world_size), int(shot)).launch_unregistered
+
+
+def create_unregistered_context_pybind_func(world_size: int, shot: int):
+    return _custom_ar_pybind_module(
+        int(world_size), int(shot)
+    ).create_unregistered_context
+
+
+def dispose_unregistered_context_pybind_func(world_size: int, shot: int):
+    return _custom_ar_pybind_module(
+        int(world_size), int(shot)
+    ).dispose_unregistered_context
+
+
+def launch_unregistered_context_pybind_func(world_size: int, shot: int):
+    return _custom_ar_pybind_module(
+        int(world_size), int(shot)
+    ).launch_unregistered_context
+
+
+def launch_context_torchop_func(world_size: int, shot: int):
+    world_size = int(world_size)
+    shot = int(shot)
+    _custom_ar_pybind_module(world_size, shot)
+    namespace = _custom_ar_torch_namespace(world_size, shot)
+    return getattr(torch.ops, namespace).launch_context
+
+
+def launch_unregistered_func(world_size: int, shot: int):
+    return _custom_ar_module(
+        int(world_size), int(shot)
+    ).sgl_musa_custom_ar_launch_unregistered
+
+
+def launch_fused_allreduce_rmsnorm_unregistered_func(
+    world_size: int,
+    hidden: int = 0,
+    short_rows: bool = False,
+    small_rows: bool = False,
+    cache_policy: int = 0,
+    row_skip_end_barrier: bool = False,
+    push_polling: int = -1,
+    lamport_push: int = -1,
+    row_warp_inv_rms_override: int = -1,
+):
+    return _custom_ar_fused_rmsnorm_module(
+        int(world_size),
+        bool(short_rows),
+        int(hidden),
+        bool(small_rows),
+        int(cache_policy),
+        bool(row_skip_end_barrier),
+        int(push_polling),
+        int(lamport_push),
+        -1,
+        int(row_warp_inv_rms_override),
+    ).sgl_musa_custom_ar_fused_allreduce_rmsnorm_unregistered
+
+
+def launch_fused_allreduce_rmsnorm_registered_func(
+    world_size: int,
+    hidden: int = 0,
+    short_rows: bool = False,
+    small_rows: bool = False,
+    cache_policy: int = 0,
+    row_skip_end_barrier: bool = False,
+    row_warp_inv_rms_override: int = -1,
+):
+    return _custom_ar_fused_rmsnorm_module(
+        int(world_size),
+        bool(short_rows),
+        int(hidden),
+        bool(small_rows),
+        int(cache_policy),
+        bool(row_skip_end_barrier),
+        0,
+        0,
+        -1,
+        int(row_warp_inv_rms_override),
+    ).sgl_musa_custom_ar_fused_allreduce_rmsnorm_registered
+
+
+def launch_fused_allreduce_rmsnorm_row_registered_func(
+    world_size: int,
+    hidden: int = 0,
+    short_rows: bool = False,
+    small_rows: bool = False,
+    row_skip_end_barrier: bool = False,
+    token_2stage_override: int = 1,
+    row_warp_inv_rms_override: int = -1,
+):
+    return _custom_ar_fused_rmsnorm_module(
+        int(world_size),
+        bool(short_rows),
+        int(hidden),
+        bool(small_rows),
+        0,
+        bool(row_skip_end_barrier),
+        0,
+        0,
+        int(token_2stage_override),
+        int(row_warp_inv_rms_override),
+    ).sgl_musa_custom_ar_fused_allreduce_rmsnorm_row_registered
+
+
+def launch_fused_allreduce_rmsnorm_row_unregistered_func(
+    world_size: int,
+    hidden: int = 0,
+    short_rows: bool = False,
+    small_rows: bool = False,
+    row_skip_end_barrier: bool = False,
+    token_2stage_override: int = 1,
+    row_warp_inv_rms_override: int = -1,
+):
+    return _custom_ar_fused_rmsnorm_module(
+        int(world_size),
+        bool(short_rows),
+        int(hidden),
+        bool(small_rows),
+        0,
+        bool(row_skip_end_barrier),
+        0,
+        0,
+        int(token_2stage_override),
+        int(row_warp_inv_rms_override),
+    ).sgl_musa_custom_ar_fused_allreduce_rmsnorm_row_unregistered
+
+
+def launch_unregistered(
+    rank_data: torch.Tensor,
+    signal_ptrs_cpu: torch.Tensor,
+    inp: torch.Tensor,
+    out: torch.Tensor,
+    self_signal_ptr: int,
+    self_buffer_ptr: int,
+    max_size_bytes: int,
+    rank: int,
+    world_size: int,
+    shot: int,
+) -> None:
+    _custom_ar_module(
+        int(world_size), int(shot)
+    ).sgl_musa_custom_ar_launch_unregistered(
+        rank_data,
+        signal_ptrs_cpu,
+        inp,
+        out,
+        int(self_signal_ptr),
+        int(self_buffer_ptr),
+        int(max_size_bytes),
+        int(rank),
+        int(world_size),
+        int(shot),
+    )

--- a/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/common.h
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/common.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <cstdint>
+
+#include <musa_runtime.h>
+#include <tvm/ffi/container/tensor.h>
+#include <tvm/ffi/dtype.h>
+#include <tvm/ffi/error.h>
+#include <tvm/ffi/extra/c_env_api.h>
+
+namespace ffi = tvm::ffi;
+
+constexpr DLDataType dl_float16{kDLFloat, 16, 1};
+constexpr DLDataType dl_float32{kDLFloat, 32, 1};
+constexpr DLDataType dl_bfloat16{kDLBfloat, 16, 1};
+constexpr DLDataType dl_int8{kDLInt, 8, 1};
+constexpr DLDataType dl_int32{kDLInt, 32, 1};
+constexpr DLDataType dl_int64{kDLInt, 64, 1};
+constexpr DLDataType dl_float8_e4m3fn{kDLFloat8_e4m3fn, 8, 1};
+
+inline bool dtype_equal(DLDataType lhs, DLDataType rhs) {
+  return lhs.code == rhs.code && lhs.bits == rhs.bits && lhs.lanes == rhs.lanes;
+}
+
+inline int64_t tensor_numel(ffi::TensorView tensor) {
+  int64_t numel = 1;
+  for (int i = 0; i < tensor.ndim(); ++i) {
+    numel *= tensor.size(i);
+  }
+  return numel;
+}
+
+inline musaStream_t get_stream(DLDevice device) {
+  return static_cast<musaStream_t>(
+      TVMFFIEnvGetStream(device.device_type, device.device_id));
+}
+
+#ifndef TORCH_CHECK
+#define TORCH_CHECK(cond, ...) TVM_FFI_ICHECK(cond)
+#endif
+
+#ifndef CHECK_EQ
+#define CHECK_EQ(a, b) TVM_FFI_ICHECK_EQ((a), (b))
+#endif
+
+#ifndef CHECK_MUSA
+#define CHECK_MUSA(x) TVM_FFI_ICHECK_EQ((x).device().device_type, kDLExtDev)
+#endif
+
+#ifndef CHECK_INPUT
+#define CHECK_INPUT(x)                                                         \
+  TVM_FFI_ICHECK_EQ((x).device().device_type, kDLExtDev);                      \
+  TVM_FFI_ICHECK((x).IsContiguous())
+#endif
+
+#ifndef CHECK_MUSA_CONTIGUOUS
+#define CHECK_MUSA_CONTIGUOUS(x)                                               \
+  TVM_FFI_ICHECK_EQ((x).device().device_type, kDLExtDev);                      \
+  TVM_FFI_ICHECK((x).IsContiguous())
+#endif
+
+#ifndef CHECK_CONTIGUOUS_2D
+#define CHECK_CONTIGUOUS_2D(x)                                                 \
+  do {                                                                         \
+    TVM_FFI_ICHECK_EQ((x).ndim(), 2);                                          \
+    TVM_FFI_ICHECK_EQ((x).stride(1), 1);                                       \
+    TVM_FFI_ICHECK_EQ((x).stride(0), (x).size(1));                             \
+  } while (0)
+#endif

--- a/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/device_utils.h
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/device_utils.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+#include <musa_bf16.h>
+#include <musa_fp16.h>
+
+#if defined(__MUSA_ARCH__)
+#define SGLANG_MUSA_ARCH __MUSA_ARCH__
+#else
+#define SGLANG_MUSA_ARCH 0
+#endif
+
+#define SGLANG_MUSA_ARCH_MP31 (SGLANG_MUSA_ARCH == 310)
+
+template <typename T> __device__ __forceinline__ float to_float(T value) {
+  if constexpr (std::is_same_v<T, half>) {
+    return __half2float(value);
+  } else if constexpr (std::is_same_v<T, __mt_bfloat16>) {
+    return __bfloat162float(value);
+  } else {
+    return static_cast<float>(value);
+  }
+}
+
+template <typename T> __device__ __forceinline__ T from_float(float value) {
+  if constexpr (std::is_same_v<T, half>) {
+    return __float2half_rn(value);
+  } else if constexpr (std::is_same_v<T, __mt_bfloat16>) {
+    return __float2bfloat16_rn(value);
+  } else {
+    return static_cast<T>(value);
+  }
+}
+
+template <int THREADS_PER_SUBWARP>
+__device__ __forceinline__ float GroupReduceMax(float val, const int tid) {
+  constexpr unsigned subwarp_mask_bits = []() constexpr {
+    if constexpr (THREADS_PER_SUBWARP == 32) {
+      return 0xffffffffu;
+    } else {
+      return (1u << THREADS_PER_SUBWARP) - 1u;
+    }
+  }();
+  const unsigned mask = subwarp_mask_bits << (threadIdx.x - tid);
+
+  if constexpr (THREADS_PER_SUBWARP >= 32) {
+    val = fmaxf(val, __shfl_xor_sync(mask, val, 16));
+  }
+  if constexpr (THREADS_PER_SUBWARP >= 16) {
+    val = fmaxf(val, __shfl_xor_sync(mask, val, 8));
+  }
+  if constexpr (THREADS_PER_SUBWARP >= 8) {
+    val = fmaxf(val, __shfl_xor_sync(mask, val, 4));
+  }
+  if constexpr (THREADS_PER_SUBWARP >= 4) {
+    val = fmaxf(val, __shfl_xor_sync(mask, val, 2));
+  }
+  if constexpr (THREADS_PER_SUBWARP >= 2) {
+    val = fmaxf(val, __shfl_xor_sync(mask, val, 1));
+  }
+  return val;
+}
+
+__device__ __forceinline__ float silu(const float &val) {
+#if defined(__MUSA_ARCH__) && (__MUSA_ARCH__ >= 1000)
+  float half_val = 0.5f * val;
+  float t = __tanhf(half_val);
+  return half_val * (1.0f + t);
+#else
+  return val / (1.0f + __expf(-val));
+#endif
+}
+
+__device__ __forceinline__ float2 fmul2_rn(float2 a, float2 b) {
+#if defined(__MUSA_ARCH__) && (__MUSA_ARCH__ >= 1000)
+  return __fmul2_rn(a, b);
+#else
+  float2 result;
+  result.x = a.x * b.x;
+  result.y = a.y * b.y;
+  return result;
+#endif
+}
+
+__device__ __forceinline__ void st_global(const int4 *ptr, const int4 &value) {
+  int4 *p = const_cast<int4 *>(ptr);
+  *p = value;
+}
+
+__device__ __forceinline__ int4 ld_global_nc(const int4 *ptr) { return *ptr; }
+
+__device__ __forceinline__ void st_global_b64_slc_new(uint64_t *ptr,
+                                                      const uint64_t value) {
+#if defined(__MUSA_ARCH__) && (__MUSA_ARCH__ == 310)
+  asm volatile(
+      "LSU.ST.B64 %1, %0, _, 8, 1, 1, inner_persist=4, outer_persist=2, "
+      "chrnt=l2_l3, slc=new, persist=0, stride_add_first=0"
+      :
+      : "R"(ptr), "R"(value));
+#else
+  *ptr = value;
+#endif
+}

--- a/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/distributed/__init__.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/distributed/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged MUSA distributed kernel sources."""

--- a/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/distributed/custom_all_reduce.mu
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/distributed/custom_all_reduce.mu
@@ -1,0 +1,1127 @@
+#include "../common.h"
+#include "../device_utils.h"
+
+#include <musa_runtime.h>
+#include <musa_bf16.h>
+#include <musa_fp16.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+
+namespace {
+
+#ifndef SGL_CUSTOM_AR_THREADS
+#define SGL_CUSTOM_AR_THREADS 512
+#endif
+
+#ifndef SGL_CUSTOM_AR_BLOCKS
+#define SGL_CUSTOM_AR_BLOCKS 36
+#endif
+
+#ifndef SGL_CUSTOM_AR_VECTOR_LOAD
+#define SGL_CUSTOM_AR_VECTOR_LOAD 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_ATOMIC_BARRIER
+#define SGL_CUSTOM_AR_ATOMIC_BARRIER 1
+#endif
+
+#ifndef SGL_CUSTOM_AR_MAX_BLOCKS
+#define SGL_CUSTOM_AR_MAX_BLOCKS 120
+#endif
+
+#ifndef SGL_CUSTOM_AR_DYNAMIC_BLOCKS
+#define SGL_CUSTOM_AR_DYNAMIC_BLOCKS 1
+#endif
+
+#ifndef SGL_CUSTOM_AR_PUSH_POLLING
+#define SGL_CUSTOM_AR_PUSH_POLLING 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_PUSH_16B_ASM
+#define SGL_CUSTOM_AR_PUSH_16B_ASM 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_2SHOT_DOUBLE_STORE
+#define SGL_CUSTOM_AR_2SHOT_DOUBLE_STORE 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_1SHOT_2RANK_SPECIAL
+#define SGL_CUSTOM_AR_1SHOT_2RANK_SPECIAL 1
+#endif
+
+#ifndef SGL_CUSTOM_AR_PUSH_SKIP_START_BARRIER
+#define SGL_CUSTOM_AR_PUSH_SKIP_START_BARRIER 0
+#endif
+
+constexpr int kMaxBlocks = SGL_CUSTOM_AR_MAX_BLOCKS;
+constexpr int kMaxThreadsPerBlock = 1024;
+constexpr int kDefaultThreads = SGL_CUSTOM_AR_THREADS;
+constexpr int kDefaultBlockLimit = SGL_CUSTOM_AR_BLOCKS;
+constexpr int kMaxRanks = 8;
+using FlagType = uint32_t;
+
+struct alignas(128) Signal {
+  alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
+  alignas(128) FlagType peer_counter[2][kMaxBlocks][kMaxRanks];
+  alignas(128) FlagType push_epoch[kMaxBlocks];
+  alignas(128) FlagType lamport_counter;
+  alignas(128) FlagType lamport_flag;
+  alignas(128) FlagType lamport_clear_packed;
+};
+
+struct __align__(16) RankData {
+  const void* ptrs[kMaxRanks];
+};
+
+struct __align__(16) RankSignals {
+  Signal* signals[kMaxRanks];
+};
+
+struct ArLaunchContext {
+  RankData data;
+  RankSignals sg;
+  Signal* self_sg;
+  int rank;
+  int world_size;
+};
+
+struct PushLaunchContext {
+  RankData data;
+  RankSignals sg;
+  Signal* self_sg;
+  const void* input;
+  void* self_buffer;
+  int rank;
+  int world_size;
+};
+
+template <typename T, int sz>
+struct __align__(alignof(T) * sz) array_t {
+  T data[sz];
+  using type = T;
+  static constexpr int size = sz;
+};
+
+template <typename T>
+struct packed_t {
+  using P = array_t<T, 16 / sizeof(T)>;
+  using A = array_t<float, 16 / sizeof(T)>;
+};
+
+template <typename T>
+struct fp_trait {};
+
+template <>
+struct fp_trait<half> {
+  using type = uint16_t;
+  static constexpr uint16_t pos_zero = 0x0000u;
+  static constexpr uint16_t neg_zero = 0x8000u;
+};
+
+template <>
+struct fp_trait<__mt_bfloat16> {
+  using type = uint16_t;
+  static constexpr uint16_t pos_zero = 0x0000u;
+  static constexpr uint16_t neg_zero = 0x8000u;
+};
+
+template <>
+struct fp_trait<float> {
+  using type = uint32_t;
+  static constexpr uint32_t pos_zero = 0x00000000u;
+  static constexpr uint32_t neg_zero = 0x80000000u;
+};
+
+template <typename DType>
+__device__ __forceinline__ void clear_pos_zero(DType& val) {
+  using Trait = fp_trait<DType>;
+  auto* ptr = reinterpret_cast<typename Trait::type*>(&val);
+  if (*ptr == Trait::pos_zero) *ptr = Trait::neg_zero;
+}
+
+template <typename DType>
+__device__ __forceinline__ bool is_pos_zero(const DType& val) {
+  using Trait = fp_trait<DType>;
+  const auto* ptr = reinterpret_cast<const typename Trait::type*>(&val);
+  return *ptr == Trait::pos_zero;
+}
+
+template <typename DType>
+__device__ __forceinline__ DType get_pos_zero() {
+  using Trait = fp_trait<DType>;
+  const auto value = Trait::pos_zero;
+  return *reinterpret_cast<const DType*>(&value);
+}
+
+template <typename T, int N>
+__device__ __forceinline__ void clear_pos_zero(array_t<T, N>& val) {
+#pragma unroll
+  for (int i = 0; i < N; ++i) {
+    clear_pos_zero(val.data[i]);
+  }
+}
+
+template <typename T, int N>
+__device__ __forceinline__ bool has_pos_zero(array_t<T, N> val) {
+  bool found = false;
+#pragma unroll
+  for (int i = 0; i < N; ++i) {
+    found |= is_pos_zero(val.data[i]);
+  }
+  return found;
+}
+
+template <typename P>
+__device__ __forceinline__ P make_pos_zero_packet() {
+  P out;
+#pragma unroll
+  for (int i = 0; i < P::size; ++i) {
+    out.data[i] = get_pos_zero<typename P::type>();
+  }
+  return out;
+}
+
+template <typename P>
+__device__ __forceinline__ P load_volatile_packet(const P* ptr) {
+  static_assert(sizeof(P) == 16 && alignof(P) == 16);
+#if SGL_CUSTOM_AR_PUSH_16B_ASM
+  using i4 = int __attribute__((ext_vector_type(4)));
+  uint4 raw;
+#if defined(__MUSA_ARCH__) && (__MUSA_ARCH__ == 310)
+  i4 tmp = __musa_ldcv_v4i32(reinterpret_cast<const i4*>(ptr));
+  raw = *reinterpret_cast<uint4*>(&tmp);
+#else
+  raw = *reinterpret_cast<const uint4*>(ptr);
+#endif
+  return *reinterpret_cast<const P*>(&raw);
+#else
+  uint4 raw;
+  const auto* src = reinterpret_cast<const volatile uint32_t*>(ptr);
+  raw.x = src[0];
+  raw.y = src[1];
+  raw.z = src[2];
+  raw.w = src[3];
+  return *reinterpret_cast<const P*>(&raw);
+#endif
+}
+
+template <typename P>
+__device__ __forceinline__ void store_volatile_packet(P* ptr, P value) {
+  static_assert(sizeof(P) == 16 && alignof(P) == 16);
+  const auto raw = *reinterpret_cast<const uint4*>(&value);
+#if SGL_CUSTOM_AR_PUSH_16B_ASM
+  using i4 = int __attribute__((ext_vector_type(4)));
+#if defined(__MUSA_ARCH__) && (__MUSA_ARCH__ == 310)
+  __musa_stwb_v4i32(*reinterpret_cast<const i4*>(&raw), reinterpret_cast<i4*>(ptr));
+#else
+  *reinterpret_cast<uint4*>(ptr) = raw;
+#endif
+#else
+  auto* dst = reinterpret_cast<volatile uint32_t*>(ptr);
+  dst[0] = raw.x;
+  dst[1] = raw.y;
+  dst[2] = raw.z;
+  dst[3] = raw.w;
+#endif
+}
+
+__device__ __forceinline__ float upcast_s(half value) {
+  return __half2float(value);
+}
+
+__device__ __forceinline__ float upcast_s(__mt_bfloat16 value) {
+  return __bfloat162float(value);
+}
+
+__device__ __forceinline__ float upcast_s(float value) {
+  return value;
+}
+
+template <typename T>
+__device__ __forceinline__ T downcast_s(float value);
+
+template <>
+__device__ __forceinline__ half downcast_s<half>(float value) {
+  return __float2half(value);
+}
+
+template <>
+__device__ __forceinline__ __mt_bfloat16 downcast_s<__mt_bfloat16>(float value) {
+  return __float2bfloat16(value);
+}
+
+template <>
+__device__ __forceinline__ float downcast_s<float>(float value) {
+  return value;
+}
+
+template <typename T>
+__device__ __forceinline__ T& assign_add(T& a, T b) {
+  a = downcast_s<T>(upcast_s(a) + upcast_s(b));
+  return a;
+}
+
+template <>
+__device__ __forceinline__ float& assign_add<float>(float& a, float b) {
+  a += b;
+  return a;
+}
+
+template <typename T, int N>
+__device__ __forceinline__ array_t<T, N>& packed_assign_add(array_t<T, N>& a, array_t<T, N> b) {
+#pragma unroll
+  for (int i = 0; i < N; ++i) {
+    assign_add(a.data[i], b.data[i]);
+  }
+  return a;
+}
+
+template <typename T, int N>
+__device__ __forceinline__ array_t<float, N> upcast(array_t<T, N> value) {
+  if constexpr (std::is_same<T, float>::value) {
+    return value;
+  } else {
+    array_t<float, N> out;
+#pragma unroll
+    for (int i = 0; i < N; ++i) {
+      out.data[i] = upcast_s(value.data[i]);
+    }
+    return out;
+  }
+}
+
+template <typename O>
+__device__ __forceinline__ O downcast(array_t<float, O::size> value) {
+  if constexpr (std::is_same<typename O::type, float>::value) {
+    return value;
+  } else {
+    O out;
+#pragma unroll
+    for (int i = 0; i < O::size; ++i) {
+      out.data[i] = downcast_s<typename O::type>(value.data[i]);
+    }
+    return out;
+  }
+}
+
+__device__ __forceinline__ void signal_store(FlagType* ptr, FlagType value) {
+  volatile_store(static_cast<uint32_t>(value), reinterpret_cast<uint32_t*>(ptr));
+}
+
+__device__ __forceinline__ void signal_store_volatile(FlagType* ptr, FlagType value) {
+  *reinterpret_cast<volatile FlagType*>(ptr) = value;
+}
+
+__device__ __forceinline__ FlagType signal_load(FlagType* ptr) {
+  flushInv_byp();
+  return static_cast<uint32_t>(volatile_load(reinterpret_cast<uint32_t*>(ptr)));
+}
+
+__device__ __forceinline__ FlagType signal_load_volatile(FlagType* ptr) {
+  return *reinterpret_cast<volatile FlagType*>(ptr);
+}
+
+template <int nranks, bool start, bool fence = false>
+__device__ __forceinline__ void multi_rank_barrier(const RankSignals& sg, Signal* self_sg, int rank) {
+  static_assert(!(start && fence));
+  if constexpr (!start) {
+    __syncthreads_lm();
+  }
+  if (threadIdx.x < nranks) {
+#if SGL_CUSTOM_AR_ATOMIC_BARRIER
+    auto flag = atomicAdd(&self_sg->self_counter[blockIdx.x][threadIdx.x], 1) + 1;
+    auto* peer = &sg.signals[threadIdx.x]->peer_counter[flag & 1][blockIdx.x][rank];
+    auto* local = &self_sg->peer_counter[flag & 1][blockIdx.x][threadIdx.x];
+    atomicExch(peer, flag);
+    while (atomicAdd(local, 0) != flag) {
+    }
+#else
+    auto flag = self_sg->self_counter[blockIdx.x][threadIdx.x] + 1;
+    self_sg->self_counter[blockIdx.x][threadIdx.x] = flag;
+    auto* peer = &sg.signals[threadIdx.x]->peer_counter[flag & 1][blockIdx.x][rank];
+    auto* local = &self_sg->peer_counter[flag & 1][blockIdx.x][threadIdx.x];
+    if constexpr (fence) {
+      signal_store(peer, flag);
+      while (signal_load(local) != flag) {
+      }
+    } else {
+      signal_store_volatile(peer, flag);
+      while (signal_load_volatile(local) != flag) {
+      }
+    }
+#endif
+  }
+  if constexpr (start || fence) {
+    __syncthreads_lm();
+  }
+}
+
+template <typename P, int nranks, typename A>
+__device__ __forceinline__ P packed_reduce(const P* ptrs[], int idx) {
+  A tmp = upcast(ptrs[0][idx]);
+#pragma unroll
+  for (int i = 1; i < nranks; ++i) {
+    packed_assign_add(tmp, upcast(ptrs[i][idx]));
+  }
+  return downcast<P>(tmp);
+}
+
+template <typename T, int nranks>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) cross_device_reduce_1stage(
+    RankData data, const RankData* data_ptr, RankSignals sg, Signal* self_sg,
+    T* __restrict__ out, int rank, int size) {
+  if (data_ptr != nullptr) {
+    data = *data_ptr;
+  }
+  using P = typename packed_t<T>::P;
+  using A = typename packed_t<T>::A;
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < size; idx += gridDim.x * blockDim.x) {
+    reinterpret_cast<P*>(out)[idx] = packed_reduce<P, nranks, A>(reinterpret_cast<const P**>(&data.ptrs[0]), idx);
+  }
+  multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+}
+
+template <typename T>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) cross_device_reduce_1stage_2rank(
+    RankData data, const RankData* data_ptr, RankSignals sg, Signal* self_sg,
+    T* __restrict__ out, int rank, int size) {
+  if (data_ptr != nullptr) {
+    data = *data_ptr;
+  }
+  using P = typename packed_t<T>::P;
+  using A = typename packed_t<T>::A;
+  const auto* local = reinterpret_cast<const P*>(data.ptrs[rank]);
+  const auto* peer = reinterpret_cast<const P*>(data.ptrs[rank ^ 1]);
+  auto* dst = reinterpret_cast<P*>(out);
+  multi_rank_barrier<2, true>(sg, self_sg, rank);
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < size; idx += gridDim.x * blockDim.x) {
+    A tmp = upcast(local[idx]);
+    packed_assign_add(tmp, upcast(peer[idx]));
+    dst[idx] = downcast<P>(tmp);
+  }
+  multi_rank_barrier<2, false>(sg, self_sg, rank);
+}
+
+template <typename T, int nranks>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) cross_device_push_1stage(
+    RankData data, const RankData* data_ptr, RankSignals sg, Signal* self_sg,
+    const T* __restrict__ input, T* __restrict__ out, int rank, int size) {
+  if (data_ptr != nullptr) {
+    data = *data_ptr;
+  }
+  using P = typename packed_t<T>::P;
+  using A = typename packed_t<T>::A;
+  const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  const int stride = gridDim.x * blockDim.x;
+  const int bytes = size * static_cast<int>(sizeof(P));
+  const P* src = reinterpret_cast<const P*>(input);
+
+#if !SGL_CUSTOM_AR_PUSH_POLLING
+  if constexpr (nranks == 2) {
+#if !SGL_CUSTOM_AR_PUSH_SKIP_START_BARRIER
+    multi_rank_barrier<2, true>(sg, self_sg, rank);
+#endif
+    P* peer_dst = reinterpret_cast<P*>(
+        reinterpret_cast<char*>(const_cast<void*>(data.ptrs[rank ^ 1])) + rank * bytes);
+    for (int idx = tid; idx < size; idx += stride) {
+      peer_dst[idx] = src[idx];
+    }
+    __musa_barrier_slc();
+    __syncthreads_lm();
+    if (threadIdx.x == 0) {
+      __threadfence_system_noflush();
+    }
+    multi_rank_barrier<2, false, true>(sg, self_sg, rank);
+
+    const auto* local_buffer = reinterpret_cast<const char*>(data.ptrs[rank]);
+    const P* peer_src = reinterpret_cast<const P*>(local_buffer + (rank ^ 1) * bytes);
+    auto* dst = reinterpret_cast<P*>(out);
+    for (int idx = tid; idx < size; idx += stride) {
+      A tmp = upcast(src[idx]);
+      packed_assign_add(tmp, upcast(peer_src[idx]));
+      dst[idx] = downcast<P>(tmp);
+    }
+    multi_rank_barrier<2, false>(sg, self_sg, rank);
+    return;
+  }
+
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+#pragma unroll
+  for (int peer = 0; peer < nranks; ++peer) {
+    P* dst = reinterpret_cast<P*>(
+        reinterpret_cast<char*>(const_cast<void*>(data.ptrs[peer])) + rank * bytes);
+    for (int idx = tid; idx < size; idx += stride) {
+      dst[idx] = src[idx];
+    }
+  }
+  __musa_barrier_slc();
+  __syncthreads_lm();
+  if (threadIdx.x == 0) {
+    __threadfence_system_noflush();
+  }
+  multi_rank_barrier<nranks, false, true>(sg, self_sg, rank);
+
+  const P* ptrs[nranks];
+  const auto* local_buffer = reinterpret_cast<const char*>(data.ptrs[rank]);
+#pragma unroll
+  for (int i = 0; i < nranks; ++i) {
+    ptrs[i] = reinterpret_cast<const P*>(local_buffer + i * bytes);
+  }
+  for (int idx = tid; idx < size; idx += stride) {
+    reinterpret_cast<P*>(out)[idx] = packed_reduce<P, nranks, A>(ptrs, idx);
+  }
+  multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+#else
+  const int epoch = self_sg->push_epoch[blockIdx.x] & 1;
+  // Push data uses a v2-style two-stage ring:
+  //   slot = epoch * nranks + source_rank
+#pragma unroll
+  for (int peer = 0; peer < nranks; ++peer) {
+    P* dst = reinterpret_cast<P*>(
+        reinterpret_cast<char*>(const_cast<void*>(data.ptrs[peer])) + (epoch * nranks + rank) * bytes);
+    for (int idx = tid; idx < size; idx += stride) {
+      P value = src[idx];
+      clear_pos_zero(value);
+      store_volatile_packet(&dst[idx], value);
+    }
+  }
+
+  __musa_barrier_slc();
+  __syncthreads_lm();
+  if (threadIdx.x == 0) {
+    __threadfence_system_noflush();
+  }
+  __syncthreads_lm();
+
+  const P* ptrs[nranks];
+  auto* local_buffer = reinterpret_cast<char*>(const_cast<void*>(data.ptrs[rank]));
+#pragma unroll
+  for (int i = 0; i < nranks; ++i) {
+    ptrs[i] = reinterpret_cast<const P*>(local_buffer + (epoch * nranks + i) * bytes);
+  }
+  for (int idx = tid; idx < size; idx += stride) {
+    P values[nranks];
+    while (true) {
+      bool waiting = false;
+      flushInv_byp();
+#pragma unroll
+      for (int i = 0; i < nranks; ++i) {
+        values[i] = load_volatile_packet(&ptrs[i][idx]);
+        waiting |= has_pos_zero(values[i]);
+      }
+      if (!waiting) break;
+    }
+    A tmp = upcast(values[0]);
+#pragma unroll
+    for (int i = 1; i < nranks; ++i) {
+      packed_assign_add(tmp, upcast(values[i]));
+    }
+    reinterpret_cast<P*>(out)[idx] = downcast<P>(tmp);
+    P* reset_ptr = reinterpret_cast<P*>(local_buffer + epoch * nranks * bytes);
+    const P pos_zero = make_pos_zero_packet<P>();
+#pragma unroll
+    for (int i = 0; i < nranks; ++i) {
+      reset_ptr[i * size + idx] = pos_zero;
+    }
+  }
+  __syncthreads_lm();
+  if (threadIdx.x == 0) {
+    self_sg->push_epoch[blockIdx.x] = (epoch + 1) & 1;
+  }
+  multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+#endif
+}
+
+template <typename P>
+__device__ __forceinline__ P* get_tmp_buf(Signal* signal) {
+  return reinterpret_cast<P*>(signal + 1);
+}
+
+template <typename T, int nranks>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) cross_device_reduce_2stage(
+    RankData data, RankSignals sg, Signal* self_sg, T* __restrict__ out, int rank, int size) {
+  int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  int stride = gridDim.x * blockDim.x;
+  using P = typename packed_t<T>::P;
+  using A = typename packed_t<T>::A;
+  int part = size / nranks;
+  int start = rank * part;
+  int end = rank == nranks - 1 ? size : start + part;
+  int largest_part = part + size % nranks;
+  const P* ptrs[nranks];
+  P* tmps[nranks];
+#pragma unroll
+  for (int i = 0; i < nranks; ++i) {
+    int target = (rank + i) % nranks;
+    ptrs[i] = reinterpret_cast<const P*>(data.ptrs[target]);
+    tmps[i] = get_tmp_buf<P>(sg.signals[target]);
+  }
+  auto tmp_out = tmps[0];
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+  for (int idx = start + tid; idx < end; idx += stride) {
+    tmp_out[idx - start] = packed_reduce<P, nranks, A>(ptrs, idx);
+  }
+  multi_rank_barrier<nranks, false, true>(sg, self_sg, rank);
+  for (int idx = tid; idx < largest_part; idx += stride) {
+#pragma unroll
+    for (int i = 0; i < nranks; ++i) {
+      int gather_rank = (rank + i) % nranks;
+      if (gather_rank == nranks - 1 || idx < part) {
+        reinterpret_cast<P*>(out)[gather_rank * part + idx] = tmps[i][idx];
+      }
+    }
+  }
+}
+
+template <typename T, int nranks, int vlen = 8>
+__device__ __forceinline__ void shfl_reduce(float* res) {
+  if constexpr (nranks >= 4) {
+#pragma unroll
+    for (int i = 0; i < vlen; ++i) {
+      res[i] += __shfl_xor_sync(0xffffffff, res[i], 16);
+    }
+  }
+#pragma unroll
+  for (int i = 0; i < vlen; ++i) {
+    res[i] += __shfl_xor_sync(0xffffffff, res[i], 8);
+  }
+}
+
+template <typename T, int nranks, int vlen = 8>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) custom_all_reduce_2shot(
+    RankData data,
+    const RankData* data_ptr,
+    RankSignals sg,
+    Signal* self_sg,
+    T* __restrict__ out,
+    int rank,
+    int size) {
+  if (data_ptr != nullptr) {
+    data = *data_ptr;
+  }
+  constexpr int nranks_sft = (nranks >> 1) - (nranks >> 3);
+  constexpr int coalesce_num = 8;
+  constexpr int coalesce_sft = 3;
+  constexpr int group_stride_sft = nranks_sft + coalesce_sft;
+  const int tid = threadIdx.x;
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int target_rank = (tid >> coalesce_sft) & (nranks - 1);
+  const int group_id = tid >> group_stride_sft;
+  const int coalesce_tid = tid & (coalesce_num - 1);
+  const int stride = gridDim.x * blockDim.x;
+
+  typedef int16_t Vec __attribute__((vector_size(16)));
+  int idx_base = blockIdx.x * blockDim.x;
+  int idx_in_blk = coalesce_tid + (rank << coalesce_sft) + (group_id << group_stride_sft);
+
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+  Vec* target_ptr = reinterpret_cast<Vec*>(const_cast<void*>(data.ptrs[target_rank]));
+  Vec* buffer_ptr = get_tmp_buf<Vec>(sg.signals[rank]);
+  do {
+    int idx = idx_in_blk + idx_base;
+    float acc[vlen] = {0};
+    if (idx < size) {
+#if SGL_CUSTOM_AR_VECTOR_LOAD
+      Vec raw = target_ptr[idx];
+      const T* src = reinterpret_cast<const T*>(&raw);
+#else
+      const T* src = reinterpret_cast<const T*>(&target_ptr[idx]);
+#endif
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        acc[i] = upcast_s(src[i]);
+      }
+    }
+    shfl_reduce<T, nranks, vlen>(acc);
+    if constexpr (nranks == 8) {
+      __shared__ float smem[kMaxThreadsPerBlock << 1];
+      if (lane < coalesce_num) {
+#pragma unroll
+        for (int i = 0; i < vlen; ++i) {
+          smem[warp * vlen * coalesce_num + coalesce_tid * vlen + i] = acc[i];
+        }
+      }
+      __syncthreads_lm();
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        acc[i] += smem[(warp ^ 1) * vlen * coalesce_num + coalesce_tid * vlen + i];
+      }
+    }
+    if (rank == target_rank && idx < size) {
+      Vec res;
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        reinterpret_cast<T*>(&res)[i] = downcast_s<T>(acc[i]);
+      }
+      buffer_ptr[idx] = res;
+#if SGL_CUSTOM_AR_2SHOT_DOUBLE_STORE
+      buffer_ptr[idx] = res;
+#endif
+    }
+    idx_base += stride;
+  } while (idx_base < size);
+
+  __musa_barrier_slc();
+  __syncthreads_lm();
+  if (tid == 0) {
+    __threadfence_system_noflush();
+  }
+  if (tid < nranks) {
+#if SGL_CUSTOM_AR_ATOMIC_BARRIER
+    auto flag = atomicAdd(&self_sg->self_counter[blockIdx.x][tid], 1) + 1;
+    auto* peer = &sg.signals[tid]->peer_counter[flag & 1][blockIdx.x][rank];
+    auto* local = &self_sg->peer_counter[flag & 1][blockIdx.x][tid];
+    atomicExch(peer, flag);
+    while (atomicAdd(local, 0) != flag) {
+    }
+#else
+    auto flag = self_sg->self_counter[blockIdx.x][tid] + 1;
+    self_sg->self_counter[blockIdx.x][tid] = flag;
+    auto* peer = &sg.signals[tid]->peer_counter[flag & 1][blockIdx.x][rank];
+    auto* local = &self_sg->peer_counter[flag & 1][blockIdx.x][tid];
+    signal_store(peer, flag);
+    while (signal_load(local) != flag) {
+    }
+#endif
+  }
+  __syncthreads_lm();
+
+  buffer_ptr = get_tmp_buf<Vec>(sg.signals[target_rank]);
+  idx_in_blk = coalesce_tid + (target_rank << coalesce_sft) + (group_id << group_stride_sft);
+  idx_base = blockIdx.x * blockDim.x;
+  do {
+    int idx = idx_in_blk + idx_base;
+    if (idx < size) {
+      reinterpret_cast<Vec*>(out)[idx] = buffer_ptr[idx];
+    }
+    idx_base += stride;
+  } while (idx_base < size);
+}
+
+template <typename T, int nranks>
+int select_block_limit(int packed_size, int shot) {
+  int limit = kDefaultBlockLimit;
+#if SGL_CUSTOM_AR_DYNAMIC_BLOCKS
+  if (shot == 0) {
+    if constexpr (nranks == 2) {
+      if (packed_size < 32 * 1024) {
+        limit = std::min(limit, 12);
+      }
+    }
+  } else if (shot == 1) {
+    if constexpr (nranks == 2) {
+      if (packed_size <= 128 * 1024) {
+        limit = std::min(limit, 24);
+      }
+    }
+  } else if ((shot == 2 || shot == 4) && !std::is_same<T, float>::value) {
+    if constexpr (nranks == 4) {
+      if (packed_size >= 4 * 1024 * 1024) {
+        limit = 40;
+      } else if (packed_size >= 1024 * 1024) {
+        limit = 80;
+      }
+    } else if constexpr (nranks == 8) {
+      if (packed_size <= 128 * 1024) {
+        limit = 60;
+      }
+    }
+  }
+#endif
+  return std::min(limit, kMaxBlocks);
+}
+
+template <typename T, int nranks>
+void launch_ar(
+    RankData data,
+    const RankData* data_ptr,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* input,
+    T* out,
+    int rank,
+    int size,
+    int shot,
+    musaStream_t stream) {
+  const int pack = packed_t<T>::P::size;
+  TVM_FFI_ICHECK_EQ(size % pack, 0);
+  int packed_size = size / pack;
+  int block_limit = select_block_limit<T, nranks>(packed_size, shot);
+  int blocks = std::min(block_limit, (packed_size + kDefaultThreads - 1) / kDefaultThreads);
+  if (blocks <= 0) {
+    return;
+  }
+  if (shot == 0 || shot == 3) {
+    cross_device_push_1stage<T, nranks><<<blocks, kDefaultThreads, 0, stream>>>(data, data_ptr, sg, self_sg, input, out, rank, packed_size);
+  } else if (shot == 1) {
+    if constexpr (nranks == 2 && SGL_CUSTOM_AR_1SHOT_2RANK_SPECIAL) {
+      cross_device_reduce_1stage_2rank<T><<<blocks, kDefaultThreads, 0, stream>>>(data, data_ptr, sg, self_sg, out, rank, packed_size);
+    } else {
+      cross_device_reduce_1stage<T, nranks><<<blocks, kDefaultThreads, 0, stream>>>(data, data_ptr, sg, self_sg, out, rank, packed_size);
+    }
+  } else if (shot == 2 || shot == 4) {
+    if constexpr (std::is_same<T, float>::value) {
+      cross_device_reduce_2stage<T, nranks><<<blocks, kDefaultThreads, 0, stream>>>(data, sg, self_sg, out, rank, packed_size);
+    } else {
+      custom_all_reduce_2shot<T, nranks><<<blocks, kDefaultThreads, 0, stream>>>(
+          data, data_ptr, sg, self_sg, out, rank, packed_size);
+    }
+  } else {
+    TVM_FFI_THROW(ValueError) << "shot must be 0, 1, 2, 3, or 4";
+  }
+}
+
+template <typename T>
+void dispatch_world_size(
+    RankData data,
+    const RankData* data_ptr,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* input,
+    T* out,
+    int rank,
+    int world_size,
+    int size,
+    int shot,
+    musaStream_t stream) {
+  switch (world_size) {
+    case 2:
+      launch_ar<T, 2>(data, data_ptr, sg, self_sg, input, out, rank, size, shot, stream);
+      break;
+    case 4:
+      launch_ar<T, 4>(data, data_ptr, sg, self_sg, input, out, rank, size, shot, stream);
+      break;
+    case 6:
+      launch_ar<T, 6>(data, data_ptr, sg, self_sg, input, out, rank, size, shot, stream);
+      break;
+    case 8:
+      launch_ar<T, 8>(data, data_ptr, sg, self_sg, input, out, rank, size, shot, stream);
+      break;
+    default:
+      TVM_FFI_THROW(ValueError) << "world_size must be one of 2/4/6/8";
+  }
+}
+
+}  // namespace
+
+int64_t sgl_musa_custom_ar_meta_size() {
+  return static_cast<int64_t>(sizeof(Signal));
+}
+
+__global__ void __launch_bounds__(1, 1) empty_kernel() {}
+
+void sgl_musa_custom_ar_launch_empty(ffi::TensorView out) {
+  CHECK_MUSA_CONTIGUOUS(out);
+  auto stream = get_stream(out.device());
+  empty_kernel<<<1, 1, 0, stream>>>();
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess) << "MUSA empty kernel failed: " << musaGetErrorString(err);
+}
+
+void sgl_musa_custom_ar_launch(
+    ffi::TensorView rank_data,
+    ffi::TensorView signal_ptrs_cpu,
+    ffi::TensorView out,
+    int64_t self_signal_ptr,
+    int64_t rank,
+    int64_t world_size,
+    int64_t shot) {
+  CHECK_MUSA_CONTIGUOUS(out);
+  TVM_FFI_ICHECK_EQ(
+      rank_data.device().device_type, out.device().device_type);
+  TVM_FFI_ICHECK_EQ(rank_data.device().device_id, out.device().device_id);
+  TVM_FFI_ICHECK(rank_data.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(rank_data.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(rank_data.size(0), kMaxRanks);
+  TVM_FFI_ICHECK_EQ(signal_ptrs_cpu.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(signal_ptrs_cpu.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(signal_ptrs_cpu.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(signal_ptrs_cpu.size(0), world_size);
+  TVM_FFI_ICHECK(rank >= 0 && rank < world_size);
+
+  RankSignals sg{};
+  const auto* ptrs = static_cast<const int64_t*>(signal_ptrs_cpu.data_ptr());
+  for (int i = 0; i < world_size; ++i) {
+    sg.signals[i] = reinterpret_cast<Signal*>(ptrs[i]);
+  }
+  RankData data{};
+  const auto* device_data_ptr =
+      reinterpret_cast<const RankData*>(rank_data.data_ptr());
+  auto* self_sg = reinterpret_cast<Signal*>(self_signal_ptr);
+  auto stream = get_stream(out.device());
+  const int64_t numel64 = tensor_numel(out);
+  TVM_FFI_ICHECK_LE(numel64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  const int size = static_cast<int>(numel64);
+
+  if (dtype_equal(out.dtype(), dl_float16)) {
+    auto* out_ptr = static_cast<half*>(out.data_ptr());
+    dispatch_world_size(data, device_data_ptr, sg, self_sg, out_ptr, out_ptr, static_cast<int>(rank), static_cast<int>(world_size), size, static_cast<int>(shot), stream);
+  } else if (dtype_equal(out.dtype(), dl_bfloat16)) {
+    auto* out_ptr = static_cast<__mt_bfloat16*>(out.data_ptr());
+    dispatch_world_size(data, device_data_ptr, sg, self_sg, out_ptr, out_ptr, static_cast<int>(rank), static_cast<int>(world_size), size, static_cast<int>(shot), stream);
+  } else if (dtype_equal(out.dtype(), dl_float32)) {
+    auto* out_ptr = static_cast<float*>(out.data_ptr());
+    dispatch_world_size(data, device_data_ptr, sg, self_sg, out_ptr, out_ptr, static_cast<int>(rank), static_cast<int>(world_size), size, static_cast<int>(shot), stream);
+  } else {
+    TVM_FFI_THROW(ValueError) << "custom ar only supports fp16/bf16/fp32";
+  }
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess) << "MUSA custom AR kernel failed: " << musaGetErrorString(err);
+}
+
+void sgl_musa_custom_ar_launch_unregistered(
+    ffi::TensorView rank_data,
+    ffi::TensorView signal_ptrs_cpu,
+    ffi::TensorView inp,
+    ffi::TensorView out,
+    int64_t self_signal_ptr,
+    int64_t self_buffer_ptr,
+    int64_t max_size_bytes,
+    int64_t rank,
+    int64_t world_size,
+    int64_t shot) {
+  CHECK_MUSA_CONTIGUOUS(inp);
+  CHECK_MUSA_CONTIGUOUS(out);
+  TVM_FFI_ICHECK_EQ(rank_data.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(rank_data.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(rank_data.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(rank_data.size(0), kMaxRanks);
+  TVM_FFI_ICHECK_EQ(signal_ptrs_cpu.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(signal_ptrs_cpu.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(signal_ptrs_cpu.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(signal_ptrs_cpu.size(0), world_size);
+  TVM_FFI_ICHECK(rank >= 0 && rank < world_size);
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), out.dtype()));
+  TVM_FFI_ICHECK_EQ(tensor_numel(inp), tensor_numel(out));
+
+  RankSignals sg{};
+  const auto* ptrs = static_cast<const int64_t*>(signal_ptrs_cpu.data_ptr());
+  for (int i = 0; i < world_size; ++i) {
+    sg.signals[i] = reinterpret_cast<Signal*>(ptrs[i]);
+  }
+  RankData data{};
+  const auto* rank_ptrs = static_cast<const int64_t*>(rank_data.data_ptr());
+  for (int i = 0; i < kMaxRanks; ++i) {
+    data.ptrs[i] = reinterpret_cast<const void*>(rank_ptrs[i]);
+  }
+  auto* self_sg = reinterpret_cast<Signal*>(self_signal_ptr);
+  auto stream = get_stream(out.device());
+  const int64_t numel64 = tensor_numel(out);
+  TVM_FFI_ICHECK_LE(numel64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  const int64_t nbytes = numel64 * ((static_cast<int64_t>(out.dtype().bits) * out.dtype().lanes + 7) / 8);
+  TVM_FFI_ICHECK_LE(nbytes, max_size_bytes);
+  if (shot == 0 || shot == 3) {
+    TVM_FFI_ICHECK_LE(nbytes * 2 * world_size, max_size_bytes);
+  }
+  if (shot != 0 && shot != 3) {
+    const musaError_t copy_err = musaMemcpyAsync(
+        reinterpret_cast<void*>(self_buffer_ptr),
+        inp.data_ptr(),
+        static_cast<size_t>(nbytes),
+        musaMemcpyDeviceToDevice,
+        stream);
+    TVM_FFI_ICHECK_EQ(copy_err, musaSuccess) << "MUSA custom AR copy failed: " << musaGetErrorString(copy_err);
+  }
+  const int size = static_cast<int>(numel64);
+
+  if (dtype_equal(out.dtype(), dl_float16)) {
+    dispatch_world_size(data, nullptr, sg, self_sg, static_cast<const half*>(inp.data_ptr()), static_cast<half*>(out.data_ptr()), static_cast<int>(rank), static_cast<int>(world_size), size, static_cast<int>(shot), stream);
+  } else if (dtype_equal(out.dtype(), dl_bfloat16)) {
+    dispatch_world_size(data, nullptr, sg, self_sg, static_cast<const __mt_bfloat16*>(inp.data_ptr()), static_cast<__mt_bfloat16*>(out.data_ptr()), static_cast<int>(rank), static_cast<int>(world_size), size, static_cast<int>(shot), stream);
+  } else if (dtype_equal(out.dtype(), dl_float32)) {
+    dispatch_world_size(data, nullptr, sg, self_sg, static_cast<const float*>(inp.data_ptr()), static_cast<float*>(out.data_ptr()), static_cast<int>(rank), static_cast<int>(world_size), size, static_cast<int>(shot), stream);
+  } else {
+    TVM_FFI_THROW(ValueError) << "custom ar only supports fp16/bf16/fp32";
+  }
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess) << "MUSA custom AR kernel failed: " << musaGetErrorString(err);
+}
+
+int64_t sgl_musa_custom_ar_create_context(
+    ffi::TensorView rank_data,
+    ffi::TensorView signal_ptrs_cpu,
+    int64_t self_signal_ptr,
+    int64_t rank,
+    int64_t world_size) {
+  TVM_FFI_ICHECK_EQ(rank_data.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(rank_data.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(rank_data.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(rank_data.size(0), kMaxRanks);
+  TVM_FFI_ICHECK_EQ(signal_ptrs_cpu.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(signal_ptrs_cpu.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(signal_ptrs_cpu.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(signal_ptrs_cpu.size(0), world_size);
+  TVM_FFI_ICHECK(rank >= 0 && rank < world_size);
+
+  auto* ctx = new ArLaunchContext{};
+  const auto* rank_ptrs = static_cast<const int64_t*>(rank_data.data_ptr());
+  for (int i = 0; i < kMaxRanks; ++i) {
+    ctx->data.ptrs[i] = reinterpret_cast<const void*>(rank_ptrs[i]);
+  }
+  const auto* sig_ptrs = static_cast<const int64_t*>(signal_ptrs_cpu.data_ptr());
+  for (int i = 0; i < world_size; ++i) {
+    ctx->sg.signals[i] = reinterpret_cast<Signal*>(sig_ptrs[i]);
+  }
+  ctx->self_sg = reinterpret_cast<Signal*>(self_signal_ptr);
+  ctx->rank = static_cast<int>(rank);
+  ctx->world_size = static_cast<int>(world_size);
+  return reinterpret_cast<int64_t>(ctx);
+}
+
+void sgl_musa_custom_ar_dispose_context(int64_t ctx_ptr) {
+  delete reinterpret_cast<ArLaunchContext*>(ctx_ptr);
+}
+
+void sgl_musa_custom_ar_launch_context(
+    int64_t ctx_ptr,
+    ffi::TensorView out,
+    int64_t shot) {
+  CHECK_MUSA_CONTIGUOUS(out);
+  auto* ctx = reinterpret_cast<ArLaunchContext*>(ctx_ptr);
+  TVM_FFI_ICHECK(ctx != nullptr);
+  auto stream = get_stream(out.device());
+  const int64_t numel64 = tensor_numel(out);
+  TVM_FFI_ICHECK_LE(numel64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  const int size = static_cast<int>(numel64);
+
+  if (dtype_equal(out.dtype(), dl_float16)) {
+    auto* out_ptr = static_cast<half*>(out.data_ptr());
+    dispatch_world_size(ctx->data, nullptr, ctx->sg, ctx->self_sg, out_ptr, out_ptr, ctx->rank, ctx->world_size, size, static_cast<int>(shot), stream);
+  } else if (dtype_equal(out.dtype(), dl_bfloat16)) {
+    auto* out_ptr = static_cast<__mt_bfloat16*>(out.data_ptr());
+    dispatch_world_size(ctx->data, nullptr, ctx->sg, ctx->self_sg, out_ptr, out_ptr, ctx->rank, ctx->world_size, size, static_cast<int>(shot), stream);
+  } else if (dtype_equal(out.dtype(), dl_float32)) {
+    auto* out_ptr = static_cast<float*>(out.data_ptr());
+    dispatch_world_size(ctx->data, nullptr, ctx->sg, ctx->self_sg, out_ptr, out_ptr, ctx->rank, ctx->world_size, size, static_cast<int>(shot), stream);
+  } else {
+    TVM_FFI_THROW(ValueError) << "custom ar only supports fp16/bf16/fp32";
+  }
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess) << "MUSA custom AR kernel failed: " << musaGetErrorString(err);
+}
+
+extern "C" void sgl_musa_custom_ar_launch_context_raw_nocheck(
+    int64_t ctx_ptr,
+    void* out,
+    int64_t numel,
+    int dtype_code,
+    int64_t stream_value,
+    int64_t shot) {
+  auto* ctx = reinterpret_cast<ArLaunchContext*>(ctx_ptr);
+  auto stream = reinterpret_cast<musaStream_t>(stream_value);
+  const int size = static_cast<int>(numel);
+  if (dtype_code == 0) {
+    dispatch_world_size(ctx->data, nullptr, ctx->sg, ctx->self_sg, static_cast<half*>(out), static_cast<half*>(out), ctx->rank, ctx->world_size, size, static_cast<int>(shot), stream);
+  } else if (dtype_code == 1) {
+    dispatch_world_size(ctx->data, nullptr, ctx->sg, ctx->self_sg, static_cast<__mt_bfloat16*>(out), static_cast<__mt_bfloat16*>(out), ctx->rank, ctx->world_size, size, static_cast<int>(shot), stream);
+  } else {
+    dispatch_world_size(ctx->data, nullptr, ctx->sg, ctx->self_sg, static_cast<float*>(out), static_cast<float*>(out), ctx->rank, ctx->world_size, size, static_cast<int>(shot), stream);
+  }
+}
+
+extern "C" void sgl_musa_custom_ar_launch_unregistered_raw_nocheck(
+    const int64_t* rank_ptrs,
+    const int64_t* signal_ptrs,
+    const void* inp,
+    void* out,
+    int64_t self_signal_ptr,
+    int64_t self_buffer_ptr,
+    int64_t numel,
+    int dtype_code,
+    int64_t stream_value,
+    int64_t rank,
+    int64_t world_size,
+    int64_t shot) {
+  RankSignals sg{};
+  for (int i = 0; i < world_size; ++i) {
+    sg.signals[i] = reinterpret_cast<Signal*>(signal_ptrs[i]);
+  }
+  RankData data{};
+  for (int i = 0; i < kMaxRanks; ++i) {
+    data.ptrs[i] = reinterpret_cast<const void*>(rank_ptrs[i]);
+  }
+  auto* self_sg = reinterpret_cast<Signal*>(self_signal_ptr);
+  auto stream = reinterpret_cast<musaStream_t>(stream_value);
+  const int size = static_cast<int>(numel);
+  const int64_t nbytes = dtype_code == 2 ? numel * 4 : numel * 2;
+  if (shot != 0 && shot != 3) {
+    musaMemcpyAsync(
+        reinterpret_cast<void*>(self_buffer_ptr),
+        inp,
+        static_cast<size_t>(nbytes),
+        musaMemcpyDeviceToDevice,
+        stream);
+  }
+
+  if (dtype_code == 0) {
+    dispatch_world_size(data, nullptr, sg, self_sg, static_cast<const half*>(inp), static_cast<half*>(out), static_cast<int>(rank), static_cast<int>(world_size), size, static_cast<int>(shot), stream);
+  } else if (dtype_code == 1) {
+    dispatch_world_size(data, nullptr, sg, self_sg, static_cast<const __mt_bfloat16*>(inp), static_cast<__mt_bfloat16*>(out), static_cast<int>(rank), static_cast<int>(world_size), size, static_cast<int>(shot), stream);
+  } else {
+    dispatch_world_size(data, nullptr, sg, self_sg, static_cast<const float*>(inp), static_cast<float*>(out), static_cast<int>(rank), static_cast<int>(world_size), size, static_cast<int>(shot), stream);
+  }
+}
+
+extern "C" int64_t sgl_musa_custom_ar_create_unregistered_context_raw(
+    const int64_t* rank_ptrs,
+    const int64_t* signal_ptrs,
+    const void* inp,
+    int64_t self_signal_ptr,
+    int64_t self_buffer_ptr,
+    int64_t rank,
+    int64_t world_size) {
+  auto* ctx = new PushLaunchContext{};
+  for (int i = 0; i < world_size; ++i) {
+    ctx->sg.signals[i] = reinterpret_cast<Signal*>(signal_ptrs[i]);
+  }
+  for (int i = 0; i < kMaxRanks; ++i) {
+    ctx->data.ptrs[i] = reinterpret_cast<const void*>(rank_ptrs[i]);
+  }
+  ctx->self_sg = reinterpret_cast<Signal*>(self_signal_ptr);
+  ctx->input = inp;
+  ctx->self_buffer = reinterpret_cast<void*>(self_buffer_ptr);
+  ctx->rank = static_cast<int>(rank);
+  ctx->world_size = static_cast<int>(world_size);
+  return reinterpret_cast<int64_t>(ctx);
+}
+
+extern "C" void sgl_musa_custom_ar_dispose_unregistered_context_raw(int64_t ctx_ptr) {
+  delete reinterpret_cast<PushLaunchContext*>(ctx_ptr);
+}
+
+extern "C" void sgl_musa_custom_ar_launch_unregistered_context_raw_nocheck(
+    int64_t ctx_ptr,
+    void* out,
+    int64_t numel,
+    int dtype_code,
+    int64_t stream_value,
+    int64_t shot) {
+  auto* ctx = reinterpret_cast<PushLaunchContext*>(ctx_ptr);
+  auto stream = reinterpret_cast<musaStream_t>(stream_value);
+  const int size = static_cast<int>(numel);
+  const int64_t nbytes = dtype_code == 2 ? numel * 4 : numel * 2;
+  if (shot != 0 && shot != 3) {
+    musaMemcpyAsync(ctx->self_buffer, ctx->input, static_cast<size_t>(nbytes), musaMemcpyDeviceToDevice, stream);
+  }
+
+  if (dtype_code == 0) {
+    dispatch_world_size(ctx->data, nullptr, ctx->sg, ctx->self_sg, static_cast<const half*>(ctx->input), static_cast<half*>(out), ctx->rank, ctx->world_size, size, static_cast<int>(shot), stream);
+  } else if (dtype_code == 1) {
+    dispatch_world_size(ctx->data, nullptr, ctx->sg, ctx->self_sg, static_cast<const __mt_bfloat16*>(ctx->input), static_cast<__mt_bfloat16*>(out), ctx->rank, ctx->world_size, size, static_cast<int>(shot), stream);
+  } else {
+    dispatch_world_size(ctx->data, nullptr, ctx->sg, ctx->self_sg, static_cast<const float*>(ctx->input), static_cast<float*>(out), ctx->rank, ctx->world_size, size, static_cast<int>(shot), stream);
+  }
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_musa_custom_ar_meta_size, sgl_musa_custom_ar_meta_size);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_musa_custom_ar_launch_empty, sgl_musa_custom_ar_launch_empty);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_musa_custom_ar_launch, sgl_musa_custom_ar_launch);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_musa_custom_ar_launch_unregistered, sgl_musa_custom_ar_launch_unregistered);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_musa_custom_ar_create_context, sgl_musa_custom_ar_create_context);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_musa_custom_ar_dispose_context, sgl_musa_custom_ar_dispose_context);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_musa_custom_ar_launch_context, sgl_musa_custom_ar_launch_context);

--- a/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/distributed/custom_all_reduce_pybind.cpp
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/distributed/custom_all_reduce_pybind.cpp
@@ -1,0 +1,103 @@
+#include <cstdint>
+
+#include <torch/extension.h>
+#include <torch/library.h>
+#include <torch_musa/csrc/aten/musa/MUSAContext.h>
+
+#ifndef SGL_CUSTOM_AR_TORCH_NS
+#define SGL_CUSTOM_AR_TORCH_NS sglang_musa_jit_ar
+#endif
+
+extern "C" void sgl_musa_custom_ar_launch_context_raw_nocheck(
+    int64_t ctx_ptr, void *out, int64_t numel, int dtype_code,
+    int64_t stream_value, int64_t shot);
+
+extern "C" void sgl_musa_custom_ar_launch_unregistered_raw_nocheck(
+    const int64_t *rank_ptrs, const int64_t *signal_ptrs, const void *inp,
+    void *out, int64_t self_signal_ptr, int64_t self_buffer_ptr, int64_t numel,
+    int dtype_code, int64_t stream_value, int64_t rank, int64_t world_size,
+    int64_t shot);
+
+extern "C" int64_t sgl_musa_custom_ar_create_unregistered_context_raw(
+    const int64_t *rank_ptrs, const int64_t *signal_ptrs, const void *inp,
+    int64_t self_signal_ptr, int64_t self_buffer_ptr, int64_t rank,
+    int64_t world_size);
+
+extern "C" void
+sgl_musa_custom_ar_dispose_unregistered_context_raw(int64_t ctx_ptr);
+
+extern "C" void sgl_musa_custom_ar_launch_unregistered_context_raw_nocheck(
+    int64_t ctx_ptr, void *out, int64_t numel, int dtype_code,
+    int64_t stream_value, int64_t shot);
+
+namespace {
+
+int dtype_code(torch::Tensor &out) {
+  switch (out.scalar_type()) {
+  case at::ScalarType::Half:
+    return 0;
+  case at::ScalarType::BFloat16:
+    return 1;
+  case at::ScalarType::Float:
+    return 2;
+  default:
+    TORCH_CHECK(false, "MUSA custom AR only supports fp16/bf16/fp32");
+  }
+}
+
+void launch_context(int64_t ctx_ptr, torch::Tensor out, int64_t shot) {
+  const auto stream = at::musa::getCurrentMUSAStream();
+  sgl_musa_custom_ar_launch_context_raw_nocheck(
+      ctx_ptr, out.data_ptr(), out.numel(), dtype_code(out),
+      reinterpret_cast<int64_t>(stream.stream()), shot);
+}
+
+void launch_unregistered(torch::Tensor rank_data, torch::Tensor signal_ptrs_cpu,
+                         torch::Tensor input, torch::Tensor out,
+                         int64_t self_signal_ptr, int64_t self_buffer_ptr,
+                         int64_t rank, int64_t world_size, int64_t shot) {
+  const auto stream = at::musa::getCurrentMUSAStream();
+  sgl_musa_custom_ar_launch_unregistered_raw_nocheck(
+      rank_data.data_ptr<int64_t>(), signal_ptrs_cpu.data_ptr<int64_t>(),
+      input.data_ptr(), out.data_ptr(), self_signal_ptr, self_buffer_ptr,
+      out.numel(), dtype_code(out), reinterpret_cast<int64_t>(stream.stream()),
+      rank, world_size, shot);
+}
+
+int64_t create_unregistered_context(torch::Tensor rank_data,
+                                    torch::Tensor signal_ptrs_cpu,
+                                    torch::Tensor input,
+                                    int64_t self_signal_ptr,
+                                    int64_t self_buffer_ptr, int64_t rank,
+                                    int64_t world_size) {
+  return sgl_musa_custom_ar_create_unregistered_context_raw(
+      rank_data.data_ptr<int64_t>(), signal_ptrs_cpu.data_ptr<int64_t>(),
+      input.data_ptr(), self_signal_ptr, self_buffer_ptr, rank, world_size);
+}
+
+void dispose_unregistered_context(int64_t ctx_ptr) {
+  sgl_musa_custom_ar_dispose_unregistered_context_raw(ctx_ptr);
+}
+
+void launch_unregistered_context(int64_t ctx_ptr, torch::Tensor out,
+                                 int64_t shot) {
+  const auto stream = at::musa::getCurrentMUSAStream();
+  sgl_musa_custom_ar_launch_unregistered_context_raw_nocheck(
+      ctx_ptr, out.data_ptr(), out.numel(), dtype_code(out),
+      reinterpret_cast<int64_t>(stream.stream()), shot);
+}
+
+} // namespace
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("launch_context", &launch_context);
+  m.def("launch_unregistered", &launch_unregistered);
+  m.def("create_unregistered_context", &create_unregistered_context);
+  m.def("dispose_unregistered_context", &dispose_unregistered_context);
+  m.def("launch_unregistered_context", &launch_unregistered_context);
+}
+
+TORCH_LIBRARY_FRAGMENT(SGL_CUSTOM_AR_TORCH_NS, m) {
+  m.def("launch_context(int ctx_ptr, Tensor! out, int shot) -> ()");
+  m.impl("launch_context", torch::kMUSA, &launch_context);
+}

--- a/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/distributed/custom_all_reduce_rmsnorm.mu
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/distributed/custom_all_reduce_rmsnorm.mu
@@ -1,0 +1,4825 @@
+#include "../common.h"
+#include "../device_utils.h"
+#include "../norm/common.mu"
+
+#include <musa_runtime.h>
+#include <musa_bf16.h>
+#include <musa_fp16.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+namespace {
+
+#ifndef SGL_CUSTOM_AR_THREADS
+#define SGL_CUSTOM_AR_THREADS 512
+#endif
+
+#ifndef SGL_CUSTOM_AR_BLOCKS
+#define SGL_CUSTOM_AR_BLOCKS 36
+#endif
+
+#ifndef SGL_CUSTOM_AR_VECTOR_LOAD
+#define SGL_CUSTOM_AR_VECTOR_LOAD 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_H8192_BLOCKS
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_H8192_BLOCKS 16
+#endif
+
+#ifndef SGL_CUSTOM_AR_ATOMIC_BARRIER
+#define SGL_CUSTOM_AR_ATOMIC_BARRIER 1
+#endif
+
+#ifndef SGL_CUSTOM_AR_MAX_BLOCKS
+#define SGL_CUSTOM_AR_MAX_BLOCKS 120
+#endif
+
+#ifndef SGL_CUSTOM_AR_DYNAMIC_BLOCKS
+#define SGL_CUSTOM_AR_DYNAMIC_BLOCKS 1
+#endif
+
+#ifndef SGL_CUSTOM_AR_RMSNORM_CACHE_HIDDEN_LIMIT
+#define SGL_CUSTOM_AR_RMSNORM_CACHE_HIDDEN_LIMIT 2048
+#endif
+
+#ifndef SGL_CUSTOM_AR_RMSNORM_T_CACHE_HIDDEN_LIMIT
+#define SGL_CUSTOM_AR_RMSNORM_T_CACHE_HIDDEN_LIMIT 8192
+#endif
+
+#ifndef SGL_CUSTOM_AR_RMSNORM_WEIGHT_CACHE_HIDDEN_LIMIT
+#define SGL_CUSTOM_AR_RMSNORM_WEIGHT_CACHE_HIDDEN_LIMIT 8192
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_TOKEN_2STAGE
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_TOKEN_2STAGE 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_SHFL_2STAGE
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_SHFL_2STAGE 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_PACKED_1STAGE
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_PACKED_1STAGE 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_SAFE_PACKED_1STAGE
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_SAFE_PACKED_1STAGE 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_VEC2RANK_1STAGE
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_VEC2RANK_1STAGE 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_PARTIAL_PACKED_NON8
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_PARTIAL_PACKED_NON8 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_VEC2_NON8
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_VEC2_NON8 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_VEC4_NON8
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_VEC4_NON8 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_REGCACHE_2RANK
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_REGCACHE_2RANK 1
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_ROW_WEIGHT_CACHE
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_ROW_WEIGHT_CACHE 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_ROW_WEIGHT_CACHE_MIN_ROWS
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_ROW_WEIGHT_CACHE_MIN_ROWS 2048
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_ROW_SHARED_INV_RMS
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_ROW_SHARED_INV_RMS 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_ROW_WARP_INV_RMS
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_ROW_WARP_INV_RMS 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_ROW_SKIP_END_BARRIER
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_ROW_SKIP_END_BARRIER 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_SUMS_BYPASS_LOAD
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_SUMS_BYPASS_LOAD 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_SMALL_ROWS
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_SMALL_ROWS 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_WARP_ROWS
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_WARP_ROWS 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_POLLING
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_POLLING 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_MIN_ROWS
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_MIN_ROWS 1
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_MAX_ROWS
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_MAX_ROWS 128
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_SLOTS
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_SLOTS 2
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_SKIP_END_BARRIER
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_SKIP_END_BARRIER 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_LAMPORT_PUSH
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_LAMPORT_PUSH 0
+#endif
+
+#ifndef SGL_CUSTOM_AR_FUSED_RMSNORM_LAMPORT_END_BARRIER
+#define SGL_CUSTOM_AR_FUSED_RMSNORM_LAMPORT_END_BARRIER 1
+#endif
+
+#ifndef SGL_CUSTOM_AR_PUSH_16B_ASM
+#define SGL_CUSTOM_AR_PUSH_16B_ASM 0
+#endif
+
+constexpr int kMaxBlocks = SGL_CUSTOM_AR_MAX_BLOCKS;
+constexpr int kMaxThreadsPerBlock = 1024;
+constexpr int kDefaultThreads = SGL_CUSTOM_AR_THREADS;
+constexpr int kDefaultBlockLimit = SGL_CUSTOM_AR_BLOCKS;
+constexpr int kH4096BlockLimit = 32;
+constexpr int kH8192BlockLimit = SGL_CUSTOM_AR_FUSED_RMSNORM_H8192_BLOCKS;
+constexpr int kCacheHiddenLimit = SGL_CUSTOM_AR_RMSNORM_CACHE_HIDDEN_LIMIT;
+constexpr int kTypedCacheHiddenLimit = SGL_CUSTOM_AR_RMSNORM_T_CACHE_HIDDEN_LIMIT;
+constexpr int kWeightCacheHiddenLimit = SGL_CUSTOM_AR_RMSNORM_WEIGHT_CACHE_HIDDEN_LIMIT;
+constexpr bool kRowSharedInvRms = SGL_CUSTOM_AR_FUSED_RMSNORM_ROW_SHARED_INV_RMS != 0;
+constexpr bool kRowWarpInvRms = SGL_CUSTOM_AR_FUSED_RMSNORM_ROW_WARP_INV_RMS != 0;
+constexpr bool kRowSkipEndBarrier =
+    SGL_CUSTOM_AR_FUSED_RMSNORM_ROW_SKIP_END_BARRIER != 0;
+constexpr int kMaxRanks = 8;
+constexpr int kOneShotMaxToken = 128;
+using FlagType = uint32_t;
+
+__device__ __host__ __forceinline__ bool rmsnorm_cache_weight_hidden(
+    int hidden,
+    int rows) {
+  return (hidden == 8192 || hidden == 1536) && hidden <= kWeightCacheHiddenLimit;
+}
+
+struct alignas(128) Signal {
+  alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
+  alignas(128) FlagType peer_counter[2][kMaxBlocks][kMaxRanks];
+  alignas(128) FlagType push_epoch[kMaxBlocks];
+  alignas(128) FlagType lamport_counter;
+  alignas(128) FlagType lamport_flag;
+  alignas(128) FlagType lamport_clear_packed;
+};
+
+struct __align__(16) RankData {
+  const void* ptrs[kMaxRanks];
+};
+
+struct __align__(16) RankSignals {
+  Signal* signals[kMaxRanks];
+};
+
+__global__ void reset_signal_kernel(Signal* signal) {
+  auto* words = reinterpret_cast<uint32_t*>(signal);
+  constexpr int words_count = static_cast<int>(sizeof(Signal) / sizeof(uint32_t));
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < words_count;
+       idx += blockDim.x * gridDim.x) {
+    words[idx] = 0;
+  }
+}
+
+int get_musa_sm_count() {
+  static int sm_count = 0;
+  if (sm_count == 0) {
+    int device_id = 0;
+    if (musaGetDevice(&device_id) == musaSuccess) {
+      int queried = 0;
+      if (musaDeviceGetAttribute(
+              &queried, musaDevAttrMultiProcessorCount, device_id) ==
+              musaSuccess &&
+          queried > 0) {
+        sm_count = queried;
+      }
+    }
+    if (sm_count <= 0) {
+      sm_count = kDefaultBlockLimit;
+    }
+  }
+  return sm_count;
+}
+
+template <typename T, int sz>
+struct __align__(alignof(T) * sz) array_t {
+  T data[sz];
+  using type = T;
+  static constexpr int size = sz;
+};
+
+template <typename T>
+struct packed_t {
+  using P = array_t<T, 16 / sizeof(T)>;
+  using A = array_t<float, 16 / sizeof(T)>;
+};
+
+template <typename T>
+struct fp_trait {};
+
+template <>
+struct fp_trait<half> {
+  using type = uint16_t;
+  static constexpr uint16_t pos_zero = 0x0000u;
+  static constexpr uint16_t neg_zero = 0x8000u;
+};
+
+template <>
+struct fp_trait<__mt_bfloat16> {
+  using type = uint16_t;
+  static constexpr uint16_t pos_zero = 0x0000u;
+  static constexpr uint16_t neg_zero = 0x8000u;
+};
+
+template <>
+struct fp_trait<float> {
+  using type = uint32_t;
+  static constexpr uint32_t pos_zero = 0x00000000u;
+  static constexpr uint32_t neg_zero = 0x80000000u;
+};
+
+template <typename DType>
+__device__ __forceinline__ void clear_pos_zero(DType& val) {
+  using Trait = fp_trait<DType>;
+  auto* ptr = reinterpret_cast<typename Trait::type*>(&val);
+  if (*ptr == Trait::pos_zero) {
+    *ptr = Trait::neg_zero;
+  }
+}
+
+template <typename DType>
+__device__ __forceinline__ bool is_pos_zero(const DType& val) {
+  using Trait = fp_trait<DType>;
+  const auto* ptr = reinterpret_cast<const typename Trait::type*>(&val);
+  return *ptr == Trait::pos_zero;
+}
+
+template <typename DType>
+__device__ __forceinline__ DType get_pos_zero() {
+  using Trait = fp_trait<DType>;
+  const auto value = Trait::pos_zero;
+  return *reinterpret_cast<const DType*>(&value);
+}
+
+template <typename T, int N>
+__device__ __forceinline__ void clear_pos_zero(array_t<T, N>& val) {
+#pragma unroll
+  for (int i = 0; i < N; ++i) {
+    clear_pos_zero(val.data[i]);
+  }
+}
+
+template <typename T, int N>
+__device__ __forceinline__ bool has_pos_zero(array_t<T, N> val) {
+  bool found = false;
+#pragma unroll
+  for (int i = 0; i < N; ++i) {
+    found |= is_pos_zero(val.data[i]);
+  }
+  return found;
+}
+
+template <typename P>
+__device__ __forceinline__ P make_pos_zero_packet() {
+  P out;
+#pragma unroll
+  for (int i = 0; i < P::size; ++i) {
+    out.data[i] = get_pos_zero<typename P::type>();
+  }
+  return out;
+}
+
+template <typename P>
+__device__ __forceinline__ P load_volatile_packet(const P* ptr) {
+  static_assert(sizeof(P) == 16 && alignof(P) == 16);
+#if SGL_CUSTOM_AR_PUSH_16B_ASM
+  using i4 = int __attribute__((ext_vector_type(4)));
+  uint4 raw;
+#if defined(__MUSA_ARCH__) && (__MUSA_ARCH__ == 310)
+  i4 tmp = __musa_ldcv_v4i32(reinterpret_cast<const i4*>(ptr));
+  raw = *reinterpret_cast<uint4*>(&tmp);
+#else
+  raw = *reinterpret_cast<const uint4*>(ptr);
+#endif
+  return *reinterpret_cast<const P*>(&raw);
+#else
+  uint4 raw;
+  const auto* src = reinterpret_cast<const volatile uint32_t*>(ptr);
+  raw.x = src[0];
+  raw.y = src[1];
+  raw.z = src[2];
+  raw.w = src[3];
+  return *reinterpret_cast<const P*>(&raw);
+#endif
+}
+
+template <typename P>
+__device__ __forceinline__ void store_volatile_packet(P* ptr, P value) {
+  static_assert(sizeof(P) == 16 && alignof(P) == 16);
+  const auto raw = *reinterpret_cast<const uint4*>(&value);
+#if SGL_CUSTOM_AR_PUSH_16B_ASM
+  using i4 = int __attribute__((ext_vector_type(4)));
+#if defined(__MUSA_ARCH__) && (__MUSA_ARCH__ == 310)
+  __musa_stwb_v4i32(*reinterpret_cast<const i4*>(&raw), reinterpret_cast<i4*>(ptr));
+#else
+  *reinterpret_cast<uint4*>(ptr) = raw;
+#endif
+#else
+  auto* dst = reinterpret_cast<volatile uint32_t*>(ptr);
+  dst[0] = raw.x;
+  dst[1] = raw.y;
+  dst[2] = raw.z;
+  dst[3] = raw.w;
+#endif
+}
+
+__device__ __forceinline__ float upcast_s(half value) {
+  return __half2float(value);
+}
+
+__device__ __forceinline__ float upcast_s(__mt_bfloat16 value) {
+  return __bfloat162float(value);
+}
+
+__device__ __forceinline__ float upcast_s(float value) {
+  return value;
+}
+
+template <typename T>
+__device__ __forceinline__ T downcast_s(float value);
+
+template <>
+__device__ __forceinline__ half downcast_s<half>(float value) {
+  return __float2half(value);
+}
+
+template <>
+__device__ __forceinline__ __mt_bfloat16 downcast_s<__mt_bfloat16>(float value) {
+  return __float2bfloat16(value);
+}
+
+template <>
+__device__ __forceinline__ float downcast_s<float>(float value) {
+  return value;
+}
+
+template <typename T>
+__device__ __forceinline__ T& assign_add(T& a, T b) {
+  a = downcast_s<T>(upcast_s(a) + upcast_s(b));
+  return a;
+}
+
+template <>
+__device__ __forceinline__ float& assign_add<float>(float& a, float b) {
+  a += b;
+  return a;
+}
+
+template <typename T, int N>
+__device__ __forceinline__ array_t<T, N>& packed_assign_add(array_t<T, N>& a, array_t<T, N> b) {
+#pragma unroll
+  for (int i = 0; i < N; ++i) {
+    assign_add(a.data[i], b.data[i]);
+  }
+  return a;
+}
+
+template <typename T, int N>
+__device__ __forceinline__ array_t<float, N> upcast(array_t<T, N> value) {
+  if constexpr (std::is_same<T, float>::value) {
+    return value;
+  } else {
+    array_t<float, N> out;
+#pragma unroll
+    for (int i = 0; i < N; ++i) {
+      out.data[i] = upcast_s(value.data[i]);
+    }
+    return out;
+  }
+}
+
+template <typename O>
+__device__ __forceinline__ O downcast(array_t<float, O::size> value) {
+  if constexpr (std::is_same<typename O::type, float>::value) {
+    return value;
+  } else {
+    O out;
+#pragma unroll
+    for (int i = 0; i < O::size; ++i) {
+      out.data[i] = downcast_s<typename O::type>(value.data[i]);
+    }
+    return out;
+  }
+}
+
+template <typename P, int nranks, typename A>
+__device__ __forceinline__ P packed_reduce(const P* ptrs[], int idx) {
+  A tmp = upcast(ptrs[0][idx]);
+#pragma unroll
+  for (int i = 1; i < nranks; ++i) {
+    packed_assign_add(tmp, upcast(ptrs[i][idx]));
+  }
+  return downcast<P>(tmp);
+}
+
+template <typename P>
+__device__ __forceinline__ P* get_tmp_buf(Signal* signal) {
+  return reinterpret_cast<P*>(signal + 1);
+}
+
+template <typename T, int nranks, int vlen = 8>
+__device__ __forceinline__ void shfl_reduce(float* res) {
+  if constexpr (nranks >= 4) {
+#pragma unroll
+    for (int i = 0; i < vlen; ++i) {
+      res[i] += __shfl_xor_sync(0xffffffff, res[i], 16);
+    }
+  }
+#pragma unroll
+  for (int i = 0; i < vlen; ++i) {
+    res[i] += __shfl_xor_sync(0xffffffff, res[i], 8);
+  }
+}
+
+__device__ __forceinline__ float warp_sum(float value) {
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_down_sync(0xffffffff, value, offset, 32);
+  }
+  return value;
+}
+
+__device__ __forceinline__ float block_rms_scale_16warps(
+    float value,
+    float* warp_sums,
+    float* inv_rms,
+    float inv_hidden,
+    float eps) {
+  const int tid = static_cast<int>(threadIdx.x);
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_down_sync(0xffffffff, value, offset, 32);
+  }
+  if (lane == 0) {
+    warp_sums[warp] = value;
+  }
+  __syncthreads_lm();
+
+  value = lane < 16 ? warp_sums[lane] : 0.0f;
+  if (warp == 0) {
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      value += __shfl_down_sync(0xffffffff, value, offset, 32);
+    }
+    if (lane == 0) {
+      *inv_rms = fast_rsqrt(value * inv_hidden + eps);
+    }
+  }
+  __syncthreads_lm();
+  return *inv_rms;
+}
+
+__device__ __forceinline__ float block_sum_16warps_tid0(float value, float* warp_sums) {
+  const int tid = static_cast<int>(threadIdx.x);
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_down_sync(0xffffffff, value, offset, 32);
+  }
+  if (lane == 0) {
+    warp_sums[warp] = value;
+  }
+  __syncthreads_lm();
+
+  value = lane < 16 ? warp_sums[lane] : 0.0f;
+  if (warp == 0) {
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      value += __shfl_down_sync(0xffffffff, value, offset, 32);
+    }
+  }
+  return value;
+}
+
+__device__ __forceinline__ float block_sum_12warps(float value, float* warp_sums) {
+  const int tid = static_cast<int>(threadIdx.x);
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_down_sync(0xffffffff, value, offset, 32);
+  }
+  if (lane == 0 && warp < 12) {
+    warp_sums[warp] = value;
+  }
+  __syncthreads_lm();
+
+  value = lane < 12 ? warp_sums[lane] : 0.0f;
+  if (warp == 0) {
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      value += __shfl_down_sync(0xffffffff, value, offset, 32);
+    }
+    if (lane == 0) {
+      warp_sums[0] = value;
+    }
+  }
+  __syncthreads_lm();
+  return warp_sums[0];
+}
+
+__device__ __forceinline__ float block_sum_12warps_tid0(float value, float* warp_sums) {
+  const int tid = static_cast<int>(threadIdx.x);
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_down_sync(0xffffffff, value, offset, 32);
+  }
+  if (lane == 0 && warp < 12) {
+    warp_sums[warp] = value;
+  }
+  __syncthreads_lm();
+
+  value = lane < 12 ? warp_sums[lane] : 0.0f;
+  if (warp == 0) {
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      value += __shfl_down_sync(0xffffffff, value, offset, 32);
+    }
+  }
+  return value;
+}
+
+template <int kActiveWarps>
+__device__ __forceinline__ float block_sum_nwarps(float value, float* warp_sums) {
+  const int tid = static_cast<int>(threadIdx.x);
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_down_sync(0xffffffff, value, offset, 32);
+  }
+  if (lane == 0 && warp < kActiveWarps) {
+    warp_sums[warp] = value;
+  }
+  __syncthreads_lm();
+
+  value = lane < kActiveWarps ? warp_sums[lane] : 0.0f;
+  if (warp == 0) {
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      value += __shfl_down_sync(0xffffffff, value, offset, 32);
+    }
+    if (lane == 0) {
+      warp_sums[0] = value;
+    }
+  }
+  __syncthreads_lm();
+  return warp_sums[0];
+}
+
+template <int kActiveWarps>
+__device__ __forceinline__ float block_sum_nwarps_tid0(
+    float value,
+    float* warp_sums) {
+  const int tid = static_cast<int>(threadIdx.x);
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_down_sync(0xffffffff, value, offset, 32);
+  }
+  if (lane == 0 && warp < kActiveWarps) {
+    warp_sums[warp] = value;
+  }
+  __syncthreads_lm();
+
+  value = lane < kActiveWarps ? warp_sums[lane] : 0.0f;
+  if (warp == 0) {
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      value += __shfl_down_sync(0xffffffff, value, offset, 32);
+    }
+  }
+  return value;
+}
+
+__device__ __forceinline__ float block_sum_tid0(float value, float* warp_sums) {
+  const int tid = static_cast<int>(threadIdx.x);
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int num_warps = (static_cast<int>(blockDim.x) + 31) >> 5;
+
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_down_sync(0xffffffff, value, offset, 32);
+  }
+  if (lane == 0) {
+    warp_sums[warp] = value;
+  }
+  __syncthreads_lm();
+
+  value = tid < num_warps ? warp_sums[lane] : 0.0f;
+  if (warp == 0) {
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      value += __shfl_down_sync(0xffffffff, value, offset, 32);
+    }
+  }
+  return value;
+}
+
+__device__ __forceinline__ float row_group_sum_tid0(
+    float value,
+    float* warp_sums,
+    int packed_hidden) {
+  const int tid = static_cast<int>(threadIdx.x);
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int tid_in_row = tid % packed_hidden;
+  const int row_group = tid / packed_hidden;
+  const int warp_in_row = tid_in_row >> 5;
+  const int warps_per_row = packed_hidden >> 5;
+
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_down_sync(0xffffffff, value, offset, 32);
+  }
+  if (lane == 0) {
+    warp_sums[warp] = value;
+  }
+  __syncthreads_lm();
+
+  value =
+      (warp_in_row == 0 && lane < warps_per_row)
+          ? warp_sums[row_group * warps_per_row + lane]
+          : 0.0f;
+  if (warp_in_row == 0) {
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      value += __shfl_down_sync(0xffffffff, value, offset, 32);
+    }
+  }
+  return value;
+}
+
+__device__ __forceinline__ float row_group_sum_all(
+    float value,
+    float* warp_sums,
+    int packed_hidden) {
+  const int tid = static_cast<int>(threadIdx.x);
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int row_group = tid / packed_hidden;
+  const int warps_per_row = packed_hidden >> 5;
+
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_down_sync(0xffffffff, value, offset, 32);
+  }
+  if (lane == 0) {
+    warp_sums[warp] = value;
+  }
+  __syncthreads_lm();
+
+  float sum = 0.0f;
+#pragma unroll
+  for (int i = 0; i < 8; ++i) {
+    if (i < warps_per_row) {
+      sum += warp_sums[row_group * warps_per_row + i];
+    }
+  }
+  __syncthreads_lm();
+  return sum;
+}
+
+__device__ __forceinline__ float row_group_rms_scale_shared(
+    float value,
+    float* warp_sums,
+    float* inv_rms,
+    float inv_hidden,
+    float eps,
+    int packed_hidden) {
+  const int tid = static_cast<int>(threadIdx.x);
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int warps_per_row = packed_hidden >> 5;
+
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_down_sync(0xffffffff, value, offset, 32);
+  }
+  if (lane == 0) {
+    warp_sums[warp] = value;
+  }
+  __syncthreads_lm();
+
+  value = lane < warps_per_row ? warp_sums[lane] : 0.0f;
+  if (warp == 0) {
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      value += __shfl_down_sync(0xffffffff, value, offset, 32);
+    }
+    if (lane == 0) {
+      *inv_rms = fast_rsqrt(value * inv_hidden + eps);
+    }
+  }
+  __syncthreads_lm();
+  return *inv_rms;
+}
+
+__device__ __forceinline__ float row_group_sum_all_wide(
+    float value,
+    float* warp_sums,
+    int packed_hidden) {
+  const int tid = static_cast<int>(threadIdx.x);
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int row_group = tid / packed_hidden;
+  const int warps_per_row = packed_hidden >> 5;
+
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_down_sync(0xffffffff, value, offset, 32);
+  }
+  if (lane == 0) {
+    warp_sums[warp] = value;
+  }
+  __syncthreads_lm();
+
+  float sum = 0.0f;
+#pragma unroll
+  for (int i = 0; i < 32; ++i) {
+    if (i < warps_per_row) {
+      sum += warp_sums[row_group * warps_per_row + i];
+    }
+  }
+  __syncthreads_lm();
+  return sum;
+}
+
+constexpr size_t align_up(size_t value, size_t alignment) {
+  return (value + alignment - 1) / alignment * alignment;
+}
+
+__device__ __forceinline__ void signal_store(FlagType* ptr, FlagType value) {
+  volatile_store(static_cast<uint32_t>(value), reinterpret_cast<uint32_t*>(ptr));
+}
+
+__device__ __forceinline__ void signal_store_volatile(FlagType* ptr, FlagType value) {
+  *reinterpret_cast<volatile FlagType*>(ptr) = value;
+}
+
+__device__ __forceinline__ FlagType signal_load(FlagType* ptr) {
+  flushInv_byp();
+  return static_cast<uint32_t>(volatile_load(reinterpret_cast<uint32_t*>(ptr)));
+}
+
+__device__ __forceinline__ FlagType signal_load_volatile(FlagType* ptr) {
+  return *reinterpret_cast<volatile FlagType*>(ptr);
+}
+
+template <int nranks, bool start, bool fence = false>
+__device__ __forceinline__ void multi_rank_barrier(const RankSignals& sg, Signal* self_sg, int rank) {
+  static_assert(!(start && fence));
+  if constexpr (!start) {
+    __syncthreads_lm();
+  }
+  if (threadIdx.x < nranks) {
+#if SGL_CUSTOM_AR_ATOMIC_BARRIER
+    auto flag = atomicAdd(&self_sg->self_counter[blockIdx.x][threadIdx.x], 1) + 1;
+    auto* peer = &sg.signals[threadIdx.x]->peer_counter[flag & 1][blockIdx.x][rank];
+    auto* local = &self_sg->peer_counter[flag & 1][blockIdx.x][threadIdx.x];
+    atomicExch(peer, flag);
+    while (atomicAdd(local, 0) != flag) {
+    }
+#else
+    auto flag = self_sg->self_counter[blockIdx.x][threadIdx.x] + 1;
+    self_sg->self_counter[blockIdx.x][threadIdx.x] = flag;
+    auto* peer = &sg.signals[threadIdx.x]->peer_counter[flag & 1][blockIdx.x][rank];
+    auto* local = &self_sg->peer_counter[flag & 1][blockIdx.x][threadIdx.x];
+    if constexpr (fence) {
+      signal_store(peer, flag);
+      while (signal_load(local) != flag) {
+      }
+    } else {
+      signal_store_volatile(peer, flag);
+      while (signal_load_volatile(local) != flag) {
+      }
+    }
+#endif
+  }
+  if constexpr (start || fence) {
+    __syncthreads_lm();
+  }
+}
+
+template <typename T, int nranks>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1)
+custom_all_reduce_residual_rmsnorm_kernel(
+    RankData data,
+    const RankData* data_ptr,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* __restrict__ residual_in,
+    T* __restrict__ residual_out,
+    T* __restrict__ norm_out,
+    const T* __restrict__ weight,
+    int rank,
+    int rows,
+    int hidden,
+    float eps) {
+  if (data_ptr != nullptr) {
+    data = *data_ptr;
+  }
+  extern __shared__ __align__(16) unsigned char smem[];
+  __shared__ float inv_rms;
+  const int tid = threadIdx.x;
+  const bool cache_float_values =
+      hidden <= kCacheHiddenLimit &&
+      !(nranks == 2 && hidden == 2048) &&
+      !(nranks == 2 && hidden == 4096 && rows < 2048);
+  const bool cache_t_values =
+      !cache_float_values && !(nranks == 2 && hidden == 2048) &&
+      hidden != 4096 && hidden <= kTypedCacheHiddenLimit;
+  const bool cache_weight = rmsnorm_cache_weight_hidden(hidden, rows);
+  float* cached = reinterpret_cast<float*>(smem);
+  T* cached_t = reinterpret_cast<T*>(smem);
+  const size_t cache_bytes =
+      cache_float_values
+          ? static_cast<size_t>(hidden) * sizeof(float)
+          : (cache_t_values ? static_cast<size_t>(hidden) * sizeof(T) : 0);
+  const size_t weight_offset = align_up(cache_bytes, alignof(T));
+  T* cached_weight = reinterpret_cast<T*>(smem + weight_offset);
+  const size_t weight_bytes = cache_weight ? static_cast<size_t>(hidden) * sizeof(T) : 0;
+  float* warp_sums =
+      reinterpret_cast<float*>(smem + align_up(weight_offset + weight_bytes, alignof(float)));
+  using P = typename packed_t<T>::P;
+  using A = typename packed_t<T>::A;
+  constexpr int pack = P::size;
+  const int packed_hidden = hidden / pack;
+  const bool use_packed =
+      (SGL_CUSTOM_AR_FUSED_RMSNORM_PACKED_1STAGE ||
+       SGL_CUSTOM_AR_FUSED_RMSNORM_SAFE_PACKED_1STAGE ||
+       SGL_CUSTOM_AR_FUSED_RMSNORM_VEC2RANK_1STAGE) &&
+      (hidden % pack) == 0;
+  const bool use_partial_packed_non8 =
+      (nranks == 4 || nranks == 8) && !use_packed &&
+      SGL_CUSTOM_AR_FUSED_RMSNORM_VEC2RANK_1STAGE &&
+      SGL_CUSTOM_AR_FUSED_RMSNORM_PARTIAL_PACKED_NON8 &&
+      hidden >= pack;
+  const bool use_vec4_non8 =
+      (nranks == 4 || nranks == 8) && !use_packed &&
+      SGL_CUSTOM_AR_FUSED_RMSNORM_VEC4_NON8 &&
+      !use_partial_packed_non8 && sizeof(T) == 2 && ((hidden & 3) == 0);
+  const bool use_vec2_non8 =
+      (nranks == 4 || nranks == 8) && !use_packed &&
+      SGL_CUSTOM_AR_FUSED_RMSNORM_VEC2_NON8 &&
+      !use_partial_packed_non8 && !use_vec4_non8 && sizeof(T) == 2 &&
+      ((hidden & 1) == 0);
+
+  const P* ptrs[nranks];
+#pragma unroll
+  for (int i = 0; i < nranks; ++i) {
+    ptrs[i] = reinterpret_cast<const P*>(data.ptrs[i]);
+  }
+
+  if (cache_weight && use_packed) {
+    for (int packed_col = tid; packed_col < packed_hidden; packed_col += blockDim.x) {
+      const int col0 = packed_col * pack;
+      *(Vec8<T>*)(cached_weight + col0) = Vec8<T>::load(weight, col0);
+    }
+  }
+
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+
+  if constexpr (nranks == 2) {
+    if (SGL_CUSTOM_AR_FUSED_RMSNORM_VEC2RANK_1STAGE &&
+        hidden <= 2048 && (hidden % pack) == 0 &&
+        (blockDim.x % packed_hidden) == 0) {
+      const int rows_per_block = blockDim.x / packed_hidden;
+      const int row_slot = tid / packed_hidden;
+      const int packed_col = tid - row_slot * packed_hidden;
+      const auto* local = reinterpret_cast<const P*>(data.ptrs[rank]);
+      const auto* peer = reinterpret_cast<const P*>(data.ptrs[rank ^ 1]);
+      const auto* residual = reinterpret_cast<const P*>(residual_in);
+      auto* residual_dst = reinterpret_cast<P*>(residual_out);
+      auto* norm_dst = reinterpret_cast<P*>(norm_out);
+      const auto* weight_vec = reinterpret_cast<const P*>(weight);
+
+      for (int row_base = blockIdx.x * rows_per_block; row_base < rows;
+           row_base += gridDim.x * rows_per_block) {
+        const int row = row_base + row_slot;
+        float values[pack] = {0.0f};
+        float square_sum = 0.0f;
+        P residual_packet_out;
+        if (row < rows) {
+          const int packed_idx = row * packed_hidden + packed_col;
+          const P local_vec = local[packed_idx];
+          const P peer_vec = peer[packed_idx];
+          const P residual_vec = residual[packed_idx];
+#pragma unroll
+          for (int i = 0; i < pack; ++i) {
+            float val = upcast_s(local_vec.data[i]);
+            val += upcast_s(peer_vec.data[i]);
+            val += upcast_s(residual_vec.data[i]);
+            values[i] = val;
+            residual_packet_out.data[i] = downcast_s<T>(val);
+            square_sum += val * val;
+          }
+          residual_dst[packed_idx] = residual_packet_out;
+        }
+
+        const float row_square_sum =
+            row_group_sum_all(square_sum, warp_sums, packed_hidden);
+        const float scale =
+            fast_rsqrt(row_square_sum / static_cast<float>(hidden) + eps);
+
+        if (row < rows) {
+          const int packed_idx = row * packed_hidden + packed_col;
+          const P w = weight_vec[packed_col];
+          P norm_packet;
+#pragma unroll
+          for (int i = 0; i < pack; ++i) {
+            const float gamma = upcast_s(w.data[i]);
+            norm_packet.data[i] =
+                downcast_s<T>(values[i] * scale * gamma);
+          }
+          norm_dst[packed_idx] = norm_packet;
+        }
+      }
+      if constexpr (!kRowSkipEndBarrier) {
+        multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+      }
+      return;
+    }
+  }
+
+  if constexpr (nranks == 4 || nranks == 8) {
+    if (SGL_CUSTOM_AR_FUSED_RMSNORM_VEC2RANK_1STAGE &&
+        hidden <= 2048 && (hidden % pack) == 0 &&
+        blockDim.x >= packed_hidden && (blockDim.x % packed_hidden) == 0) {
+      const int rows_per_block = blockDim.x / packed_hidden;
+      const int row_slot = tid / packed_hidden;
+      const int packed_col = tid - row_slot * packed_hidden;
+      const int col0 = packed_col * pack;
+      for (int row_base = blockIdx.x * rows_per_block; row_base < rows;
+           row_base += gridDim.x * rows_per_block) {
+        const int row = row_base + row_slot;
+        Float8 sum_float;
+        float square_sum_row = 0.0f;
+        if (row < rows) {
+          float acc[pack] = {0.0f};
+#pragma unroll
+          for (int r = 0; r < nranks; ++r) {
+            const auto* peer = reinterpret_cast<const T*>(data.ptrs[r]);
+            Vec8<T> x = Vec8<T>::load(peer + row * hidden, col0);
+#pragma unroll
+            for (int i = 0; i < pack; ++i) {
+              acc[i] += to_float<T>(x.val.elem[i]);
+            }
+          }
+          Vec8<T> residual_vec = Vec8<T>::load(residual_in + row * hidden, col0);
+          Vec8<T> residual_vec_out;
+#pragma unroll
+          for (int i = 0; i < pack; ++i) {
+            float val = acc[i] + to_float<T>(residual_vec.val.elem[i]);
+            sum_float.val.elem[i] = val;
+            residual_vec_out.val.elem[i] = from_float<T>(val);
+            square_sum_row += val * val;
+          }
+          *(Vec8<T>*)(residual_out + row * hidden + col0) = residual_vec_out;
+        }
+
+        const float row_square_sum =
+            row_group_sum_all(square_sum_row, warp_sums, packed_hidden);
+        const float scale =
+            fast_rsqrt(row_square_sum / static_cast<float>(hidden) + eps);
+
+        if (row < rows) {
+          Vec8<T> w = Vec8<T>::load(weight, col0);
+          Vec8<T> dst;
+#pragma unroll
+          for (int i = 0; i < pack; ++i) {
+            const float gamma = to_float<T>(w.val.elem[i]);
+            dst.val.elem[i] =
+                from_float<T>(sum_float.val.elem[i] * scale * gamma);
+          }
+          *(Vec8<T>*)(norm_out + row * hidden + col0) = dst;
+        }
+      }
+      if constexpr (!kRowSkipEndBarrier) {
+        multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+      }
+      return;
+    }
+
+    if (SGL_CUSTOM_AR_FUSED_RMSNORM_VEC2RANK_1STAGE &&
+        (hidden == 4096 || hidden == 8192) && (hidden % pack) == 0 &&
+        blockDim.x >= packed_hidden && (blockDim.x % packed_hidden) == 0) {
+      const int rows_per_block = static_cast<int>(blockDim.x) / packed_hidden;
+      const int row_slot = tid / packed_hidden;
+      const int packed_col = tid - row_slot * packed_hidden;
+      const int col0 = packed_col * pack;
+      for (int row_base = blockIdx.x * rows_per_block; row_base < rows;
+           row_base += gridDim.x * rows_per_block) {
+        const int row = row_base + row_slot;
+        Float8 sum_float;
+        float square_sum_row = 0.0f;
+        if (row < rows) {
+          float acc[pack] = {0.0f};
+#pragma unroll
+          for (int r = 0; r < nranks; ++r) {
+            const auto* peer = reinterpret_cast<const T*>(data.ptrs[r]);
+            Vec8<T> x = Vec8<T>::load(peer + row * hidden, col0);
+#pragma unroll
+            for (int i = 0; i < pack; ++i) {
+              acc[i] += to_float<T>(x.val.elem[i]);
+            }
+          }
+          Vec8<T> residual_vec = Vec8<T>::load(residual_in + row * hidden, col0);
+          Vec8<T> residual_vec_out;
+#pragma unroll
+          for (int i = 0; i < pack; ++i) {
+            float val = acc[i] + to_float<T>(residual_vec.val.elem[i]);
+            sum_float.val.elem[i] = val;
+            residual_vec_out.val.elem[i] = from_float<T>(val);
+            square_sum_row += val * val;
+          }
+          *(Vec8<T>*)(residual_out + row * hidden + col0) = residual_vec_out;
+        }
+
+        const float row_square_sum =
+            packed_hidden <= 256
+                ? row_group_sum_all(square_sum_row, warp_sums, packed_hidden)
+                : row_group_sum_all_wide(square_sum_row, warp_sums, packed_hidden);
+        const float scale =
+            fast_rsqrt(row_square_sum / static_cast<float>(hidden) + eps);
+
+        if (row < rows) {
+          Vec8<T> w = Vec8<T>::load(weight, col0);
+          Vec8<T> dst;
+#pragma unroll
+          for (int i = 0; i < pack; ++i) {
+            const float gamma = to_float<T>(w.val.elem[i]);
+            dst.val.elem[i] =
+                from_float<T>(sum_float.val.elem[i] * scale * gamma);
+          }
+          *(Vec8<T>*)(norm_out + row * hidden + col0) = dst;
+        }
+      }
+      if constexpr (!kRowSkipEndBarrier) {
+        multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+      }
+      return;
+    }
+  }
+
+  for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+    const int base = row * hidden;
+    float square_sum = 0.0f;
+    if constexpr (nranks == 2) {
+      if (SGL_CUSTOM_AR_FUSED_RMSNORM_REGCACHE_2RANK &&
+          (hidden % pack) == 0 && blockDim.x == packed_hidden &&
+          packed_hidden <= kMaxThreadsPerBlock &&
+          (hidden == 4096 || (hidden & (hidden - 1)) != 0)) {
+        const auto* local = reinterpret_cast<const T*>(data.ptrs[rank]);
+        const auto* peer = reinterpret_cast<const T*>(data.ptrs[rank ^ 1]);
+        const int col0 = tid * pack;
+        Float8 sum_float;
+        Vec8<T> local_vec = Vec8<T>::load(local + base, col0);
+        Vec8<T> peer_vec = Vec8<T>::load(peer + base, col0);
+        Vec8<T> residual_vec = Vec8<T>::load(residual_in + base, col0);
+        Vec8<T> residual_vec_out;
+#pragma unroll
+        for (int i = 0; i < pack; ++i) {
+          float val = to_float<T>(local_vec.val.elem[i]);
+          val += to_float<T>(peer_vec.val.elem[i]);
+          val += to_float<T>(residual_vec.val.elem[i]);
+          sum_float.val.elem[i] = val;
+          residual_vec_out.val.elem[i] = from_float<T>(val);
+          square_sum += val * val;
+        }
+        *(Vec8<T>*)(residual_out + base + col0) = residual_vec_out;
+
+        const float row_square_sum = block_sum(square_sum, warp_sums);
+        if (tid == 0) {
+          inv_rms = fast_rsqrt(row_square_sum / static_cast<float>(hidden) + eps);
+        }
+        __syncthreads_lm();
+
+        Vec8<T> w = Vec8<T>::load(weight, col0);
+        Vec8<T> dst;
+#pragma unroll
+        for (int i = 0; i < pack; ++i) {
+          const float gamma = to_float<T>(w.val.elem[i]);
+          dst.val.elem[i] = from_float<T>(sum_float.val.elem[i] * inv_rms * gamma);
+        }
+        *(Vec8<T>*)(norm_out + base + col0) = dst;
+        if (row + gridDim.x < rows) {
+          __syncthreads_lm();
+        }
+        continue;
+      }
+    }
+    if constexpr (nranks == 2) {
+      if (SGL_CUSTOM_AR_FUSED_RMSNORM_VEC2RANK_1STAGE && (hidden % pack) == 0) {
+        const auto* local = reinterpret_cast<const T*>(data.ptrs[rank]);
+        const auto* peer = reinterpret_cast<const T*>(data.ptrs[rank ^ 1]);
+        for (int col0 = tid * pack; col0 < hidden; col0 += blockDim.x * pack) {
+          Vec8<T> local_vec = Vec8<T>::load(local + base, col0);
+          Vec8<T> peer_vec = Vec8<T>::load(peer + base, col0);
+          Vec8<T> residual_vec = Vec8<T>::load(residual_in + base, col0);
+          Vec8<T> residual_vec_out;
+#pragma unroll
+          for (int i = 0; i < pack; ++i) {
+            const int col = col0 + i;
+            float val = to_float<T>(local_vec.val.elem[i]);
+            val += to_float<T>(peer_vec.val.elem[i]);
+            val += to_float<T>(residual_vec.val.elem[i]);
+            residual_vec_out.val.elem[i] = from_float<T>(val);
+            if (cache_float_values) {
+              cached[col] = val;
+            } else if (cache_t_values) {
+              cached_t[col] = residual_vec_out.val.elem[i];
+            }
+            square_sum += val * val;
+          }
+          *(Vec8<T>*)(residual_out + base + col0) = residual_vec_out;
+        }
+      } else if (use_packed && SGL_CUSTOM_AR_FUSED_RMSNORM_PACKED_1STAGE) {
+        const int packed_base = row * packed_hidden;
+        for (int packed_col = tid; packed_col < packed_hidden; packed_col += blockDim.x) {
+          const int col0 = packed_col * pack;
+          float acc[pack] = {0.0f};
+#pragma unroll
+          for (int r = 0; r < nranks; ++r) {
+            const auto* peer = reinterpret_cast<const T*>(data.ptrs[r]);
+            Vec8<T> x = Vec8<T>::load_byp_slc(peer + base, col0);
+#pragma unroll
+            for (int i = 0; i < pack; ++i) {
+              acc[i] += to_float<T>(x.val.elem[i]);
+            }
+          }
+          Vec8<T> residual_vec = Vec8<T>::load_byp_slc(residual_in + base, col0);
+          Vec8<T> residual_vec_out;
+          Float8 sum_float;
+#pragma unroll
+          for (int i = 0; i < pack; ++i) {
+            const int col = col0 + i;
+            float val = acc[i] + to_float<T>(residual_vec.val.elem[i]);
+            residual_vec_out.val.elem[i] = from_float<T>(val);
+            sum_float.val.elem[i] = val;
+            if (cache_float_values) {
+              cached[col] = val;
+            } else if (cache_t_values) {
+              cached_t[col] = residual_vec_out.val.elem[i];
+            }
+            square_sum += val * val;
+          }
+          *(Vec8<T>*)(residual_out + base + col0) = residual_vec_out;
+        }
+      } else {
+        for (int col = tid; col < hidden; col += blockDim.x) {
+          float ar_sum = 0.0f;
+#pragma unroll
+          for (int r = 0; r < nranks; ++r) {
+            const auto* peer = reinterpret_cast<const T*>(data.ptrs[r]);
+            ar_sum += to_float(peer[base + col]);
+          }
+          const float val = ar_sum + to_float(residual_in[base + col]);
+          const T residual_value = from_float<T>(val);
+          residual_out[base + col] = residual_value;
+          if (cache_float_values) {
+            cached[col] = val;
+          } else if (cache_t_values) {
+            cached_t[col] = residual_value;
+          }
+          square_sum += val * val;
+        }
+      }
+    } else if (use_packed && SGL_CUSTOM_AR_FUSED_RMSNORM_PACKED_1STAGE) {
+      const int packed_base = row * packed_hidden;
+      for (int packed_col = tid; packed_col < packed_hidden; packed_col += blockDim.x) {
+        const int col0 = packed_col * pack;
+        float acc[pack] = {0.0f};
+#pragma unroll
+        for (int r = 0; r < nranks; ++r) {
+          const auto* peer = reinterpret_cast<const T*>(data.ptrs[r]);
+          Vec8<T> x = Vec8<T>::load_byp_slc(peer + base, col0);
+#pragma unroll
+          for (int i = 0; i < pack; ++i) {
+            acc[i] += to_float<T>(x.val.elem[i]);
+          }
+        }
+        Vec8<T> residual_vec = Vec8<T>::load_byp_slc(residual_in + base, col0);
+        Vec8<T> residual_vec_out;
+        Float8 sum_float;
+#pragma unroll
+        for (int i = 0; i < pack; ++i) {
+          const int col = col0 + i;
+          float val = acc[i] + to_float<T>(residual_vec.val.elem[i]);
+          residual_vec_out.val.elem[i] = from_float<T>(val);
+          sum_float.val.elem[i] = val;
+          if (cache_float_values) {
+            cached[col] = val;
+          } else if (cache_t_values) {
+            cached_t[col] = residual_vec_out.val.elem[i];
+          }
+          square_sum += val * val;
+        }
+        *(Vec8<T>*)(residual_out + base + col0) = residual_vec_out;
+      }
+    } else if (use_packed) {
+      const int packed_base = row * packed_hidden;
+      for (int packed_col = tid; packed_col < packed_hidden; packed_col += blockDim.x) {
+        const int packed_idx = packed_base + packed_col;
+        const int col0 = packed_col * pack;
+        P reduced = packed_reduce<P, nranks, A>(ptrs, packed_idx);
+        P residual_packet = reinterpret_cast<const P*>(residual_in)[packed_idx];
+        P residual_packet_out;
+#pragma unroll
+        for (int i = 0; i < pack; ++i) {
+          const int col = col0 + i;
+          float val = upcast_s(reduced.data[i]);
+          val += upcast_s(residual_packet.data[i]);
+          residual_packet_out.data[i] = downcast_s<T>(val);
+          if (cache_float_values) {
+            cached[col] = val;
+          } else if (cache_t_values) {
+            cached_t[col] = residual_packet_out.data[i];
+          }
+          square_sum += val * val;
+        }
+        reinterpret_cast<P*>(residual_out)[packed_idx] = residual_packet_out;
+      }
+    } else if (use_partial_packed_non8) {
+      const int row_mod = base & (pack - 1);
+      const int aligned_start = row_mod == 0 ? 0 : min(hidden, pack - row_mod);
+      const int aligned_packed_hidden = (hidden - aligned_start) / pack;
+      const int aligned_end = aligned_start + aligned_packed_hidden * pack;
+      for (int col = tid; col < aligned_start; col += blockDim.x) {
+        float ar_sum = 0.0f;
+#pragma unroll
+        for (int r = 0; r < nranks; ++r) {
+          const auto* peer = reinterpret_cast<const T*>(data.ptrs[r]);
+          ar_sum += to_float(peer[base + col]);
+        }
+        const float val = ar_sum + to_float(residual_in[base + col]);
+        const T residual_value = from_float<T>(val);
+        residual_out[base + col] = residual_value;
+        if (cache_float_values) {
+          cached[col] = val;
+        } else if (cache_t_values) {
+          cached_t[col] = residual_value;
+        }
+        square_sum += val * val;
+      }
+      for (int packed_col = tid; packed_col < aligned_packed_hidden;
+           packed_col += blockDim.x) {
+        const int col0 = aligned_start + packed_col * pack;
+        float acc[pack] = {0.0f};
+#pragma unroll
+        for (int r = 0; r < nranks; ++r) {
+          const auto* peer = reinterpret_cast<const T*>(data.ptrs[r]);
+          Vec8<T> x = Vec8<T>::load_byp_slc(peer + base, col0);
+#pragma unroll
+          for (int i = 0; i < pack; ++i) {
+            acc[i] += to_float<T>(x.val.elem[i]);
+          }
+        }
+        Vec8<T> residual_vec = Vec8<T>::load_byp_slc(residual_in + base, col0);
+        Vec8<T> residual_vec_out;
+#pragma unroll
+        for (int i = 0; i < pack; ++i) {
+          const int col = col0 + i;
+          float val = acc[i] + to_float<T>(residual_vec.val.elem[i]);
+          residual_vec_out.val.elem[i] = from_float<T>(val);
+          if (cache_float_values) {
+            cached[col] = val;
+          } else if (cache_t_values) {
+            cached_t[col] = residual_vec_out.val.elem[i];
+          }
+          square_sum += val * val;
+        }
+        *(Vec8<T>*)(residual_out + base + col0) = residual_vec_out;
+      }
+      for (int col = aligned_end + tid; col < hidden; col += blockDim.x) {
+        float ar_sum = 0.0f;
+#pragma unroll
+        for (int r = 0; r < nranks; ++r) {
+          const auto* peer = reinterpret_cast<const T*>(data.ptrs[r]);
+          ar_sum += to_float(peer[base + col]);
+        }
+        const float val = ar_sum + to_float(residual_in[base + col]);
+        const T residual_value = from_float<T>(val);
+        residual_out[base + col] = residual_value;
+        if (cache_float_values) {
+          cached[col] = val;
+        } else if (cache_t_values) {
+          cached_t[col] = residual_value;
+        }
+        square_sum += val * val;
+      }
+    } else if (use_vec4_non8) {
+      using Vec4 = int64_t;
+      const int packed4_hidden = hidden >> 2;
+      const int base4 = row * packed4_hidden;
+      const Vec4* ptrs4[nranks];
+#pragma unroll
+      for (int r = 0; r < nranks; ++r) {
+        ptrs4[r] = reinterpret_cast<const Vec4*>(data.ptrs[r]);
+      }
+      const Vec4* residual4 = reinterpret_cast<const Vec4*>(residual_in);
+      Vec4* residual_out4 = reinterpret_cast<Vec4*>(residual_out);
+      Vec4* cached_t4 = reinterpret_cast<Vec4*>(cached_t);
+      for (int packed_col = tid; packed_col < packed4_hidden;
+           packed_col += blockDim.x) {
+        float vals[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+#pragma unroll
+        for (int r = 0; r < nranks; ++r) {
+          const Vec4 raw = ptrs4[r][base4 + packed_col];
+          const T* src = reinterpret_cast<const T*>(&raw);
+#pragma unroll
+          for (int i = 0; i < 4; ++i) {
+            vals[i] += upcast_s(src[i]);
+          }
+        }
+        const Vec4 residual_raw = residual4[base4 + packed_col];
+        const T* residual_src = reinterpret_cast<const T*>(&residual_raw);
+        Vec4 out;
+        T* dst = reinterpret_cast<T*>(&out);
+        const int col0 = packed_col << 2;
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+          vals[i] += upcast_s(residual_src[i]);
+          dst[i] = downcast_s<T>(vals[i]);
+          if (cache_float_values) {
+            cached[col0 + i] = vals[i];
+          }
+          square_sum += vals[i] * vals[i];
+        }
+        residual_out4[base4 + packed_col] = out;
+        if (cache_t_values) {
+          cached_t4[packed_col] = out;
+        }
+      }
+    } else if (use_vec2_non8) {
+      using Vec2 = int32_t;
+      const int packed2_hidden = hidden >> 1;
+      const int base2 = row * packed2_hidden;
+      const Vec2* ptrs2[nranks];
+#pragma unroll
+      for (int r = 0; r < nranks; ++r) {
+        ptrs2[r] = reinterpret_cast<const Vec2*>(data.ptrs[r]);
+      }
+      const Vec2* residual2 = reinterpret_cast<const Vec2*>(residual_in);
+      Vec2* residual_out2 = reinterpret_cast<Vec2*>(residual_out);
+      Vec2* cached_t2 = reinterpret_cast<Vec2*>(cached_t);
+      for (int packed_col = tid; packed_col < packed2_hidden;
+           packed_col += blockDim.x) {
+        float vals[2] = {0.0f, 0.0f};
+#pragma unroll
+        for (int r = 0; r < nranks; ++r) {
+          const Vec2 raw = ptrs2[r][base2 + packed_col];
+          const T* src = reinterpret_cast<const T*>(&raw);
+          vals[0] += upcast_s(src[0]);
+          vals[1] += upcast_s(src[1]);
+        }
+        const Vec2 residual_raw = residual2[base2 + packed_col];
+        const T* residual_src = reinterpret_cast<const T*>(&residual_raw);
+        vals[0] += upcast_s(residual_src[0]);
+        vals[1] += upcast_s(residual_src[1]);
+
+        Vec2 out;
+        T* dst = reinterpret_cast<T*>(&out);
+        dst[0] = downcast_s<T>(vals[0]);
+        dst[1] = downcast_s<T>(vals[1]);
+        residual_out2[base2 + packed_col] = out;
+        const int col0 = packed_col << 1;
+        if (cache_float_values) {
+          cached[col0] = vals[0];
+          cached[col0 + 1] = vals[1];
+        } else if (cache_t_values) {
+          cached_t2[packed_col] = out;
+        }
+        square_sum += vals[0] * vals[0] + vals[1] * vals[1];
+      }
+    } else {
+      for (int col = tid; col < hidden; col += blockDim.x) {
+        float ar_sum = 0.0f;
+#pragma unroll
+        for (int r = 0; r < nranks; ++r) {
+          const auto* peer = reinterpret_cast<const T*>(data.ptrs[r]);
+          ar_sum += to_float(peer[base + col]);
+        }
+        const float val = ar_sum + to_float(residual_in[base + col]);
+        const T residual_value = from_float<T>(val);
+        residual_out[base + col] = residual_value;
+        if (cache_float_values) {
+          cached[col] = val;
+        } else if (cache_t_values) {
+          cached_t[col] = residual_value;
+        }
+        square_sum += val * val;
+      }
+    }
+
+    const float row_square_sum =
+        (nranks == 8 && hidden == 1536 && blockDim.x == 512)
+            ? block_sum_nwarps<6>(square_sum, warp_sums)
+            : block_sum(square_sum, warp_sums);
+    if (tid == 0) {
+      inv_rms = fast_rsqrt(row_square_sum / static_cast<float>(hidden) + eps);
+    }
+    __syncthreads_lm();
+
+    if (use_packed) {
+      for (int packed_col = tid; packed_col < packed_hidden; packed_col += blockDim.x) {
+        const int col0 = packed_col * pack;
+        Float8 sum_float;
+        if (cache_float_values) {
+          sum_float = *(Float8*)(cached + col0);
+        } else if (cache_t_values) {
+          Vec8<T> r = *(Vec8<T>*)(cached_t + col0);
+          #pragma unroll
+          for (int i = 0; i < pack; ++i) {
+            sum_float.val.elem[i] = to_float<T>(r.val.elem[i]);
+          }
+        } else {
+          Vec8<T> r = Vec8<T>::load(residual_out + base, col0);
+#pragma unroll
+          for (int i = 0; i < pack; ++i) {
+            sum_float.val.elem[i] = to_float<T>(r.val.elem[i]);
+          }
+        }
+        Vec8<T> w = cache_weight ? *(Vec8<T>*)(cached_weight + col0) : Vec8<T>::load(weight, col0);
+        Vec8<T> dst;
+#pragma unroll
+        for (int i = 0; i < pack; ++i) {
+          const float gamma = to_float<T>(w.val.elem[i]);
+          dst.val.elem[i] = from_float<T>(sum_float.val.elem[i] * inv_rms * gamma);
+        }
+        *(Vec8<T>*)(norm_out + base + col0) = dst;
+      }
+    } else if (use_partial_packed_non8) {
+      const int row_mod = base & (pack - 1);
+      const int aligned_start = row_mod == 0 ? 0 : min(hidden, pack - row_mod);
+      const int aligned_packed_hidden = (hidden - aligned_start) / pack;
+      const int aligned_end = aligned_start + aligned_packed_hidden * pack;
+      for (int col = tid; col < aligned_start; col += blockDim.x) {
+        float val;
+        if (cache_float_values) {
+          val = cached[col];
+        } else if (cache_t_values) {
+          val = to_float(cached_t[col]);
+        } else {
+          val = to_float(residual_out[base + col]);
+        }
+        const float gamma = to_float(weight[col]);
+        norm_out[base + col] = from_float<T>(val * inv_rms * gamma);
+      }
+      for (int packed_col = tid; packed_col < aligned_packed_hidden;
+           packed_col += blockDim.x) {
+        const int col0 = aligned_start + packed_col * pack;
+        Float8 sum_float;
+        if (cache_float_values) {
+          sum_float = *(Float8*)(cached + col0);
+        } else if (cache_t_values) {
+          Vec8<T> r = *(Vec8<T>*)(cached_t + col0);
+#pragma unroll
+          for (int i = 0; i < pack; ++i) {
+            sum_float.val.elem[i] = to_float<T>(r.val.elem[i]);
+          }
+        } else {
+          Vec8<T> r = Vec8<T>::load(residual_out + base, col0);
+#pragma unroll
+          for (int i = 0; i < pack; ++i) {
+            sum_float.val.elem[i] = to_float<T>(r.val.elem[i]);
+          }
+        }
+        Vec8<T> w = Vec8<T>::load(weight, col0);
+        Vec8<T> dst;
+#pragma unroll
+        for (int i = 0; i < pack; ++i) {
+          const float gamma = to_float<T>(w.val.elem[i]);
+          dst.val.elem[i] = from_float<T>(sum_float.val.elem[i] * inv_rms * gamma);
+        }
+        *(Vec8<T>*)(norm_out + base + col0) = dst;
+      }
+      for (int col = aligned_end + tid; col < hidden; col += blockDim.x) {
+        float val;
+        if (cache_float_values) {
+          val = cached[col];
+        } else if (cache_t_values) {
+          val = to_float(cached_t[col]);
+        } else {
+          val = to_float(residual_out[base + col]);
+        }
+        const float gamma = to_float(weight[col]);
+        norm_out[base + col] = from_float<T>(val * inv_rms * gamma);
+      }
+    } else if (use_vec4_non8) {
+      using Vec4 = int64_t;
+      const int packed4_hidden = hidden >> 2;
+      const int base4 = row * packed4_hidden;
+      const Vec4* cached_t4 = reinterpret_cast<const Vec4*>(cached_t);
+      const Vec4* residual_out4 = reinterpret_cast<const Vec4*>(residual_out);
+      const Vec4* weight4 = reinterpret_cast<const Vec4*>(weight);
+      Vec4* norm_out4 = reinterpret_cast<Vec4*>(norm_out);
+      for (int packed_col = tid; packed_col < packed4_hidden;
+           packed_col += blockDim.x) {
+        float vals[4];
+        const int col0 = packed_col << 2;
+        if (cache_float_values) {
+#pragma unroll
+          for (int i = 0; i < 4; ++i) {
+            vals[i] = cached[col0 + i];
+          }
+        } else {
+          const Vec4 raw = cache_t_values ? cached_t4[packed_col]
+                                          : residual_out4[base4 + packed_col];
+          const T* src = reinterpret_cast<const T*>(&raw);
+#pragma unroll
+          for (int i = 0; i < 4; ++i) {
+            vals[i] = upcast_s(src[i]);
+          }
+        }
+
+        const Vec4 weight_raw = weight4[packed_col];
+        const T* weight_src = reinterpret_cast<const T*>(&weight_raw);
+        Vec4 out;
+        T* dst = reinterpret_cast<T*>(&out);
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+          dst[i] = downcast_s<T>(vals[i] * inv_rms * upcast_s(weight_src[i]));
+        }
+        norm_out4[base4 + packed_col] = out;
+      }
+    } else if (use_vec2_non8) {
+      using Vec2 = int32_t;
+      const int packed2_hidden = hidden >> 1;
+      const int base2 = row * packed2_hidden;
+      const Vec2* cached_t2 = reinterpret_cast<const Vec2*>(cached_t);
+      const Vec2* residual_out2 = reinterpret_cast<const Vec2*>(residual_out);
+      const Vec2* weight2 = reinterpret_cast<const Vec2*>(weight);
+      Vec2* norm_out2 = reinterpret_cast<Vec2*>(norm_out);
+      for (int packed_col = tid; packed_col < packed2_hidden;
+           packed_col += blockDim.x) {
+        float vals[2];
+        if (cache_float_values) {
+          const int col0 = packed_col << 1;
+          vals[0] = cached[col0];
+          vals[1] = cached[col0 + 1];
+        } else {
+          const Vec2 raw = cache_t_values ? cached_t2[packed_col]
+                                          : residual_out2[base2 + packed_col];
+          const T* src = reinterpret_cast<const T*>(&raw);
+          vals[0] = upcast_s(src[0]);
+          vals[1] = upcast_s(src[1]);
+        }
+
+        const Vec2 weight_raw = weight2[packed_col];
+        const T* weight_src = reinterpret_cast<const T*>(&weight_raw);
+        Vec2 out;
+        T* dst = reinterpret_cast<T*>(&out);
+        dst[0] = downcast_s<T>(vals[0] * inv_rms * upcast_s(weight_src[0]));
+        dst[1] = downcast_s<T>(vals[1] * inv_rms * upcast_s(weight_src[1]));
+        norm_out2[base2 + packed_col] = out;
+      }
+    } else {
+      for (int col = tid; col < hidden; col += blockDim.x) {
+        float val;
+        if (cache_float_values) {
+          val = cached[col];
+        } else if (cache_t_values) {
+          val = to_float(cached_t[col]);
+        } else {
+          val = to_float(residual_out[base + col]);
+        }
+        const float gamma = to_float(weight[col]);
+        norm_out[base + col] = from_float<T>(val * inv_rms * gamma);
+      }
+    }
+    if (row + gridDim.x < rows) {
+      __syncthreads_lm();
+    }
+  }
+
+  if constexpr (!(kRowSkipEndBarrier && nranks == 2)) {
+    multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+  }
+}
+
+template <typename T, int nranks>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1)
+custom_all_reduce_residual_rmsnorm_2stage_kernel(
+    RankData data,
+    const RankData* data_ptr,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* __restrict__ residual_in,
+    T* __restrict__ residual_out,
+    T* __restrict__ norm_out,
+    const T* __restrict__ weight,
+    int rank,
+    int rows,
+    int hidden,
+    float eps,
+    int packed_size) {
+  if (data_ptr != nullptr) {
+    data = *data_ptr;
+  }
+  using P = typename packed_t<T>::P;
+  using A = typename packed_t<T>::A;
+  constexpr int pack = P::size;
+
+  extern __shared__ __align__(16) unsigned char smem[];
+
+  const int tid = threadIdx.x;
+  const bool cache_float_values = hidden <= kCacheHiddenLimit;
+  const bool cache_t_values =
+      !cache_float_values && hidden != 4096 && hidden <= kTypedCacheHiddenLimit;
+  const bool cache_weight = rmsnorm_cache_weight_hidden(hidden, rows);
+  float* cached = reinterpret_cast<float*>(smem);
+  T* cached_t = reinterpret_cast<T*>(smem);
+  const size_t cache_bytes =
+      cache_float_values
+          ? static_cast<size_t>(hidden) * sizeof(float)
+          : (cache_t_values ? static_cast<size_t>(hidden) * sizeof(T) : 0);
+  const size_t weight_offset = align_up(cache_bytes, alignof(T));
+  T* cached_weight = reinterpret_cast<T*>(smem + weight_offset);
+  const size_t weight_bytes = cache_weight ? static_cast<size_t>(hidden) * sizeof(T) : 0;
+  float* warp_sums =
+      reinterpret_cast<float*>(smem + align_up(weight_offset + weight_bytes, alignof(float)));
+
+  const P* ptrs[nranks];
+#pragma unroll
+  for (int i = 0; i < nranks; ++i) {
+    ptrs[i] = reinterpret_cast<const P*>(data.ptrs[i]);
+  }
+  const P* residual_p = reinterpret_cast<const P*>(residual_in);
+  const P* weight_p = reinterpret_cast<const P*>(weight);
+  P* residual_out_p = reinterpret_cast<P*>(residual_out);
+  P* norm_out_p = reinterpret_cast<P*>(norm_out);
+  P* self_tmp = get_tmp_buf<P>(self_sg);
+
+  if (cache_weight) {
+    for (int packed_col = tid; packed_col < hidden / pack; packed_col += blockDim.x) {
+      const int col0 = packed_col * pack;
+      *(Vec8<T>*)(cached_weight + col0) = Vec8<T>::load(weight, col0);
+    }
+  }
+
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+
+  const int packed_hidden = hidden / pack;
+  const int rows_per_rank = rows / nranks;
+  const int row_remainder = rows % nranks;
+
+  const int owner_begin =
+      rank * rows_per_rank + (row_remainder > rank ? rank : row_remainder);
+  const int owner_rows = rows_per_rank + (row_remainder > rank ? 1 : 0);
+  const int owner_end = owner_begin + owner_rows;
+
+  for (int row = owner_begin + blockIdx.x; row < owner_end; row += gridDim.x) {
+    const int packed_base = row * packed_hidden;
+    for (int packed_col = tid; packed_col < packed_hidden; packed_col += blockDim.x) {
+      const int packed_idx = packed_base + packed_col;
+      P reduced = packed_reduce<P, nranks, A>(ptrs, packed_idx);
+      self_tmp[packed_idx] = reduced;
+    }
+  }
+
+  __musa_barrier_slc();
+  __syncthreads_lm();
+  if (tid == 0) {
+    __threadfence_system_noflush();
+  }
+  multi_rank_barrier<nranks, false, true>(sg, self_sg, rank);
+
+  for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+    const int base = row * hidden;
+    const int packed_base = row * packed_hidden;
+    float square_sum = 0.0f;
+    int owner = row_remainder == 0 ? row / rows_per_rank : nranks - 1;
+    int scan_begin = 0;
+    if (row_remainder != 0) {
+#pragma unroll
+      for (int r = 0; r < nranks; ++r) {
+        const int scan_rows = rows_per_rank + (row_remainder > r ? 1 : 0);
+        if (row >= scan_begin && row < scan_begin + scan_rows) {
+          owner = r;
+        }
+        scan_begin += scan_rows;
+      }
+    }
+    const P* owner_tmp = get_tmp_buf<P>(sg.signals[owner]);
+
+    for (int packed_col = tid; packed_col < packed_hidden; packed_col += blockDim.x) {
+      const int packed_idx = packed_base + packed_col;
+      P reduced = owner_tmp[packed_idx];
+      P residual_packet = residual_p[packed_idx];
+      P residual_packet_out;
+
+#pragma unroll
+      for (int i = 0; i < pack; ++i) {
+        const int col = packed_col * pack + i;
+        float val = upcast_s(reduced.data[i]);
+        val += upcast_s(residual_packet.data[i]);
+        T residual_value = downcast_s<T>(val);
+        residual_packet_out.data[i] = residual_value;
+        if (cache_float_values) {
+          cached[col] = val;
+        } else if (cache_t_values) {
+          cached_t[col] = residual_value;
+        }
+        square_sum += val * val;
+      }
+      residual_out_p[packed_idx] = residual_packet_out;
+    }
+
+    const float row_square_sum = block_sum(square_sum, warp_sums);
+    const float inv_rms = fast_rsqrt(row_square_sum / static_cast<float>(hidden) + eps);
+
+    for (int packed_col = tid; packed_col < packed_hidden; packed_col += blockDim.x) {
+      const int packed_idx = packed_base + packed_col;
+      P weight_packet =
+          cache_weight ? reinterpret_cast<const P*>(cached_weight)[packed_col]
+                       : weight_p[packed_col];
+      P norm_packet;
+#pragma unroll
+      for (int i = 0; i < pack; ++i) {
+        const int col = packed_col * pack + i;
+        float val;
+        if (cache_float_values) {
+          val = cached[col];
+        } else if (cache_t_values) {
+          val = upcast_s(cached_t[col]);
+        } else {
+          val = upcast_s(residual_out[base + col]);
+        }
+        const float gamma = upcast_s(weight_packet.data[i]);
+        norm_packet.data[i] = downcast_s<T>(val * inv_rms * gamma);
+      }
+      norm_out_p[packed_idx] = norm_packet;
+    }
+    if (hidden != 3072) {
+      __syncthreads_lm();
+    }
+  }
+
+  if constexpr (!kRowSkipEndBarrier) {
+    if (hidden != 3072) {
+      multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+    }
+  }
+}
+
+template <typename T, int nranks>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1)
+custom_all_reduce_residual_kernel(
+    RankData data,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* __restrict__ residual_in,
+    T* __restrict__ residual_out,
+    int rank,
+    int size) {
+  using P = typename packed_t<T>::P;
+  using A = typename packed_t<T>::A;
+  constexpr int pack = P::size;
+  const int packed_size = size / pack;
+  const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  const int stride = gridDim.x * blockDim.x;
+
+  const P* ptrs[nranks];
+#pragma unroll
+  for (int i = 0; i < nranks; ++i) {
+    ptrs[i] = reinterpret_cast<const P*>(data.ptrs[i]);
+  }
+  const P* residual = reinterpret_cast<const P*>(residual_in);
+  P* dst = reinterpret_cast<P*>(residual_out);
+
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+  for (int idx = tid; idx < packed_size; idx += stride) {
+    P reduced = packed_reduce<P, nranks, A>(ptrs, idx);
+    P residual_packet = residual[idx];
+    P out;
+#pragma unroll
+    for (int i = 0; i < pack; ++i) {
+      out.data[i] =
+          downcast_s<T>(upcast_s(reduced.data[i]) + upcast_s(residual_packet.data[i]));
+    }
+    dst[idx] = out;
+  }
+  multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+}
+
+template <typename T, int nranks, int vlen = 8>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1)
+custom_all_reduce_residual_2shot_kernel(
+    RankData data,
+    const RankData* data_ptr,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* __restrict__ residual_in,
+    T* __restrict__ residual_out,
+    int rank,
+    int packed_size) {
+  if (data_ptr != nullptr) {
+    data = *data_ptr;
+  }
+  constexpr int nranks_sft = (nranks >> 1) - (nranks >> 3);
+  constexpr int coalesce_num = 8;
+  constexpr int coalesce_sft = 3;
+  constexpr int group_stride_sft = nranks_sft + coalesce_sft;
+  const int tid = threadIdx.x;
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int target_rank = (tid >> coalesce_sft) & (nranks - 1);
+  const int group_id = tid >> group_stride_sft;
+  const int coalesce_tid = tid & (coalesce_num - 1);
+  const int stride = gridDim.x * blockDim.x;
+
+  using Vec = array_t<T, vlen>;
+  int idx_base = blockIdx.x * blockDim.x;
+  int idx_in_blk = coalesce_tid + (rank << coalesce_sft) + (group_id << group_stride_sft);
+
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+  Vec* target_ptr = reinterpret_cast<Vec*>(const_cast<void*>(data.ptrs[target_rank]));
+  Vec* buffer_ptr = get_tmp_buf<Vec>(sg.signals[rank]);
+  do {
+    const int idx = idx_in_blk + idx_base;
+    float acc[vlen] = {0};
+    if (idx < packed_size) {
+#if SGL_CUSTOM_AR_VECTOR_LOAD
+      Vec raw = target_ptr[idx];
+      const T* src = reinterpret_cast<const T*>(&raw);
+#else
+      const T* src = reinterpret_cast<const T*>(&target_ptr[idx]);
+#endif
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        acc[i] = upcast_s(src[i]);
+      }
+    }
+    shfl_reduce<T, nranks, vlen>(acc);
+    if constexpr (nranks == 8) {
+      __shared__ float smem[kMaxThreadsPerBlock << 1];
+      if (lane < coalesce_num) {
+#pragma unroll
+        for (int i = 0; i < vlen; ++i) {
+          smem[warp * vlen * coalesce_num + coalesce_tid * vlen + i] = acc[i];
+        }
+      }
+      __syncthreads_lm();
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        acc[i] += smem[(warp ^ 1) * vlen * coalesce_num + coalesce_tid * vlen + i];
+      }
+    }
+    if (rank == target_rank && idx < packed_size) {
+      Vec res;
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        reinterpret_cast<T*>(&res)[i] = downcast_s<T>(acc[i]);
+      }
+      buffer_ptr[idx] = res;
+    }
+    idx_base += stride;
+  } while (idx_base < packed_size);
+
+  __musa_barrier_slc();
+  __syncthreads_lm();
+  if (tid == 0) {
+    __threadfence_system_noflush();
+  }
+  if (tid < nranks) {
+#if SGL_CUSTOM_AR_ATOMIC_BARRIER
+    auto flag = atomicAdd(&self_sg->self_counter[blockIdx.x][tid], 1) + 1;
+    auto* peer = &sg.signals[tid]->peer_counter[flag & 1][blockIdx.x][rank];
+    auto* local = &self_sg->peer_counter[flag & 1][blockIdx.x][tid];
+    atomicExch(peer, flag);
+    while (atomicAdd(local, 0) != flag) {
+    }
+#else
+    auto flag = self_sg->self_counter[blockIdx.x][tid] + 1;
+    self_sg->self_counter[blockIdx.x][tid] = flag;
+    auto* peer = &sg.signals[tid]->peer_counter[flag & 1][blockIdx.x][rank];
+    auto* local = &self_sg->peer_counter[flag & 1][blockIdx.x][tid];
+    signal_store(peer, flag);
+    while (signal_load(local) != flag) {
+    }
+#endif
+  }
+  __syncthreads_lm();
+
+  buffer_ptr = get_tmp_buf<Vec>(sg.signals[target_rank]);
+  const Vec* residual = reinterpret_cast<const Vec*>(residual_in);
+  Vec* dst = reinterpret_cast<Vec*>(residual_out);
+  idx_in_blk = coalesce_tid + (target_rank << coalesce_sft) + (group_id << group_stride_sft);
+  idx_base = blockIdx.x * blockDim.x;
+  do {
+    const int idx = idx_in_blk + idx_base;
+    if (idx < packed_size) {
+      const Vec reduced = buffer_ptr[idx];
+      const Vec residual_packet = residual[idx];
+      Vec out;
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        reinterpret_cast<T*>(&out)[i] = downcast_s<T>(
+            upcast_s(reinterpret_cast<const T*>(&reduced)[i]) +
+            upcast_s(reinterpret_cast<const T*>(&residual_packet)[i]));
+      }
+      dst[idx] = out;
+    }
+    idx_base += stride;
+  } while (idx_base < packed_size);
+
+  multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+}
+
+template <typename T, int nranks, int vlen = 8>
+__global__ void __launch_bounds__(256, 1)
+custom_all_reduce_residual_rmsnorm_warp_rows_kernel(
+    RankData data,
+    const RankData* data_ptr,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* __restrict__ residual_in,
+    T* __restrict__ residual_out,
+    T* __restrict__ norm_out,
+    const T* __restrict__ weight,
+    int rank,
+    int rows,
+    int hidden,
+    float eps) {
+  if (data_ptr != nullptr) {
+    data = *data_ptr;
+  }
+  const int tid = threadIdx.x;
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int warps_per_block = blockDim.x >> 5;
+  const float inv_hidden = 1.0f / static_cast<float>(hidden);
+
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+
+  for (int row = blockIdx.x * warps_per_block + warp; row < rows;
+       row += gridDim.x * warps_per_block) {
+    const int base = row * hidden;
+    float square_sum = 0.0f;
+    for (int col0 = lane * vlen; col0 < hidden; col0 += 32 * vlen) {
+      float acc[vlen] = {0.0f};
+#pragma unroll
+      for (int r = 0; r < nranks; ++r) {
+        const auto* peer = reinterpret_cast<const T*>(data.ptrs[r]);
+        Vec8<T> x = Vec8<T>::load(peer + base, col0);
+#pragma unroll
+        for (int i = 0; i < vlen; ++i) {
+          acc[i] += to_float<T>(x.val.elem[i]);
+        }
+      }
+      Vec8<T> residual_vec = Vec8<T>::load(residual_in + base, col0);
+      Vec8<T> residual_vec_out;
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        const float val = acc[i] + to_float<T>(residual_vec.val.elem[i]);
+        residual_vec_out.val.elem[i] = from_float<T>(val);
+        square_sum += val * val;
+      }
+      *(Vec8<T>*)(residual_out + base + col0) = residual_vec_out;
+    }
+
+    const float row_square_sum = warp_sum(square_sum);
+    const float scale =
+        fast_rsqrt(__shfl_sync(0xffffffff, row_square_sum, 0, 32) * inv_hidden + eps);
+
+    for (int col0 = lane * vlen; col0 < hidden; col0 += 32 * vlen) {
+      Vec8<T> residual_vec = Vec8<T>::load(residual_out + base, col0);
+      Vec8<T> weight_vec = Vec8<T>::load(weight, col0);
+      Vec8<T> dst;
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        const float val = to_float<T>(residual_vec.val.elem[i]);
+        const float gamma = to_float<T>(weight_vec.val.elem[i]);
+        dst.val.elem[i] = from_float<T>(val * scale * gamma);
+      }
+      *(Vec8<T>*)(norm_out + base + col0) = dst;
+    }
+  }
+
+  multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+}
+
+template <typename T, int nranks, int vlen = 8>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1)
+custom_all_reduce_residual_sums_direct_kernel(
+    RankData data,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* __restrict__ residual_in,
+    T* __restrict__ residual_out,
+    float* __restrict__ row_sums,
+    int rank,
+    int rows,
+    int hidden) {
+  static_assert(nranks == 2, "direct residual sums is specialized for TP2");
+  const int tid = threadIdx.x;
+  constexpr int pack = vlen;
+  const int packed_hidden = hidden / pack;
+  __shared__ float warp_sums[(kMaxThreadsPerBlock + 31) / 32];
+
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+
+  const auto* local = reinterpret_cast<const T*>(data.ptrs[rank]);
+  const auto* peer = reinterpret_cast<const T*>(data.ptrs[rank ^ 1]);
+  for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+    const int base = row * hidden;
+    float square_sum = 0.0f;
+    for (int packed_col = tid; packed_col < packed_hidden;
+         packed_col += blockDim.x) {
+      const int col0 = packed_col * pack;
+      Vec8<T> local_vec = Vec8<T>::load_byp_slc(local + base, col0);
+      Vec8<T> peer_vec = Vec8<T>::load_byp_slc(peer + base, col0);
+      Vec8<T> residual_vec = Vec8<T>::load_byp_slc(residual_in + base, col0);
+      Vec8<T> residual_vec_out;
+#pragma unroll
+      for (int i = 0; i < pack; ++i) {
+        const float val = to_float<T>(local_vec.val.elem[i]) +
+                          to_float<T>(peer_vec.val.elem[i]) +
+                          to_float<T>(residual_vec.val.elem[i]);
+        residual_vec_out.val.elem[i] = from_float<T>(val);
+        square_sum += val * val;
+      }
+      *(Vec8<T>*)(residual_out + base + col0) = residual_vec_out;
+    }
+
+    const float row_square_sum = block_sum_tid0(square_sum, warp_sums);
+    if (tid == 0) {
+      row_sums[row] = row_square_sum;
+    }
+  }
+
+  __musa_barrier_slc();
+  __syncthreads_lm();
+  if (tid == 0) {
+    __threadfence_system_noflush();
+  }
+  __syncthreads_lm();
+  multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+}
+
+template <typename T, int nranks>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1)
+custom_all_reduce_residual_sums_scalar_kernel(
+    RankData data,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* __restrict__ residual_in,
+    T* __restrict__ residual_out,
+    float* __restrict__ row_sums,
+    int rank,
+    int rows,
+    int hidden) {
+  const int tid = threadIdx.x;
+  __shared__ float warp_sums[(kMaxThreadsPerBlock + 31) / 32];
+  T* self_tmp = get_tmp_buf<T>(self_sg);
+
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+
+  const T* ptrs[nranks];
+#pragma unroll
+  for (int r = 0; r < nranks; ++r) {
+    ptrs[r] = reinterpret_cast<const T*>(data.ptrs[r]);
+  }
+
+  if (rows > 1) {
+    if ((hidden & 1) == 0) {
+      using Vec2 = int32_t;
+      const int packed2_hidden = hidden >> 1;
+      const Vec2* ptrs2[nranks];
+#pragma unroll
+      for (int r = 0; r < nranks; ++r) {
+        ptrs2[r] = reinterpret_cast<const Vec2*>(ptrs[r]);
+      }
+      const Vec2* residual2 = reinterpret_cast<const Vec2*>(residual_in);
+      Vec2* residual_out2 = reinterpret_cast<Vec2*>(residual_out);
+
+      for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+        const int base2 = row * packed2_hidden;
+        float square_sum = 0.0f;
+        for (int packed_col = tid; packed_col < packed2_hidden;
+             packed_col += blockDim.x) {
+          float vals[2] = {0.0f, 0.0f};
+#pragma unroll
+          for (int r = 0; r < nranks; ++r) {
+            const Vec2 raw = ptrs2[r][base2 + packed_col];
+            const T* src = reinterpret_cast<const T*>(&raw);
+            vals[0] += upcast_s(src[0]);
+            vals[1] += upcast_s(src[1]);
+          }
+          const Vec2 residual_raw = residual2[base2 + packed_col];
+          const T* residual_src = reinterpret_cast<const T*>(&residual_raw);
+          vals[0] += upcast_s(residual_src[0]);
+          vals[1] += upcast_s(residual_src[1]);
+
+          Vec2 out;
+          T* dst = reinterpret_cast<T*>(&out);
+          dst[0] = downcast_s<T>(vals[0]);
+          dst[1] = downcast_s<T>(vals[1]);
+          residual_out2[base2 + packed_col] = out;
+          square_sum += vals[0] * vals[0] + vals[1] * vals[1];
+        }
+
+        const float row_square_sum = block_sum_tid0(square_sum, warp_sums);
+        if (tid == 0) {
+          row_sums[row] = row_square_sum;
+        }
+      }
+
+      __musa_barrier_slc();
+      __syncthreads_lm();
+      if (tid == 0) {
+        __threadfence_system_noflush();
+      }
+      __syncthreads_lm();
+      multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+      return;
+    }
+
+    for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+      const int base = row * hidden;
+      float square_sum = 0.0f;
+      for (int col = tid; col < hidden; col += blockDim.x) {
+        float val = upcast_s(residual_in[base + col]);
+#pragma unroll
+        for (int r = 0; r < nranks; ++r) {
+          val += upcast_s(ptrs[r][base + col]);
+        }
+        residual_out[base + col] = downcast_s<T>(val);
+        square_sum += val * val;
+      }
+
+      const float row_square_sum = block_sum_tid0(square_sum, warp_sums);
+      if (tid == 0) {
+        row_sums[row] = row_square_sum;
+      }
+    }
+
+    __musa_barrier_slc();
+    __syncthreads_lm();
+    if (tid == 0) {
+      __threadfence_system_noflush();
+    }
+    __syncthreads_lm();
+    multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+    return;
+  }
+
+  for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+    const int base = row * hidden;
+    for (int col = rank + tid * nranks; col < hidden;
+         col += blockDim.x * nranks) {
+      float val = 0.0f;
+#pragma unroll
+      for (int r = 0; r < nranks; ++r) {
+        val += upcast_s(ptrs[r][base + col]);
+      }
+      self_tmp[base + col] = downcast_s<T>(val);
+    }
+  }
+
+  __musa_barrier_slc();
+  __syncthreads_lm();
+  if (tid == 0) {
+    __threadfence_system_noflush();
+  }
+  multi_rank_barrier<nranks, false, true>(sg, self_sg, rank);
+
+  for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+    const int base = row * hidden;
+    float square_sum = 0.0f;
+    for (int col = tid; col < hidden; col += blockDim.x) {
+      const int owner = col & (nranks - 1);
+      const T* owner_tmp = get_tmp_buf<T>(sg.signals[owner]);
+      const float val =
+          upcast_s(owner_tmp[base + col]) + upcast_s(residual_in[base + col]);
+      residual_out[base + col] = downcast_s<T>(val);
+      square_sum += val * val;
+    }
+
+    const float row_square_sum = block_sum_tid0(square_sum, warp_sums);
+    if (tid == 0) {
+      row_sums[row] = row_square_sum;
+    }
+  }
+
+  __musa_barrier_slc();
+  __syncthreads_lm();
+  if (tid == 0) {
+    __threadfence_system_noflush();
+  }
+  __syncthreads_lm();
+  multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+}
+
+template <typename T, int nranks, int vlen = 8>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1)
+custom_all_reduce_residual_2shot_sums_kernel(
+    RankData data,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* __restrict__ residual_in,
+    T* __restrict__ residual_out,
+    float* __restrict__ row_sums,
+    int rank,
+    int rows,
+    int hidden,
+    int packed_size) {
+  constexpr int nranks_sft = (nranks >> 1) - (nranks >> 3);
+  constexpr int coalesce_num = 8;
+  constexpr int coalesce_sft = 3;
+  constexpr int group_stride_sft = nranks_sft + coalesce_sft;
+  const int tid = threadIdx.x;
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int target_rank = (tid >> coalesce_sft) & (nranks - 1);
+  const int group_id = tid >> group_stride_sft;
+  const int coalesce_tid = tid & (coalesce_num - 1);
+  const int stride = gridDim.x * blockDim.x;
+  const int packed_hidden = hidden / vlen;
+
+  using Vec = array_t<T, vlen>;
+  __shared__ float warp_sums[(kMaxThreadsPerBlock + 31) / 32];
+  int idx_base = blockIdx.x * blockDim.x;
+  int idx_in_blk = coalesce_tid + (rank << coalesce_sft) + (group_id << group_stride_sft);
+
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+
+  Vec* target_ptr = reinterpret_cast<Vec*>(const_cast<void*>(data.ptrs[target_rank]));
+  Vec* buffer_ptr = get_tmp_buf<Vec>(sg.signals[rank]);
+  do {
+    const int idx = idx_in_blk + idx_base;
+    float acc[vlen] = {0};
+    if (idx < packed_size) {
+#if SGL_CUSTOM_AR_VECTOR_LOAD
+      Vec raw = target_ptr[idx];
+      const T* src = reinterpret_cast<const T*>(&raw);
+#else
+      const T* src = reinterpret_cast<const T*>(&target_ptr[idx]);
+#endif
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        acc[i] = upcast_s(src[i]);
+      }
+    }
+    shfl_reduce<T, nranks, vlen>(acc);
+    if constexpr (nranks == 8) {
+      __shared__ float smem[kMaxThreadsPerBlock << 1];
+      if (lane < coalesce_num) {
+#pragma unroll
+        for (int i = 0; i < vlen; ++i) {
+          smem[warp * vlen * coalesce_num + coalesce_tid * vlen + i] = acc[i];
+        }
+      }
+      __syncthreads_lm();
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        acc[i] += smem[(warp ^ 1) * vlen * coalesce_num + coalesce_tid * vlen + i];
+      }
+    }
+    if (rank == target_rank && idx < packed_size) {
+      Vec res;
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        reinterpret_cast<T*>(&res)[i] = downcast_s<T>(acc[i]);
+      }
+      buffer_ptr[idx] = res;
+    }
+    idx_base += stride;
+  } while (idx_base < packed_size);
+
+  __musa_barrier_slc();
+  __syncthreads_lm();
+  if (tid == 0) {
+    __threadfence_system_noflush();
+  }
+  if (tid < nranks) {
+#if SGL_CUSTOM_AR_ATOMIC_BARRIER
+    auto flag = atomicAdd(&self_sg->self_counter[blockIdx.x][tid], 1) + 1;
+    auto* peer = &sg.signals[tid]->peer_counter[flag & 1][blockIdx.x][rank];
+    auto* local = &self_sg->peer_counter[flag & 1][blockIdx.x][tid];
+    atomicExch(peer, flag);
+    while (atomicAdd(local, 0) != flag) {
+    }
+#else
+    auto flag = self_sg->self_counter[blockIdx.x][tid] + 1;
+    self_sg->self_counter[blockIdx.x][tid] = flag;
+    auto* peer = &sg.signals[tid]->peer_counter[flag & 1][blockIdx.x][rank];
+    auto* local = &self_sg->peer_counter[flag & 1][blockIdx.x][tid];
+    signal_store(peer, flag);
+    while (signal_load(local) != flag) {
+    }
+#endif
+  }
+  __syncthreads_lm();
+
+  buffer_ptr = get_tmp_buf<Vec>(sg.signals[target_rank]);
+  const Vec* residual = reinterpret_cast<const Vec*>(residual_in);
+  Vec* dst = reinterpret_cast<Vec*>(residual_out);
+  if constexpr (nranks == 4 || nranks == 8) {
+    if ((hidden == 1536 || hidden == 3072 || hidden == 4096) &&
+        blockDim.x == 512) {
+      const Vec* owner_tmp = get_tmp_buf<Vec>(sg.signals[target_rank]);
+      for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+        const int idx = row * packed_hidden + tid;
+        float square_sum = 0.0f;
+        if (tid < packed_hidden) {
+          const Vec reduced = owner_tmp[idx];
+          const Vec residual_packet = residual[idx];
+          Vec out;
+#pragma unroll
+          for (int i = 0; i < vlen; ++i) {
+            const float val =
+                upcast_s(reinterpret_cast<const T*>(&reduced)[i]) +
+                upcast_s(reinterpret_cast<const T*>(&residual_packet)[i]);
+            reinterpret_cast<T*>(&out)[i] = downcast_s<T>(val);
+            square_sum += val * val;
+          }
+          dst[idx] = out;
+        }
+        const float row_square_sum =
+            hidden == 4096
+                ? block_sum_16warps_tid0(square_sum, warp_sums)
+                : (hidden == 3072
+                       ? block_sum_12warps_tid0(square_sum, warp_sums)
+                       : block_sum_nwarps_tid0<6>(square_sum, warp_sums));
+        if (tid == 0) {
+          row_sums[row] = row_square_sum;
+        }
+      }
+
+      if constexpr (!kRowSkipEndBarrier) {
+        multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+      }
+      return;
+    }
+  }
+  idx_in_blk = coalesce_tid + (target_rank << coalesce_sft) + (group_id << group_stride_sft);
+  idx_base = blockIdx.x * blockDim.x;
+  do {
+    const int idx = idx_in_blk + idx_base;
+    float values[vlen] = {0};
+    float square_sum = 0.0f;
+    if (idx < packed_size) {
+#if SGL_CUSTOM_AR_FUSED_RMSNORM_SUMS_BYPASS_LOAD == 1 || \
+    SGL_CUSTOM_AR_FUSED_RMSNORM_SUMS_BYPASS_LOAD == 2
+      const Vec8<T> reduced =
+          Vec8<T>::load_byp_slc(reinterpret_cast<const T*>(buffer_ptr), idx * vlen);
+#else
+      const Vec reduced = buffer_ptr[idx];
+#endif
+#if SGL_CUSTOM_AR_FUSED_RMSNORM_SUMS_BYPASS_LOAD == 1 || \
+    SGL_CUSTOM_AR_FUSED_RMSNORM_SUMS_BYPASS_LOAD == 3
+      const Vec8<T> residual_packet = Vec8<T>::load_byp_slc(residual_in, idx * vlen);
+#else
+      const Vec residual_packet = residual[idx];
+#endif
+      Vec out;
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+#if SGL_CUSTOM_AR_FUSED_RMSNORM_SUMS_BYPASS_LOAD == 1
+        const float val =
+            upcast_s(reinterpret_cast<const T*>(&reduced)[i]) +
+            upcast_s(reinterpret_cast<const T*>(&residual_packet)[i]);
+#elif SGL_CUSTOM_AR_FUSED_RMSNORM_SUMS_BYPASS_LOAD == 2
+        const float val =
+            upcast_s(reinterpret_cast<const T*>(&reduced)[i]) +
+            upcast_s(reinterpret_cast<const T*>(&residual_packet)[i]);
+#elif SGL_CUSTOM_AR_FUSED_RMSNORM_SUMS_BYPASS_LOAD == 3
+        const float val =
+            upcast_s(reinterpret_cast<const T*>(&reduced)[i]) +
+            upcast_s(reinterpret_cast<const T*>(&residual_packet)[i]);
+#else
+        const float val =
+            upcast_s(reinterpret_cast<const T*>(&reduced)[i]) +
+            upcast_s(reinterpret_cast<const T*>(&residual_packet)[i]);
+#endif
+        reinterpret_cast<T*>(&out)[i] = downcast_s<T>(val);
+        square_sum += val * val;
+      }
+      dst[idx] = out;
+    }
+    const float row_square_sum = block_sum_tid0(square_sum, warp_sums);
+    if (tid == 0) {
+      const int row = idx_base / packed_hidden;
+      if (row < rows) {
+        row_sums[row] = row_square_sum;
+      }
+    }
+    idx_base += stride;
+  } while (idx_base < packed_size);
+
+  multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+}
+
+template <
+    typename T,
+    int nranks,
+    bool kSharedInvRms,
+    bool kCacheWeightStatic,
+    int vlen = 8>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1)
+custom_all_reduce_residual_2shot_rmsnorm_row_kernel(
+    RankData data,
+    const RankData* data_ptr,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* __restrict__ residual_in,
+    T* __restrict__ residual_out,
+    T* __restrict__ norm_out,
+    const T* __restrict__ weight,
+    int rank,
+    int rows,
+    int hidden,
+    float eps,
+    int packed_size) {
+  if (data_ptr != nullptr) {
+    data = *data_ptr;
+  }
+  constexpr int nranks_sft = (nranks >> 1) - (nranks >> 3);
+  constexpr int coalesce_num = 8;
+  constexpr int coalesce_sft = 3;
+  constexpr int group_stride_sft = nranks_sft + coalesce_sft;
+  const int tid = threadIdx.x;
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int target_rank = (tid >> coalesce_sft) & (nranks - 1);
+  const int group_id = tid >> group_stride_sft;
+  const int coalesce_tid = tid & (coalesce_num - 1);
+  const int stride = gridDim.x * blockDim.x;
+  const int packed_hidden = hidden / vlen;
+  const float inv_hidden = 1.0f / static_cast<float>(hidden);
+
+  using Vec = array_t<T, vlen>;
+  __shared__ float inv_rms;
+  extern __shared__ __align__(16) unsigned char row_smem[];
+  const size_t weight_bytes =
+      kCacheWeightStatic ? static_cast<size_t>(hidden) * sizeof(T) : 0;
+  T* cached_weight = reinterpret_cast<T*>(row_smem);
+  float* warp_sums =
+      reinterpret_cast<float*>(row_smem + align_up(weight_bytes, alignof(float)));
+  const Vec* weight_vec = reinterpret_cast<const Vec*>(weight);
+
+  int idx_base = blockIdx.x * blockDim.x;
+  int idx_in_blk = coalesce_tid + (rank << coalesce_sft) + (group_id << group_stride_sft);
+
+  if constexpr (kCacheWeightStatic) {
+    for (int packed_col = tid; packed_col < packed_hidden; packed_col += blockDim.x) {
+      const int col0 = packed_col * vlen;
+      *(Vec*)(cached_weight + col0) = weight_vec[packed_col];
+    }
+    __syncthreads_lm();
+  }
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+  if (vlen != packed_t<T>::P::size && (hidden % vlen) == 0 &&
+      blockDim.x >= packed_hidden && packed_hidden <= kMaxThreadsPerBlock) {
+    const Vec* residual = reinterpret_cast<const Vec*>(residual_in);
+    Vec* residual_dst = reinterpret_cast<Vec*>(residual_out);
+    Vec* norm_dst = reinterpret_cast<Vec*>(norm_out);
+    for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+      const int packed_col = tid;
+      const int packed_idx = row * packed_hidden + packed_col;
+      float values[vlen] = {0};
+      float square_sum = 0.0f;
+      Vec out;
+      if (packed_col < packed_hidden) {
+#pragma unroll
+        for (int r = 0; r < nranks; ++r) {
+          const Vec packet = reinterpret_cast<const Vec*>(data.ptrs[r])[packed_idx];
+#pragma unroll
+          for (int i = 0; i < vlen; ++i) {
+            values[i] += upcast_s(reinterpret_cast<const T*>(&packet)[i]);
+          }
+        }
+        const Vec residual_packet = residual[packed_idx];
+#pragma unroll
+        for (int i = 0; i < vlen; ++i) {
+          values[i] += upcast_s(reinterpret_cast<const T*>(&residual_packet)[i]);
+          reinterpret_cast<T*>(&out)[i] = downcast_s<T>(values[i]);
+          square_sum += values[i] * values[i];
+        }
+      }
+      const float row_square_sum = block_sum(square_sum, warp_sums);
+      const float scale = fast_rsqrt(row_square_sum * inv_hidden + eps);
+      if (packed_col < packed_hidden) {
+        const Vec w = kCacheWeightStatic
+            ? *(reinterpret_cast<const Vec*>(cached_weight) + packed_col)
+            : weight_vec[packed_col];
+        Vec norm_packet;
+#pragma unroll
+        for (int i = 0; i < vlen; ++i) {
+          const float gamma = upcast_s(reinterpret_cast<const T*>(&w)[i]);
+          reinterpret_cast<T*>(&norm_packet)[i] =
+              downcast_s<T>(values[i] * scale * gamma);
+        }
+        residual_dst[packed_idx] = out;
+        norm_dst[packed_idx] = norm_packet;
+      }
+    }
+
+    if constexpr (!kRowSkipEndBarrier) {
+      multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+    }
+    return;
+  }
+  if constexpr (nranks == 2) {
+    if (hidden == 6144 && (hidden % vlen) == 0 && blockDim.x == 512) {
+      const Vec* local = reinterpret_cast<const Vec*>(data.ptrs[rank]);
+      const Vec* peer = reinterpret_cast<const Vec*>(data.ptrs[rank ^ 1]);
+      const Vec* residual = reinterpret_cast<const Vec*>(residual_in);
+      Vec* residual_dst = reinterpret_cast<Vec*>(residual_out);
+      Vec* norm_dst = reinterpret_cast<Vec*>(norm_out);
+      for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+        const int row_base = row * packed_hidden;
+        const int packed_col0 = tid;
+        const int packed_col1 = tid + blockDim.x;
+        const int packed_idx0 = row_base + packed_col0;
+        const int packed_idx1 = row_base + packed_col1;
+        float values0[vlen] = {0};
+        float values1[vlen] = {0};
+        float square_sum = 0.0f;
+        Vec out0;
+        Vec out1;
+
+        const Vec local0 = local[packed_idx0];
+        const Vec peer0 = peer[packed_idx0];
+        const Vec residual0 = residual[packed_idx0];
+#pragma unroll
+        for (int i = 0; i < vlen; ++i) {
+          float val = upcast_s(reinterpret_cast<const T*>(&local0)[i]);
+          val += upcast_s(reinterpret_cast<const T*>(&peer0)[i]);
+          val += upcast_s(reinterpret_cast<const T*>(&residual0)[i]);
+          values0[i] = val;
+          reinterpret_cast<T*>(&out0)[i] = downcast_s<T>(val);
+          square_sum += val * val;
+        }
+
+        if (packed_col1 < packed_hidden) {
+          const Vec local1 = local[packed_idx1];
+          const Vec peer1 = peer[packed_idx1];
+          const Vec residual1 = residual[packed_idx1];
+#pragma unroll
+          for (int i = 0; i < vlen; ++i) {
+            float val = upcast_s(reinterpret_cast<const T*>(&local1)[i]);
+            val += upcast_s(reinterpret_cast<const T*>(&peer1)[i]);
+            val += upcast_s(reinterpret_cast<const T*>(&residual1)[i]);
+            values1[i] = val;
+            reinterpret_cast<T*>(&out1)[i] = downcast_s<T>(val);
+            square_sum += val * val;
+          }
+        }
+
+        const float row_square_sum = block_sum(square_sum, warp_sums);
+        const float scale = fast_rsqrt(row_square_sum * inv_hidden + eps);
+
+        const Vec w0 = kCacheWeightStatic
+            ? *(reinterpret_cast<const Vec*>(cached_weight) + packed_col0)
+            : weight_vec[packed_col0];
+        Vec norm0;
+#pragma unroll
+        for (int i = 0; i < vlen; ++i) {
+          const float gamma = upcast_s(reinterpret_cast<const T*>(&w0)[i]);
+          reinterpret_cast<T*>(&norm0)[i] =
+              downcast_s<T>(values0[i] * scale * gamma);
+        }
+        residual_dst[packed_idx0] = out0;
+        norm_dst[packed_idx0] = norm0;
+
+        if (packed_col1 < packed_hidden) {
+          const Vec w1 = kCacheWeightStatic
+              ? *(reinterpret_cast<const Vec*>(cached_weight) + packed_col1)
+              : weight_vec[packed_col1];
+          Vec norm1;
+#pragma unroll
+          for (int i = 0; i < vlen; ++i) {
+            const float gamma = upcast_s(reinterpret_cast<const T*>(&w1)[i]);
+            reinterpret_cast<T*>(&norm1)[i] =
+                downcast_s<T>(values1[i] * scale * gamma);
+          }
+          residual_dst[packed_idx1] = out1;
+          norm_dst[packed_idx1] = norm1;
+        }
+      }
+
+      if constexpr (!kRowSkipEndBarrier) {
+        multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+      }
+      return;
+    }
+    if ((hidden == 1536 || hidden == 3072 ||
+         (hidden == 6144 && rows >= 8192)) &&
+        (hidden % vlen) == 0 && blockDim.x == packed_hidden) {
+      const Vec* local = reinterpret_cast<const Vec*>(data.ptrs[rank]);
+      const Vec* peer = reinterpret_cast<const Vec*>(data.ptrs[rank ^ 1]);
+      const Vec* residual = reinterpret_cast<const Vec*>(residual_in);
+      Vec* residual_dst = reinterpret_cast<Vec*>(residual_out);
+      Vec* norm_dst = reinterpret_cast<Vec*>(norm_out);
+      for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+        const int packed_idx = row * packed_hidden + tid;
+        const Vec local_packet = local[packed_idx];
+        const Vec peer_packet = peer[packed_idx];
+        const Vec residual_packet = residual[packed_idx];
+        float values[vlen] = {0};
+        float square_sum = 0.0f;
+        Vec out;
+#pragma unroll
+        for (int i = 0; i < vlen; ++i) {
+          float val = upcast_s(reinterpret_cast<const T*>(&local_packet)[i]);
+          val += upcast_s(reinterpret_cast<const T*>(&peer_packet)[i]);
+          val += upcast_s(reinterpret_cast<const T*>(&residual_packet)[i]);
+          values[i] = val;
+          reinterpret_cast<T*>(&out)[i] = downcast_s<T>(val);
+          square_sum += val * val;
+        }
+        residual_dst[packed_idx] = out;
+
+        const float row_square_sum =
+            row_group_sum_all_wide(square_sum, warp_sums, packed_hidden);
+        const float scale = fast_rsqrt(row_square_sum * inv_hidden + eps);
+
+        const Vec w = kCacheWeightStatic
+            ? *(reinterpret_cast<const Vec*>(cached_weight) + tid)
+            : weight_vec[tid];
+        Vec norm_packet;
+#pragma unroll
+        for (int i = 0; i < vlen; ++i) {
+          const float gamma = upcast_s(reinterpret_cast<const T*>(&w)[i]);
+          reinterpret_cast<T*>(&norm_packet)[i] =
+              downcast_s<T>(values[i] * scale * gamma);
+        }
+        norm_dst[packed_idx] = norm_packet;
+      }
+
+      if constexpr (!kRowSkipEndBarrier) {
+        multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+      }
+      return;
+    }
+  }
+  Vec* target_ptr = reinterpret_cast<Vec*>(const_cast<void*>(data.ptrs[target_rank]));
+  Vec* buffer_ptr = get_tmp_buf<Vec>(sg.signals[rank]);
+  do {
+    const int idx = idx_in_blk + idx_base;
+    float acc[vlen] = {0};
+    if (idx < packed_size) {
+#if SGL_CUSTOM_AR_VECTOR_LOAD
+      Vec raw = target_ptr[idx];
+      const T* src = reinterpret_cast<const T*>(&raw);
+#else
+      const T* src = reinterpret_cast<const T*>(&target_ptr[idx]);
+#endif
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        acc[i] = upcast_s(src[i]);
+      }
+    }
+    shfl_reduce<T, nranks, vlen>(acc);
+    if constexpr (nranks == 8) {
+      __shared__ float smem[kMaxThreadsPerBlock << 1];
+      if (lane < coalesce_num) {
+#pragma unroll
+        for (int i = 0; i < vlen; ++i) {
+          smem[warp * vlen * coalesce_num + coalesce_tid * vlen + i] = acc[i];
+        }
+      }
+      __syncthreads_lm();
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        acc[i] += smem[(warp ^ 1) * vlen * coalesce_num + coalesce_tid * vlen + i];
+      }
+    }
+    if (rank == target_rank && idx < packed_size) {
+      Vec res;
+#if SGL_CUSTOM_AR_FUSED_RMSNORM_TMP_WITH_RESIDUAL
+      const Vec residual_packet =
+          reinterpret_cast<const Vec*>(residual_in)[idx];
+#endif
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+#if SGL_CUSTOM_AR_FUSED_RMSNORM_TMP_WITH_RESIDUAL
+        const float val =
+            acc[i] + upcast_s(reinterpret_cast<const T*>(&residual_packet)[i]);
+        reinterpret_cast<T*>(&res)[i] = downcast_s<T>(val);
+#else
+        reinterpret_cast<T*>(&res)[i] = downcast_s<T>(acc[i]);
+#endif
+      }
+      buffer_ptr[idx] = res;
+    }
+    idx_base += stride;
+  } while (idx_base < packed_size);
+
+  __musa_barrier_slc();
+  __syncthreads_lm();
+  if (tid == 0) {
+    __threadfence_system_noflush();
+  }
+  if (tid < nranks) {
+#if SGL_CUSTOM_AR_ATOMIC_BARRIER
+    auto flag = atomicAdd(&self_sg->self_counter[blockIdx.x][tid], 1) + 1;
+    auto* peer = &sg.signals[tid]->peer_counter[flag & 1][blockIdx.x][rank];
+    auto* local = &self_sg->peer_counter[flag & 1][blockIdx.x][tid];
+    atomicExch(peer, flag);
+    while (atomicAdd(local, 0) != flag) {
+    }
+#else
+    auto flag = self_sg->self_counter[blockIdx.x][tid] + 1;
+    self_sg->self_counter[blockIdx.x][tid] = flag;
+    auto* peer = &sg.signals[tid]->peer_counter[flag & 1][blockIdx.x][rank];
+    auto* local = &self_sg->peer_counter[flag & 1][blockIdx.x][tid];
+    signal_store(peer, flag);
+    while (signal_load(local) != flag) {
+    }
+#endif
+  }
+  __syncthreads_lm();
+
+  const Vec* residual = reinterpret_cast<const Vec*>(residual_in);
+  Vec* residual_dst = reinterpret_cast<Vec*>(residual_out);
+  Vec* norm_dst = reinterpret_cast<Vec*>(norm_out);
+
+  if constexpr (nranks == 4 || nranks == 8) {
+    if (vlen != packed_t<T>::P::size && (hidden % vlen) == 0 &&
+        blockDim.x >= packed_hidden && packed_hidden <= kMaxThreadsPerBlock) {
+      const int packed_col = tid;
+      for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+        float values[vlen] = {0};
+        float square_sum = 0.0f;
+        Vec out;
+        if (tid < packed_hidden) {
+          const int packed_idx = row * packed_hidden + packed_col;
+          const int idx_target_rank =
+              (packed_idx >> coalesce_sft) & (nranks - 1);
+          const Vec* owner_tmp = get_tmp_buf<Vec>(sg.signals[idx_target_rank]);
+          const Vec reduced = owner_tmp[packed_idx];
+#if !SGL_CUSTOM_AR_FUSED_RMSNORM_TMP_WITH_RESIDUAL
+          const Vec residual_packet = residual[packed_idx];
+#endif
+#pragma unroll
+          for (int i = 0; i < vlen; ++i) {
+            float val = upcast_s(reinterpret_cast<const T*>(&reduced)[i]);
+#if !SGL_CUSTOM_AR_FUSED_RMSNORM_TMP_WITH_RESIDUAL
+            val += upcast_s(reinterpret_cast<const T*>(&residual_packet)[i]);
+#endif
+            values[i] = val;
+            reinterpret_cast<T*>(&out)[i] = downcast_s<T>(val);
+            square_sum += val * val;
+          }
+        }
+        const float row_square_sum = block_sum(square_sum, warp_sums);
+        const float scale = fast_rsqrt(row_square_sum * inv_hidden + eps);
+        if (tid < packed_hidden) {
+          const int packed_idx = row * packed_hidden + packed_col;
+          const Vec w = kCacheWeightStatic
+              ? *(reinterpret_cast<const Vec*>(cached_weight) + packed_col)
+              : weight_vec[packed_col];
+          Vec norm_packet;
+#pragma unroll
+          for (int i = 0; i < vlen; ++i) {
+            const float gamma = upcast_s(reinterpret_cast<const T*>(&w)[i]);
+            reinterpret_cast<T*>(&norm_packet)[i] =
+                downcast_s<T>(values[i] * scale * gamma);
+          }
+          residual_dst[packed_idx] = out;
+          norm_dst[packed_idx] = norm_packet;
+        }
+      }
+
+      if constexpr (!kRowSkipEndBarrier) {
+        multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+      }
+      return;
+    }
+  }
+
+  if (SGL_CUSTOM_AR_FUSED_RMSNORM_SMALL_ROWS &&
+      (hidden == 512 || hidden == 1024 || hidden == 2048) &&
+      blockDim.x == packed_hidden) {
+    const int packed_col = tid;
+    for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+      float values[vlen] = {0};
+      float square_sum = 0.0f;
+      const int packed_idx = row * packed_hidden + packed_col;
+      const int col_target_rank = (packed_col >> coalesce_sft) & (nranks - 1);
+      const Vec* owner_tmp = get_tmp_buf<Vec>(sg.signals[col_target_rank]);
+      const Vec reduced = owner_tmp[packed_idx];
+#if !SGL_CUSTOM_AR_FUSED_RMSNORM_TMP_WITH_RESIDUAL
+      const Vec residual_packet = residual[packed_idx];
+#endif
+      Vec out;
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        float val = upcast_s(reinterpret_cast<const T*>(&reduced)[i]);
+#if !SGL_CUSTOM_AR_FUSED_RMSNORM_TMP_WITH_RESIDUAL
+        val += upcast_s(reinterpret_cast<const T*>(&residual_packet)[i]);
+#endif
+        values[i] = val;
+        reinterpret_cast<T*>(&out)[i] = downcast_s<T>(val);
+        square_sum += val * val;
+      }
+      const float scale =
+          row_group_rms_scale_shared(square_sum, warp_sums, &inv_rms, inv_hidden,
+                                     eps, packed_hidden);
+      const Vec w = weight_vec[packed_col];
+      Vec norm_packet;
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        const float gamma = upcast_s(reinterpret_cast<const T*>(&w)[i]);
+        reinterpret_cast<T*>(&norm_packet)[i] =
+            downcast_s<T>(values[i] * scale * gamma);
+      }
+      residual_dst[packed_idx] = out;
+      norm_dst[packed_idx] = norm_packet;
+    }
+
+    if constexpr (!kRowSkipEndBarrier) {
+      multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+    }
+    return;
+  }
+
+  if ((hidden == 512 || hidden == 1024 || hidden == 2048) &&
+      blockDim.x >= packed_hidden && (blockDim.x % packed_hidden) == 0) {
+    const int rows_per_block = static_cast<int>(blockDim.x) / packed_hidden;
+    const int row_slot = tid / packed_hidden;
+    const int packed_col = tid - row_slot * packed_hidden;
+    for (int row_base = blockIdx.x * rows_per_block; row_base < rows;
+         row_base += gridDim.x * rows_per_block) {
+      const int row = row_base + row_slot;
+      float values[vlen] = {0};
+      float square_sum = 0.0f;
+      Vec out;
+      if (row < rows) {
+        const int packed_idx = row * packed_hidden + packed_col;
+        const int col_target_rank = (packed_col >> coalesce_sft) & (nranks - 1);
+        const Vec* owner_tmp = get_tmp_buf<Vec>(sg.signals[col_target_rank]);
+        const Vec reduced = owner_tmp[packed_idx];
+#if !SGL_CUSTOM_AR_FUSED_RMSNORM_TMP_WITH_RESIDUAL
+        const Vec residual_packet = residual[packed_idx];
+#endif
+#pragma unroll
+        for (int i = 0; i < vlen; ++i) {
+          float val = upcast_s(reinterpret_cast<const T*>(&reduced)[i]);
+#if !SGL_CUSTOM_AR_FUSED_RMSNORM_TMP_WITH_RESIDUAL
+          val += upcast_s(reinterpret_cast<const T*>(&residual_packet)[i]);
+#endif
+          values[i] = val;
+          reinterpret_cast<T*>(&out)[i] = downcast_s<T>(val);
+          square_sum += val * val;
+        }
+      }
+      const float row_square_sum =
+          row_group_sum_all(square_sum, warp_sums, packed_hidden);
+      const float scale = fast_rsqrt(row_square_sum * inv_hidden + eps);
+      if (row < rows) {
+        const int packed_idx = row * packed_hidden + packed_col;
+        const Vec w = weight_vec[packed_col];
+        Vec norm_packet;
+#pragma unroll
+        for (int i = 0; i < vlen; ++i) {
+          const float gamma = upcast_s(reinterpret_cast<const T*>(&w)[i]);
+          reinterpret_cast<T*>(&norm_packet)[i] =
+              downcast_s<T>(values[i] * scale * gamma);
+        }
+        residual_dst[packed_idx] = out;
+        norm_dst[packed_idx] = norm_packet;
+      }
+    }
+
+    if constexpr (!kRowSkipEndBarrier) {
+      multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+    }
+    return;
+  }
+
+  if (SGL_CUSTOM_AR_FUSED_RMSNORM_SMALL_ROWS &&
+      hidden == 4096 && blockDim.x == packed_hidden) {
+      const Vec* owner_tmp = get_tmp_buf<Vec>(sg.signals[target_rank]);
+      for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+        const int packed_idx = row * packed_hidden + tid;
+        float values[vlen] = {0};
+        float square_sum = 0.0f;
+        const Vec reduced = owner_tmp[packed_idx];
+#if !SGL_CUSTOM_AR_FUSED_RMSNORM_TMP_WITH_RESIDUAL
+        const Vec residual_packet = residual[packed_idx];
+#endif
+        Vec out;
+#pragma unroll
+        for (int i = 0; i < vlen; ++i) {
+          float val = upcast_s(reinterpret_cast<const T*>(&reduced)[i]);
+#if !SGL_CUSTOM_AR_FUSED_RMSNORM_TMP_WITH_RESIDUAL
+          val += upcast_s(reinterpret_cast<const T*>(&residual_packet)[i]);
+#endif
+          values[i] = val;
+          reinterpret_cast<T*>(&out)[i] = downcast_s<T>(val);
+          square_sum += val * val;
+        }
+        const float row_square_sum =
+            hidden == 3072 ? block_sum_12warps(square_sum, warp_sums)
+                           : block_sum(square_sum, warp_sums);
+        const float scale = fast_rsqrt(row_square_sum * inv_hidden + eps);
+
+        Vec norm_packet;
+        const Vec w = kCacheWeightStatic
+            ? *(reinterpret_cast<const Vec*>(cached_weight) + tid)
+            : weight_vec[tid];
+#pragma unroll
+        for (int i = 0; i < vlen; ++i) {
+          const float gamma = upcast_s(reinterpret_cast<const T*>(&w)[i]);
+          reinterpret_cast<T*>(&norm_packet)[i] =
+              downcast_s<T>(values[i] * scale * gamma);
+        }
+        residual_dst[packed_idx] = out;
+        norm_dst[packed_idx] = norm_packet;
+      }
+
+      if constexpr (!kRowSkipEndBarrier) {
+        multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+      }
+      return;
+  }
+
+  if constexpr (nranks == 4 || nranks == 8) {
+    if ((hidden == 1536 || hidden == 3072 || hidden == 4096) &&
+        blockDim.x == 512) {
+      const Vec* owner_tmp = get_tmp_buf<Vec>(sg.signals[target_rank]);
+      for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+        const int packed_idx = row * packed_hidden + tid;
+        float values[vlen] = {0};
+        float square_sum = 0.0f;
+        if (tid < packed_hidden) {
+          const Vec reduced = owner_tmp[packed_idx];
+#if !SGL_CUSTOM_AR_FUSED_RMSNORM_TMP_WITH_RESIDUAL
+          const Vec residual_packet = residual[packed_idx];
+#endif
+          Vec out;
+#pragma unroll
+          for (int i = 0; i < vlen; ++i) {
+            float val = upcast_s(reinterpret_cast<const T*>(&reduced)[i]);
+#if !SGL_CUSTOM_AR_FUSED_RMSNORM_TMP_WITH_RESIDUAL
+            val += upcast_s(reinterpret_cast<const T*>(&residual_packet)[i]);
+#endif
+            values[i] = val;
+            reinterpret_cast<T*>(&out)[i] = downcast_s<T>(val);
+            square_sum += val * val;
+          }
+          residual_dst[packed_idx] = out;
+        }
+        const float row_square_sum =
+            hidden == 4096
+                ? block_sum(square_sum, warp_sums)
+                : (hidden == 3072
+                       ? block_sum_12warps(square_sum, warp_sums)
+                       : block_sum_nwarps<6>(square_sum, warp_sums));
+        const float scale = fast_rsqrt(row_square_sum * inv_hidden + eps);
+
+        if (tid < packed_hidden) {
+          Vec norm_packet;
+          const Vec w = kCacheWeightStatic
+              ? *(reinterpret_cast<const Vec*>(cached_weight) + tid)
+              : weight_vec[tid];
+#pragma unroll
+          for (int i = 0; i < vlen; ++i) {
+            const float gamma = upcast_s(reinterpret_cast<const T*>(&w)[i]);
+            reinterpret_cast<T*>(&norm_packet)[i] =
+                downcast_s<T>(values[i] * scale * gamma);
+          }
+          norm_dst[packed_idx] = norm_packet;
+        }
+      }
+
+      if constexpr (!kRowSkipEndBarrier) {
+        multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+      }
+      return;
+    }
+  }
+  buffer_ptr = get_tmp_buf<Vec>(sg.signals[target_rank]);
+  idx_in_blk = coalesce_tid + (target_rank << coalesce_sft) + (group_id << group_stride_sft);
+  idx_base = blockIdx.x * blockDim.x;
+  do {
+    const int idx = idx_in_blk + idx_base;
+    float values[vlen] = {0};
+    float square_sum = 0.0f;
+    if (idx < packed_size) {
+#if SGL_CUSTOM_AR_FUSED_RMSNORM_SUMS_BYPASS_LOAD == 1 || \
+    SGL_CUSTOM_AR_FUSED_RMSNORM_SUMS_BYPASS_LOAD == 2
+      const Vec8<T> reduced =
+          Vec8<T>::load_byp_slc(reinterpret_cast<const T*>(buffer_ptr), idx * vlen);
+#else
+      const Vec reduced = buffer_ptr[idx];
+#endif
+#if !SGL_CUSTOM_AR_FUSED_RMSNORM_TMP_WITH_RESIDUAL
+#if SGL_CUSTOM_AR_FUSED_RMSNORM_SUMS_BYPASS_LOAD == 1 || \
+    SGL_CUSTOM_AR_FUSED_RMSNORM_SUMS_BYPASS_LOAD == 3
+      const Vec8<T> residual_packet = Vec8<T>::load_byp_slc(residual_in, idx * vlen);
+#else
+      const Vec residual_packet = residual[idx];
+#endif
+#endif
+      Vec out;
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+#if SGL_CUSTOM_AR_FUSED_RMSNORM_TMP_WITH_RESIDUAL
+#if SGL_CUSTOM_AR_FUSED_RMSNORM_SUMS_BYPASS_LOAD == 1 || \
+    SGL_CUSTOM_AR_FUSED_RMSNORM_SUMS_BYPASS_LOAD == 2
+        float val = upcast_s(reinterpret_cast<const T*>(&reduced)[i]);
+#else
+        float val = upcast_s(reinterpret_cast<const T*>(&reduced)[i]);
+#endif
+#else
+#if SGL_CUSTOM_AR_FUSED_RMSNORM_SUMS_BYPASS_LOAD == 1
+        float val = upcast_s(reinterpret_cast<const T*>(&reduced)[i]);
+        val += upcast_s(reinterpret_cast<const T*>(&residual_packet)[i]);
+#elif SGL_CUSTOM_AR_FUSED_RMSNORM_SUMS_BYPASS_LOAD == 2
+        float val = upcast_s(reinterpret_cast<const T*>(&reduced)[i]);
+        val += upcast_s(reinterpret_cast<const T*>(&residual_packet)[i]);
+#elif SGL_CUSTOM_AR_FUSED_RMSNORM_SUMS_BYPASS_LOAD == 3
+        float val = upcast_s(reinterpret_cast<const T*>(&reduced)[i]);
+        val += upcast_s(reinterpret_cast<const T*>(&residual_packet)[i]);
+#else
+        float val = upcast_s(reinterpret_cast<const T*>(&reduced)[i]);
+        val += upcast_s(reinterpret_cast<const T*>(&residual_packet)[i]);
+#endif
+#endif
+        values[i] = val;
+        reinterpret_cast<T*>(&out)[i] = downcast_s<T>(val);
+        square_sum += val * val;
+      }
+      residual_dst[idx] = out;
+    }
+    const float row_square_sum = block_sum(square_sum, warp_sums);
+    if constexpr (kSharedInvRms) {
+      if (tid == 0) {
+        inv_rms = fast_rsqrt(row_square_sum * inv_hidden + eps);
+      }
+      __syncthreads_lm();
+    }
+    if (idx < packed_size) {
+      const int packed_col = idx % packed_hidden;
+      const Vec w = kCacheWeightStatic
+          ? *(reinterpret_cast<const Vec*>(cached_weight) + packed_col)
+          : weight_vec[packed_col];
+      Vec norm_packet;
+      float scale;
+      if constexpr (kSharedInvRms) {
+        scale = inv_rms;
+      } else if constexpr (kRowWarpInvRms) {
+        scale = lane == 0 ? fast_rsqrt(row_square_sum * inv_hidden + eps) : 0.0f;
+        scale = __shfl_sync(0xffffffff, scale, 0, 32);
+      } else {
+        scale = fast_rsqrt(row_square_sum * inv_hidden + eps);
+      }
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        const float gamma = upcast_s(reinterpret_cast<const T*>(&w)[i]);
+        reinterpret_cast<T*>(&norm_packet)[i] =
+            downcast_s<T>(values[i] * scale * gamma);
+      }
+      norm_dst[idx] = norm_packet;
+    }
+    idx_base += stride;
+  } while (idx_base < packed_size);
+
+  multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+}
+
+template <typename T, int nranks, int vlen = 8>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1)
+custom_all_reduce_residual_rmsnorm_shfl_2stage_kernel(
+    RankData data,
+    const RankData* data_ptr,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* __restrict__ residual_in,
+    T* __restrict__ residual_out,
+    T* __restrict__ norm_out,
+    const T* __restrict__ weight,
+    int rank,
+    int rows,
+    int hidden,
+    float eps,
+    int packed_size) {
+  if (data_ptr != nullptr) {
+    data = *data_ptr;
+  }
+  constexpr int nranks_sft = (nranks >> 1) - (nranks >> 3);
+  constexpr int coalesce_num = 8;
+  constexpr int coalesce_sft = 3;
+  constexpr int group_stride_sft = nranks_sft + coalesce_sft;
+  constexpr int group_stride = 1 << group_stride_sft;
+  constexpr int pack = vlen;
+  const int tid = threadIdx.x;
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int target_rank = (tid >> coalesce_sft) & (nranks - 1);
+  const int group_id = tid >> group_stride_sft;
+  const int coalesce_tid = tid & (coalesce_num - 1);
+  const int stride = gridDim.x * blockDim.x;
+  const int packed_hidden = hidden / pack;
+
+  typedef int16_t Vec __attribute__((vector_size(16)));
+
+  extern __shared__ __align__(16) unsigned char smem[];
+  __shared__ float inv_rms;
+
+  const bool cache_float_values = hidden <= kCacheHiddenLimit;
+  const bool cache_t_values =
+      !cache_float_values && hidden != 4096 && hidden <= kTypedCacheHiddenLimit;
+  const bool cache_weight = rmsnorm_cache_weight_hidden(hidden, rows);
+  float* cached = reinterpret_cast<float*>(smem);
+  T* cached_t = reinterpret_cast<T*>(smem);
+  const size_t cache_bytes =
+      cache_float_values
+          ? static_cast<size_t>(hidden) * sizeof(float)
+          : (cache_t_values ? static_cast<size_t>(hidden) * sizeof(T) : 0);
+  const size_t weight_offset = align_up(cache_bytes, alignof(T));
+  T* cached_weight = reinterpret_cast<T*>(smem + weight_offset);
+  const size_t weight_bytes = cache_weight ? static_cast<size_t>(hidden) * sizeof(T) : 0;
+  float* warp_sums =
+      reinterpret_cast<float*>(smem + align_up(weight_offset + weight_bytes, alignof(float)));
+
+  if (cache_weight) {
+    for (int packed_col = tid; packed_col < packed_hidden; packed_col += blockDim.x) {
+      const int col0 = packed_col * pack;
+      *(Vec8<T>*)(cached_weight + col0) = Vec8<T>::load(weight, col0);
+    }
+  }
+
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+
+  int idx_base = blockIdx.x * blockDim.x;
+  int idx_in_blk = coalesce_tid + (rank << coalesce_sft) + (group_id << group_stride_sft);
+  Vec* target_ptr = reinterpret_cast<Vec*>(const_cast<void*>(data.ptrs[target_rank]));
+  Vec* buffer_ptr = get_tmp_buf<Vec>(sg.signals[rank]);
+  do {
+    const int idx = idx_in_blk + idx_base;
+    float acc[vlen] = {0};
+    if (idx < packed_size) {
+#if SGL_CUSTOM_AR_VECTOR_LOAD
+      Vec raw = target_ptr[idx];
+      const T* src = reinterpret_cast<const T*>(&raw);
+#else
+      const T* src = reinterpret_cast<const T*>(&target_ptr[idx]);
+#endif
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        acc[i] = upcast_s(src[i]);
+      }
+    }
+    shfl_reduce<T, nranks, vlen>(acc);
+    if constexpr (nranks == 8) {
+      __shared__ float reduce_smem[kMaxThreadsPerBlock << 1];
+      if (lane < coalesce_num) {
+#pragma unroll
+        for (int i = 0; i < vlen; ++i) {
+          reduce_smem[warp * vlen * coalesce_num + coalesce_tid * vlen + i] = acc[i];
+        }
+      }
+      __syncthreads_lm();
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        acc[i] += reduce_smem[(warp ^ 1) * vlen * coalesce_num + coalesce_tid * vlen + i];
+      }
+    }
+    if (rank == target_rank && idx < packed_size) {
+      Vec res;
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        reinterpret_cast<T*>(&res)[i] = downcast_s<T>(acc[i]);
+      }
+      buffer_ptr[idx] = res;
+    }
+    idx_base += stride;
+  } while (idx_base < packed_size);
+
+  __musa_barrier_slc();
+  __syncthreads_lm();
+  if (tid == 0) {
+    __threadfence_system_noflush();
+  }
+  if (tid < nranks) {
+#if SGL_CUSTOM_AR_ATOMIC_BARRIER
+    auto flag = atomicAdd(&self_sg->self_counter[blockIdx.x][tid], 1) + 1;
+    auto* peer = &sg.signals[tid]->peer_counter[flag & 1][blockIdx.x][rank];
+    auto* local = &self_sg->peer_counter[flag & 1][blockIdx.x][tid];
+    atomicExch(peer, flag);
+    while (atomicAdd(local, 0) != flag) {
+    }
+#else
+    auto flag = self_sg->self_counter[blockIdx.x][tid] + 1;
+    self_sg->self_counter[blockIdx.x][tid] = flag;
+    auto* peer = &sg.signals[tid]->peer_counter[flag & 1][blockIdx.x][rank];
+    auto* local = &self_sg->peer_counter[flag & 1][blockIdx.x][tid];
+    signal_store(peer, flag);
+    while (signal_load(local) != flag) {
+    }
+#endif
+  }
+  __syncthreads_lm();
+
+  for (int row = blockIdx.x; row < rows; row += gridDim.x) {
+    const int base = row * hidden;
+    const int packed_base = row * packed_hidden;
+    float square_sum = 0.0f;
+    for (int packed_col = tid; packed_col < packed_hidden; packed_col += blockDim.x) {
+      const int packed_idx = packed_base + packed_col;
+      const int owner = (packed_idx & (group_stride - 1)) >> coalesce_sft;
+      const Vec* owner_tmp = get_tmp_buf<Vec>(sg.signals[owner]);
+      const Vec reduced = owner_tmp[packed_idx];
+      const Vec residual_packet = reinterpret_cast<const Vec*>(residual_in)[packed_idx];
+      Vec residual_packet_out;
+#pragma unroll
+      for (int i = 0; i < vlen; ++i) {
+        const int col = packed_col * pack + i;
+        float val = upcast_s(reinterpret_cast<const T*>(&reduced)[i]);
+        val += upcast_s(reinterpret_cast<const T*>(&residual_packet)[i]);
+        const T residual_value = downcast_s<T>(val);
+        reinterpret_cast<T*>(&residual_packet_out)[i] = residual_value;
+        if (cache_float_values) {
+          cached[col] = val;
+        } else if (cache_t_values) {
+          cached_t[col] = residual_value;
+        }
+        square_sum += val * val;
+      }
+      reinterpret_cast<Vec*>(residual_out)[packed_idx] = residual_packet_out;
+    }
+
+    const float row_square_sum = block_sum(square_sum, warp_sums);
+    if (tid == 0) {
+      inv_rms = fast_rsqrt(row_square_sum / static_cast<float>(hidden) + eps);
+    }
+    __syncthreads_lm();
+
+    for (int packed_col = tid; packed_col < packed_hidden; packed_col += blockDim.x) {
+      const int col0 = packed_col * pack;
+      Float8 sum_float;
+      if (cache_float_values) {
+        sum_float = *(Float8*)(cached + col0);
+      } else if (cache_t_values) {
+        Vec8<T> r = *(Vec8<T>*)(cached_t + col0);
+#pragma unroll
+        for (int i = 0; i < pack; ++i) {
+          sum_float.val.elem[i] = to_float<T>(r.val.elem[i]);
+        }
+      } else {
+        Vec8<T> r = Vec8<T>::load(residual_out + base, col0);
+#pragma unroll
+        for (int i = 0; i < pack; ++i) {
+          sum_float.val.elem[i] = to_float<T>(r.val.elem[i]);
+        }
+      }
+      Vec8<T> w = cache_weight ? *(Vec8<T>*)(cached_weight + col0) : Vec8<T>::load(weight, col0);
+      Vec8<T> dst;
+#pragma unroll
+      for (int i = 0; i < pack; ++i) {
+        const float gamma = to_float<T>(w.val.elem[i]);
+        dst.val.elem[i] = from_float<T>(sum_float.val.elem[i] * inv_rms * gamma);
+      }
+      *(Vec8<T>*)(norm_out + base + col0) = dst;
+    }
+    __syncthreads_lm();
+  }
+
+  multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+}
+
+template <typename T, int nranks>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1)
+custom_all_reduce_residual_rmsnorm_push_polling_kernel(
+    RankData data,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* __restrict__ input,
+    const T* __restrict__ residual_in,
+    T* __restrict__ residual_out,
+    T* __restrict__ norm_out,
+    const T* __restrict__ weight,
+    int rank,
+    int rows,
+    int hidden,
+    float eps,
+    int packed_size) {
+  static_assert(nranks == 4, "push-polling fused RMSNorm is only tuned for TP4");
+  extern __shared__ __align__(16) unsigned char smem[];
+  auto* warp_sums = reinterpret_cast<float*>(smem);
+  using P = typename packed_t<T>::P;
+  constexpr int pack = P::size;
+  const int tid = threadIdx.x;
+  const int packed_hidden = hidden / pack;
+  const int rows_per_block = blockDim.x / packed_hidden;
+  const int row_slot = tid / packed_hidden;
+  const int packed_col = tid - row_slot * packed_hidden;
+  const int col0 = packed_col * pack;
+  const int bytes = packed_size * static_cast<int>(sizeof(P));
+  constexpr int push_slots = SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_SLOTS;
+  const int epoch = self_sg->push_epoch[blockIdx.x] % push_slots;
+  const int slot_offset = epoch * nranks * packed_size;
+
+  const auto* src = reinterpret_cast<const P*>(input);
+#pragma unroll
+  for (int peer = 0; peer < nranks; ++peer) {
+    auto* dst = reinterpret_cast<P*>(
+        reinterpret_cast<char*>(const_cast<void*>(data.ptrs[peer])) +
+        (epoch * nranks + rank) * bytes);
+    for (int idx = tid + blockIdx.x * blockDim.x; idx < packed_size;
+         idx += blockDim.x * gridDim.x) {
+      P value = src[idx];
+      clear_pos_zero(value);
+      store_volatile_packet(&dst[idx], value);
+    }
+  }
+
+  __musa_barrier_slc();
+  __syncthreads_lm();
+  if (tid == 0) {
+    __threadfence_system_noflush();
+  }
+  __syncthreads_lm();
+
+  const auto* local_buffer =
+      reinterpret_cast<const P*>(data.ptrs[rank]) + slot_offset;
+  P* reset_ptr = reinterpret_cast<P*>(
+      reinterpret_cast<char*>(const_cast<void*>(data.ptrs[rank])) +
+      epoch * nranks * bytes);
+  const P pos_zero = make_pos_zero_packet<P>();
+
+  for (int row_base = blockIdx.x * rows_per_block; row_base < rows;
+       row_base += gridDim.x * rows_per_block) {
+    const int row = row_base + row_slot;
+    Float8 sum_float;
+    float square_sum_row = 0.0f;
+    int packed_idx = 0;
+    if (row < rows) {
+      packed_idx = row * packed_hidden + packed_col;
+      P values[nranks];
+      while (true) {
+        bool waiting = false;
+        flushInv_byp();
+#pragma unroll
+        for (int i = 0; i < nranks; ++i) {
+          values[i] = load_volatile_packet(local_buffer + i * packed_size + packed_idx);
+          waiting |= has_pos_zero(values[i]);
+        }
+        if (!waiting) {
+          break;
+        }
+      }
+      auto acc = upcast(values[0]);
+#pragma unroll
+      for (int i = 1; i < nranks; ++i) {
+        packed_assign_add(acc, upcast(values[i]));
+      }
+      Vec8<T> residual_vec = Vec8<T>::load(residual_in + row * hidden, col0);
+      Vec8<T> residual_vec_out;
+#pragma unroll
+      for (int i = 0; i < pack; ++i) {
+        float val = acc.data[i] + to_float<T>(residual_vec.val.elem[i]);
+        sum_float.val.elem[i] = val;
+        residual_vec_out.val.elem[i] = from_float<T>(val);
+        square_sum_row += val * val;
+      }
+      *(Vec8<T>*)(residual_out + row * hidden + col0) = residual_vec_out;
+    }
+
+    const float row_square_sum =
+        row_group_sum_all_wide(square_sum_row, warp_sums, packed_hidden);
+    const float scale =
+        fast_rsqrt(row_square_sum / static_cast<float>(hidden) + eps);
+
+    if (row < rows) {
+      Vec8<T> w = Vec8<T>::load(weight, col0);
+      Vec8<T> dst;
+#pragma unroll
+      for (int i = 0; i < pack; ++i) {
+        const float gamma = to_float<T>(w.val.elem[i]);
+        dst.val.elem[i] = from_float<T>(sum_float.val.elem[i] * scale * gamma);
+      }
+      *(Vec8<T>*)(norm_out + row * hidden + col0) = dst;
+#pragma unroll
+      for (int i = 0; i < nranks; ++i) {
+        reset_ptr[i * packed_size + packed_idx] = pos_zero;
+      }
+    }
+  }
+
+  __syncthreads_lm();
+  if (tid == 0) {
+    self_sg->push_epoch[blockIdx.x] = (epoch + 1) % push_slots;
+  }
+#if !SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_SKIP_END_BARRIER
+  multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+#endif
+}
+
+template <typename T, int nranks>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1)
+custom_all_reduce_residual_rmsnorm_lamport_init_kernel(
+    RankData data,
+    RankSignals sg,
+    Signal* self_sg,
+    int rank,
+    int packed_size,
+    int slot_stride_packed) {
+  using P = typename packed_t<T>::P;
+  constexpr int push_slots = 3;
+  const int tid = threadIdx.x;
+  const P pos_zero = make_pos_zero_packet<P>();
+
+  if (blockIdx.x == 0 && tid == 0) {
+    self_sg->lamport_counter = 0;
+    self_sg->lamport_flag = 0;
+    self_sg->lamport_clear_packed = 0;
+  }
+
+  auto* base = reinterpret_cast<P*>(const_cast<void*>(data.ptrs[rank]));
+  const int total_packets = push_slots * nranks * packed_size;
+  for (int linear = tid + blockIdx.x * blockDim.x; linear < total_packets;
+       linear += blockDim.x * gridDim.x) {
+    const int slot_rank = linear / packed_size;
+    const int offset = linear - slot_rank * packed_size;
+    store_volatile_packet(base + slot_rank * slot_stride_packed + offset, pos_zero);
+  }
+
+  __musa_barrier_slc();
+  __syncthreads_lm();
+  if (tid == 0) {
+    __threadfence_system_noflush();
+  }
+  __syncthreads_lm();
+  multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+}
+
+template <typename T, int nranks>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1)
+custom_all_reduce_residual_rmsnorm_lamport_kernel(
+    RankData data,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* __restrict__ input,
+    const T* __restrict__ residual_in,
+    T* __restrict__ residual_out,
+    T* __restrict__ norm_out,
+    const T* __restrict__ weight,
+    int rank,
+    int rows,
+    int hidden,
+    float eps,
+    int packed_size,
+    int slot_stride_packed) {
+  static_assert(
+      nranks == 2 || nranks == 4,
+      "Lamport fused RMSNorm is implemented for TP2/TP4");
+  extern __shared__ __align__(16) unsigned char smem[];
+  auto* warp_sums = reinterpret_cast<float*>(smem);
+  auto* shared_inv_rms = warp_sums + ((blockDim.x + 31) >> 5);
+  using P = typename packed_t<T>::P;
+  constexpr int pack = P::size;
+  constexpr int push_slots = 3;
+  const int tid = threadIdx.x;
+  const int packed_hidden = hidden / pack;
+  const int rows_per_block = blockDim.x / packed_hidden;
+  const int row_slot = tid / packed_hidden;
+  const int packed_col = tid - row_slot * packed_hidden;
+  const int col0 = packed_col * pack;
+  const int flag = self_sg->lamport_flag % push_slots;
+  const int clear_slot = (flag + 2) % push_slots;
+  const int clear_packed = static_cast<int>(self_sg->lamport_clear_packed);
+  const auto* src = reinterpret_cast<const P*>(input);
+
+  __syncthreads_lm();
+  if (tid == 0) {
+    atomicAdd(&self_sg->lamport_counter, 1);
+  }
+
+#pragma unroll
+  for (int peer = 0; peer < nranks; ++peer) {
+    auto* dst = reinterpret_cast<P*>(const_cast<void*>(data.ptrs[peer])) +
+                (flag * nranks + rank) * slot_stride_packed;
+    for (int idx = tid + blockIdx.x * blockDim.x; idx < packed_size;
+         idx += blockDim.x * gridDim.x) {
+      P value = src[idx];
+      clear_pos_zero(value);
+      store_volatile_packet(&dst[idx], value);
+    }
+  }
+
+  auto* clear_ptr = reinterpret_cast<P*>(const_cast<void*>(data.ptrs[rank])) +
+                    clear_slot * nranks * slot_stride_packed;
+  const P pos_zero = make_pos_zero_packet<P>();
+  const int clear_limit = min(clear_packed, nranks * slot_stride_packed);
+  for (int idx = tid + blockIdx.x * blockDim.x; idx < clear_limit;
+       idx += blockDim.x * gridDim.x) {
+    store_volatile_packet(&clear_ptr[idx], pos_zero);
+  }
+
+#if !SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_SKIP_END_BARRIER
+  __musa_barrier_slc();
+  __syncthreads_lm();
+  if (tid == 0) {
+    __threadfence_system_noflush();
+  }
+  __syncthreads_lm();
+#endif
+
+  const auto* local_buffer =
+      reinterpret_cast<const P*>(data.ptrs[rank]) + flag * nranks * slot_stride_packed;
+
+  for (int row_base = blockIdx.x * rows_per_block; row_base < rows;
+       row_base += gridDim.x * rows_per_block) {
+    const int row = row_base + row_slot;
+    Float8 sum_float;
+    float square_sum_row = 0.0f;
+    if (row < rows) {
+      const int packed_idx = row * packed_hidden + packed_col;
+      P values[nranks];
+      while (true) {
+        bool waiting = false;
+        flushInv_byp();
+#pragma unroll
+        for (int i = 0; i < nranks; ++i) {
+          values[i] = load_volatile_packet(local_buffer + i * slot_stride_packed + packed_idx);
+          waiting |= has_pos_zero(values[i]);
+        }
+        if (!waiting) {
+          break;
+        }
+      }
+      auto acc = upcast(values[0]);
+#pragma unroll
+      for (int i = 1; i < nranks; ++i) {
+        packed_assign_add(acc, upcast(values[i]));
+      }
+      Vec8<T> residual_vec = Vec8<T>::load(residual_in + row * hidden, col0);
+      Vec8<T> residual_vec_out;
+#pragma unroll
+      for (int i = 0; i < pack; ++i) {
+        float val = acc.data[i] + to_float<T>(residual_vec.val.elem[i]);
+        sum_float.val.elem[i] = val;
+        residual_vec_out.val.elem[i] = from_float<T>(val);
+        square_sum_row += val * val;
+      }
+      *(Vec8<T>*)(residual_out + row * hidden + col0) = residual_vec_out;
+    }
+
+    const float scale =
+        packed_hidden == 512 && rows_per_block == 1
+            ? block_rms_scale_16warps(
+                  square_sum_row, warp_sums, shared_inv_rms,
+                  1.0f / static_cast<float>(hidden), eps)
+            : fast_rsqrt(
+                  row_group_sum_all_wide(square_sum_row, warp_sums, packed_hidden) /
+                      static_cast<float>(hidden) +
+                  eps);
+
+    if (row < rows) {
+      Vec8<T> w = Vec8<T>::load(weight, col0);
+      Vec8<T> dst;
+#pragma unroll
+      for (int i = 0; i < pack; ++i) {
+        const float gamma = to_float<T>(w.val.elem[i]);
+        dst.val.elem[i] = from_float<T>(sum_float.val.elem[i] * scale * gamma);
+      }
+      *(Vec8<T>*)(norm_out + row * hidden + col0) = dst;
+    }
+  }
+
+  __syncthreads_lm();
+  if (blockIdx.x == 0 && tid == 0) {
+    while (*reinterpret_cast<volatile FlagType*>(&self_sg->lamport_counter) !=
+           static_cast<FlagType>(gridDim.x)) {
+    }
+    self_sg->lamport_flag = (flag + 1) % push_slots;
+    self_sg->lamport_clear_packed = packed_size * nranks;
+    self_sg->lamport_counter = 0;
+  }
+#if SGL_CUSTOM_AR_FUSED_RMSNORM_LAMPORT_END_BARRIER
+  if (rows <= 32 && blockIdx.x == 0) {
+    __syncthreads_lm();
+    multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+  }
+#endif
+}
+
+template <typename T, int nranks>
+void launch_fused_ar_rmsnorm(
+    RankData data,
+    const RankData* data_ptr,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* input_src,
+    const T* residual_in,
+    T* residual_out,
+    T* norm_out,
+    const T* weight,
+    int rank,
+    int rows,
+    int hidden,
+    float eps,
+    int slot_stride_packed,
+    musaStream_t stream) {
+  constexpr int pack = packed_t<T>::P::size;
+  const int threads = std::min(kDefaultThreads, kMaxThreadsPerBlock);
+  const int block_limit =
+      hidden == 4096
+          ? (nranks == 2 && rows >= 1024
+                 ? (rows >= 8192 ? 42 : (rows >= 4096 ? 44 : 42))
+                 : kH4096BlockLimit)
+          : (hidden == 8192 ? kH8192BlockLimit : kDefaultBlockLimit);
+  const int blocks = std::min(block_limit, rows);
+  if (blocks <= 0) {
+    return;
+  }
+  const size_t smem_bytes =
+      align_up(
+          align_up(
+              hidden <= kCacheHiddenLimit
+                  ? static_cast<size_t>(hidden) * sizeof(float)
+                  : (hidden != 4096 && hidden <= kTypedCacheHiddenLimit
+                         ? static_cast<size_t>(hidden) * sizeof(T)
+                         : 0),
+              alignof(T)) +
+              (rmsnorm_cache_weight_hidden(hidden, rows)
+                   ? static_cast<size_t>(hidden) * sizeof(T)
+                   : 0),
+          alignof(float)) +
+      static_cast<size_t>((threads + 31) / 32) * sizeof(float);
+  const int64_t packed_size64 =
+      (static_cast<int64_t>(rows) * static_cast<int64_t>(hidden)) / pack;
+#if SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_POLLING
+  if constexpr ((nranks == 2 || nranks == 4) && !std::is_same<T, float>::value) {
+    if (input_src != nullptr &&
+        rows >= SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_MIN_ROWS &&
+        rows <= SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_MAX_ROWS &&
+        rows <= kOneShotMaxToken && hidden == 4096 && (hidden % pack) == 0 &&
+        packed_size64 <= static_cast<int64_t>(std::numeric_limits<int32_t>::max())) {
+      const int push_threads = 512;
+      const int push_blocks = std::max(1, std::min(get_musa_sm_count(), rows));
+      const size_t push_smem =
+          static_cast<size_t>((push_threads + 31) / 32 + 1) * sizeof(float);
+#if SGL_CUSTOM_AR_FUSED_RMSNORM_LAMPORT_PUSH
+      if (slot_stride_packed >= static_cast<int>(packed_size64)) {
+        custom_all_reduce_residual_rmsnorm_lamport_kernel<T, nranks>
+            <<<push_blocks, push_threads, push_smem, stream>>>(
+                data, sg, self_sg, input_src, residual_in, residual_out, norm_out,
+                weight, rank, rows, hidden, eps, static_cast<int>(packed_size64),
+                slot_stride_packed);
+        return;
+      }
+#endif
+      if constexpr (nranks == 4) {
+        custom_all_reduce_residual_rmsnorm_push_polling_kernel<T, nranks>
+            <<<push_blocks, push_threads, push_smem, stream>>>(
+                data, sg, self_sg, input_src, residual_in, residual_out, norm_out,
+                weight, rank, rows, hidden, eps, static_cast<int>(packed_size64));
+        return;
+      }
+    }
+  }
+#endif
+#if SGL_CUSTOM_AR_FUSED_RMSNORM_WARP_ROWS
+  if constexpr ((nranks == 2 || nranks == 4 || nranks == 8) &&
+                !std::is_same<T, float>::value) {
+    if (rows <= 512 && (hidden == 512 || hidden == 1024 || hidden == 2048)) {
+      constexpr int warp_threads = 256;
+      constexpr int warps_per_block = warp_threads / 32;
+      const int warp_blocks = std::min(
+          block_limit, (rows + warps_per_block - 1) / warps_per_block);
+      custom_all_reduce_residual_rmsnorm_warp_rows_kernel<T, nranks>
+          <<<warp_blocks, warp_threads, 0, stream>>>(
+              data, data_ptr, sg, self_sg, residual_in, residual_out, norm_out, weight,
+              rank, rows, hidden, eps);
+      return;
+    }
+  }
+#endif
+#if SGL_CUSTOM_AR_FUSED_RMSNORM_SHFL_2STAGE
+  if constexpr ((nranks == 4 || nranks == 8) && !std::is_same<T, float>::value) {
+    if (hidden % pack == 0 &&
+        packed_size64 <= static_cast<int64_t>(std::numeric_limits<int32_t>::max())) {
+      custom_all_reduce_residual_rmsnorm_shfl_2stage_kernel<T, nranks>
+          <<<blocks, threads, smem_bytes, stream>>>(
+              data, data_ptr, sg, self_sg, residual_in, residual_out, norm_out, weight,
+              rank, rows, hidden, eps, static_cast<int>(packed_size64));
+      return;
+    }
+  }
+#endif
+#if SGL_CUSTOM_AR_FUSED_RMSNORM_TOKEN_2STAGE
+  if (hidden % pack == 0 && rows >= 128) {
+    if (packed_size64 <= static_cast<int64_t>(std::numeric_limits<int32_t>::max())) {
+      custom_all_reduce_residual_rmsnorm_2stage_kernel<T, nranks>
+          <<<blocks, threads, smem_bytes, stream>>>(
+              data, data_ptr, sg, self_sg, residual_in, residual_out, norm_out, weight,
+              rank, rows, hidden, eps, static_cast<int>(packed_size64));
+      return;
+    }
+  }
+#endif
+  custom_all_reduce_residual_rmsnorm_kernel<T, nranks>
+      <<<blocks, threads, smem_bytes, stream>>>(
+          data, data_ptr, sg, self_sg, residual_in, residual_out, norm_out, weight,
+          rank, rows, hidden, eps);
+}
+
+template <typename T, int nranks>
+int select_residual_2shot_block_limit(int packed_size) {
+  int limit = kDefaultBlockLimit;
+#if SGL_CUSTOM_AR_DYNAMIC_BLOCKS
+  if constexpr (nranks == 4) {
+    if (packed_size >= 4 * 1024 * 1024) {
+      limit = 40;
+    }
+  } else if constexpr (nranks == 8) {
+    limit = 60;
+  }
+#endif
+  return std::min(limit, kMaxBlocks);
+}
+
+template <typename T, int nranks>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1)
+custom_all_reduce_residual_scalar_kernel(
+    RankData data,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* __restrict__ residual_in,
+    T* __restrict__ residual_out,
+    int rank,
+    int size) {
+  const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  const int stride = gridDim.x * blockDim.x;
+
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+
+  for (int idx = tid; idx < size; idx += stride) {
+    float ar_sum = 0.0f;
+#pragma unroll
+    for (int r = 0; r < nranks; ++r) {
+      const auto* peer = reinterpret_cast<const T*>(data.ptrs[r]);
+      ar_sum += to_float(peer[idx]);
+    }
+    residual_out[idx] = from_float<T>(ar_sum + to_float(residual_in[idx]));
+  }
+
+  __musa_barrier_slc();
+  __syncthreads_lm();
+  if (threadIdx.x == 0) {
+    __threadfence_system_noflush();
+  }
+  __syncthreads_lm();
+  multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+}
+
+template <typename T, int nranks>
+void launch_residual_ar(
+    RankData data,
+    const RankData* data_ptr,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* residual_in,
+    T* residual_out,
+    int rank,
+    int size,
+    musaStream_t stream) {
+  constexpr int pack = packed_t<T>::P::size;
+  const int threads = std::min(kDefaultThreads, kMaxThreadsPerBlock);
+  if (size % pack != 0) {
+    const int blocks = std::min(kMaxBlocks, (size + threads - 1) / threads);
+    if (blocks <= 0) {
+      return;
+    }
+    custom_all_reduce_residual_scalar_kernel<T, nranks>
+        <<<blocks, threads, 0, stream>>>(
+            data, sg, self_sg, residual_in, residual_out, rank, size);
+    return;
+  }
+  const int packed_size = size / pack;
+  if constexpr ((nranks == 4 || nranks == 8) && !std::is_same<T, float>::value) {
+    const int block_limit = select_residual_2shot_block_limit<T, nranks>(packed_size);
+    const int blocks = std::min(block_limit, (packed_size + threads - 1) / threads);
+    if (blocks <= 0) {
+      return;
+    }
+    custom_all_reduce_residual_2shot_kernel<T, nranks>
+        <<<blocks, threads, 0, stream>>>(
+            data, data_ptr, sg, self_sg, residual_in, residual_out, rank,
+            packed_size);
+  } else {
+    const int blocks = std::min(kMaxBlocks, (packed_size + threads - 1) / threads);
+    if (blocks <= 0) {
+      return;
+    }
+    custom_all_reduce_residual_kernel<T, nranks>
+        <<<blocks, threads, 0, stream>>>(
+            data, sg, self_sg, residual_in, residual_out, rank, size);
+  }
+}
+
+template <typename T, int nranks>
+bool launch_residual_ar_sums(
+    RankData data,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* residual_in,
+    T* residual_out,
+    float* row_sums,
+    int rank,
+    int rows,
+    int hidden,
+    musaStream_t stream) {
+  constexpr int pack = packed_t<T>::P::size;
+  const int packed_hidden = hidden / pack;
+  const int threads =
+      nranks == 2 ? std::min(packed_hidden, kMaxThreadsPerBlock)
+                  : (packed_hidden <= kMaxThreadsPerBlock ? packed_hidden : 0);
+  if constexpr (!((nranks == 2 || nranks == 4 || nranks == 8) && !std::is_same<T, float>::value)) {
+    return false;
+  }
+  if ((hidden % pack) != 0) {
+    const int scalar_threads = std::min(hidden, kMaxThreadsPerBlock);
+    const int blocks = std::min(kDefaultBlockLimit, rows);
+    if (scalar_threads <= 0 || blocks <= 0) {
+      return true;
+    }
+    custom_all_reduce_residual_sums_scalar_kernel<T, nranks>
+        <<<blocks, scalar_threads, 0, stream>>>(
+            data, sg, self_sg, residual_in, residual_out, row_sums, rank, rows,
+            hidden);
+    return true;
+  }
+  if constexpr (nranks == 4 || nranks == 8) {
+    if (packed_hidden > kMaxThreadsPerBlock) {
+      return false;
+    }
+  }
+  if (threads <= 0 || threads > kMaxThreadsPerBlock) {
+    return false;
+  }
+  const int64_t packed_size64 =
+      (static_cast<int64_t>(rows) * static_cast<int64_t>(hidden)) / pack;
+  if (packed_size64 > static_cast<int64_t>(std::numeric_limits<int32_t>::max())) {
+    return false;
+  }
+  const int packed_size = static_cast<int>(packed_size64);
+  if constexpr (nranks == 2) {
+    const int blocks = std::min(kDefaultBlockLimit, rows);
+    if (blocks <= 0) {
+      return true;
+    }
+    custom_all_reduce_residual_sums_direct_kernel<T, 2>
+        <<<blocks, threads, 0, stream>>>(
+            data, sg, self_sg, residual_in, residual_out, row_sums, rank, rows,
+            hidden);
+    return true;
+  }
+  TVM_FFI_ICHECK_EQ(threads, packed_hidden);
+  const int block_limit = select_residual_2shot_block_limit<T, nranks>(packed_size);
+  const int blocks = std::min(block_limit, (packed_size + threads - 1) / threads);
+  if (blocks <= 0) {
+    return true;
+  }
+  custom_all_reduce_residual_2shot_sums_kernel<T, nranks>
+      <<<blocks, threads, 0, stream>>>(
+          data, sg, self_sg, residual_in, residual_out, row_sums, rank, rows,
+          hidden, packed_size);
+  return true;
+}
+
+template <typename T, int nranks, int vlen>
+bool launch_residual_ar_rmsnorm_row_vlen(
+    RankData data,
+    const RankData* data_ptr,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* residual_in,
+    T* residual_out,
+    T* norm_out,
+    const T* weight,
+    int rank,
+    int rows,
+    int hidden,
+    float eps,
+    musaStream_t stream) {
+  if constexpr (!((nranks == 2 || nranks == 4 || nranks == 8) && !std::is_same<T, float>::value)) {
+    return false;
+  }
+  constexpr int pack = vlen;
+  if constexpr (vlen != packed_t<T>::P::size) {
+    return false;
+  }
+  const int packed_hidden = hidden / pack;
+  const bool use_direct_512 =
+      hidden == 4096 || (nranks == 2 && hidden == 6144) ||
+      ((nranks == 4 || nranks == 8) &&
+       (hidden == 1536 || hidden == 3072) &&
+       !(hidden == 1536 && rows <= 128));
+  const int threads =
+      (SGL_CUSTOM_AR_FUSED_RMSNORM_SMALL_ROWS &&
+         (hidden == 512 || hidden == 1024 || hidden == 2048))
+          ? packed_hidden
+      : use_direct_512
+          ? 512
+      : (hidden == 512 || hidden == 1024 || hidden == 2048)
+          ? 512
+      : (hidden <= 2048 && packed_hidden <= kMaxThreadsPerBlock)
+          ? packed_hidden
+          : (packed_hidden <= kMaxThreadsPerBlock ? packed_hidden : 0);
+  if (threads <= 0 || (hidden % pack) != 0) {
+    return false;
+  }
+  if (hidden <= 2048 && !use_direct_512) {
+    TVM_FFI_ICHECK_EQ(threads % packed_hidden, 0);
+  } else if (use_direct_512) {
+    TVM_FFI_ICHECK_EQ(threads, 512);
+  } else {
+    TVM_FFI_ICHECK_EQ(threads, packed_hidden);
+  }
+  const int64_t packed_size64 =
+      (static_cast<int64_t>(rows) * static_cast<int64_t>(hidden)) / pack;
+  if (packed_size64 > static_cast<int64_t>(std::numeric_limits<int32_t>::max())) {
+    return false;
+  }
+  const int packed_size = static_cast<int>(packed_size64);
+  const int block_limit = select_residual_2shot_block_limit<T, nranks>(packed_size);
+  const bool one_block_per_row =
+      threads == packed_hidden && rows <= kOneShotMaxToken;
+  const int blocks = one_block_per_row
+      ? std::min(rows, kMaxBlocks)
+      : std::min(block_limit, (packed_size + threads - 1) / threads);
+  if (blocks <= 0) {
+    return true;
+  }
+  const bool cache_weight =
+      SGL_CUSTOM_AR_FUSED_RMSNORM_ROW_WEIGHT_CACHE &&
+      rows >= SGL_CUSTOM_AR_FUSED_RMSNORM_ROW_WEIGHT_CACHE_MIN_ROWS &&
+      hidden <= kWeightCacheHiddenLimit;
+  const size_t smem_bytes =
+      align_up(cache_weight ? static_cast<size_t>(hidden) * sizeof(T) : 0, alignof(float)) +
+      static_cast<size_t>((threads + 31) / 32) * sizeof(float);
+  if (cache_weight) {
+    custom_all_reduce_residual_2shot_rmsnorm_row_kernel<T, nranks, true, true, vlen>
+        <<<blocks, threads, smem_bytes, stream>>>(
+            data, data_ptr, sg, self_sg, residual_in, residual_out, norm_out, weight,
+            rank, rows, hidden, eps, packed_size);
+  } else if constexpr (kRowSharedInvRms) {
+    custom_all_reduce_residual_2shot_rmsnorm_row_kernel<T, nranks, true, false, vlen>
+        <<<blocks, threads, smem_bytes, stream>>>(
+            data, data_ptr, sg, self_sg, residual_in, residual_out, norm_out, weight,
+            rank, rows, hidden, eps, packed_size);
+  } else {
+    custom_all_reduce_residual_2shot_rmsnorm_row_kernel<T, nranks, false, false, vlen>
+        <<<blocks, threads, smem_bytes, stream>>>(
+            data, data_ptr, sg, self_sg, residual_in, residual_out, norm_out, weight,
+            rank, rows, hidden, eps, packed_size);
+  }
+  return true;
+}
+
+template <typename T, int nranks>
+bool launch_residual_ar_rmsnorm_row(
+    RankData data,
+    const RankData* data_ptr,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* residual_in,
+    T* residual_out,
+    T* norm_out,
+    const T* weight,
+    int rank,
+    int rows,
+    int hidden,
+    float eps,
+    musaStream_t stream) {
+  if ((hidden % 8) == 0) {
+    return launch_residual_ar_rmsnorm_row_vlen<T, nranks, 8>(
+        data, data_ptr, sg, self_sg, residual_in, residual_out, norm_out, weight, rank,
+        rows, hidden, eps, stream);
+  }
+  return false;
+}
+
+template <typename T>
+void dispatch_world_size(
+    RankData data,
+    const RankData* data_ptr,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* input_src,
+    const T* residual_in,
+    T* residual_out,
+    T* norm_out,
+    const T* weight,
+    int rank,
+    int world_size,
+    int rows,
+    int hidden,
+    float eps,
+    int slot_stride_packed,
+    musaStream_t stream) {
+  switch (world_size) {
+    case 2:
+      launch_fused_ar_rmsnorm<T, 2>(
+          data, data_ptr, sg, self_sg, input_src, residual_in, residual_out, norm_out,
+          weight, rank, rows, hidden, eps, slot_stride_packed, stream);
+      break;
+    case 4:
+      launch_fused_ar_rmsnorm<T, 4>(
+          data, data_ptr, sg, self_sg, input_src, residual_in, residual_out, norm_out,
+          weight, rank, rows, hidden, eps, slot_stride_packed, stream);
+      break;
+    case 6:
+      launch_fused_ar_rmsnorm<T, 6>(
+          data, data_ptr, sg, self_sg, input_src, residual_in, residual_out, norm_out,
+          weight, rank, rows, hidden, eps, slot_stride_packed, stream);
+      break;
+    case 8:
+      launch_fused_ar_rmsnorm<T, 8>(
+          data, data_ptr, sg, self_sg, input_src, residual_in, residual_out, norm_out,
+          weight, rank, rows, hidden, eps, slot_stride_packed, stream);
+      break;
+    default:
+      TVM_FFI_THROW(ValueError) << "world_size must be one of 2/4/6/8";
+  }
+}
+
+template <typename T>
+void dispatch_residual_world_size(
+    RankData data,
+    const RankData* data_ptr,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* residual_in,
+    T* residual_out,
+    int rank,
+    int world_size,
+    int size,
+    musaStream_t stream) {
+  switch (world_size) {
+    case 2:
+      launch_residual_ar<T, 2>(
+          data, data_ptr, sg, self_sg, residual_in, residual_out, rank, size,
+          stream);
+      break;
+    case 4:
+      launch_residual_ar<T, 4>(
+          data, data_ptr, sg, self_sg, residual_in, residual_out, rank, size,
+          stream);
+      break;
+    case 6:
+      launch_residual_ar<T, 6>(
+          data, data_ptr, sg, self_sg, residual_in, residual_out, rank, size,
+          stream);
+      break;
+    case 8:
+      launch_residual_ar<T, 8>(
+          data, data_ptr, sg, self_sg, residual_in, residual_out, rank, size,
+          stream);
+      break;
+    default:
+      TVM_FFI_THROW(ValueError) << "world_size must be one of 2/4/6/8";
+  }
+}
+
+template <typename T>
+bool dispatch_residual_sums_world_size(
+    RankData data,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* residual_in,
+    T* residual_out,
+    float* row_sums,
+    int rank,
+    int world_size,
+    int rows,
+    int hidden,
+    musaStream_t stream) {
+  switch (world_size) {
+    case 2:
+      return launch_residual_ar_sums<T, 2>(
+          data, sg, self_sg, residual_in, residual_out, row_sums, rank, rows,
+          hidden, stream);
+    case 4:
+      return launch_residual_ar_sums<T, 4>(
+          data, sg, self_sg, residual_in, residual_out, row_sums, rank, rows,
+          hidden, stream);
+    case 8:
+      return launch_residual_ar_sums<T, 8>(
+          data, sg, self_sg, residual_in, residual_out, row_sums, rank, rows,
+          hidden, stream);
+    default:
+      return false;
+  }
+}
+
+template <typename T>
+bool dispatch_residual_rmsnorm_row_world_size(
+    RankData data,
+    const RankData* data_ptr,
+    RankSignals sg,
+    Signal* self_sg,
+    const T* residual_in,
+    T* residual_out,
+    T* norm_out,
+    const T* weight,
+    int rank,
+    int world_size,
+    int rows,
+    int hidden,
+    float eps,
+    musaStream_t stream) {
+  switch (world_size) {
+    case 2:
+      return launch_residual_ar_rmsnorm_row<T, 2>(
+          data, data_ptr, sg, self_sg, residual_in, residual_out, norm_out, weight, rank,
+          rows, hidden, eps, stream);
+    case 4:
+      return launch_residual_ar_rmsnorm_row<T, 4>(
+          data, data_ptr, sg, self_sg, residual_in, residual_out, norm_out, weight, rank,
+          rows, hidden, eps, stream);
+    case 8:
+      return launch_residual_ar_rmsnorm_row<T, 8>(
+          data, data_ptr, sg, self_sg, residual_in, residual_out, norm_out, weight, rank,
+          rows, hidden, eps, stream);
+    default:
+      return false;
+  }
+}
+
+}  // namespace
+
+void sgl_musa_custom_ar_fused_allreduce_rmsnorm_unregistered(
+    ffi::TensorView rank_data,
+    ffi::TensorView signal_ptrs_cpu,
+    ffi::TensorView inp,
+    ffi::TensorView norm_out,
+    ffi::TensorView residual_in,
+    ffi::TensorView residual_out,
+    ffi::TensorView weight,
+    int64_t self_signal_ptr,
+    int64_t self_buffer_ptr,
+    int64_t max_size_bytes,
+    int64_t rank,
+    int64_t world_size,
+    float eps,
+    int64_t reset_lamport) {
+  CHECK_MUSA_CONTIGUOUS(inp);
+  CHECK_MUSA_CONTIGUOUS(norm_out);
+  CHECK_MUSA_CONTIGUOUS(residual_in);
+  CHECK_MUSA_CONTIGUOUS(residual_out);
+  CHECK_MUSA_CONTIGUOUS(weight);
+  CHECK_CONTIGUOUS_2D(inp);
+  CHECK_CONTIGUOUS_2D(norm_out);
+  CHECK_CONTIGUOUS_2D(residual_in);
+  CHECK_CONTIGUOUS_2D(residual_out);
+  TVM_FFI_ICHECK_EQ(weight.ndim(), 1);
+  TVM_FFI_ICHECK_EQ(inp.size(0), norm_out.size(0));
+  TVM_FFI_ICHECK_EQ(inp.size(1), norm_out.size(1));
+  TVM_FFI_ICHECK_EQ(inp.size(0), residual_in.size(0));
+  TVM_FFI_ICHECK_EQ(inp.size(1), residual_in.size(1));
+  TVM_FFI_ICHECK_EQ(inp.size(0), residual_out.size(0));
+  TVM_FFI_ICHECK_EQ(inp.size(1), residual_out.size(1));
+  TVM_FFI_ICHECK_EQ(inp.size(1), weight.size(0));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), norm_out.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), residual_in.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), residual_out.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), weight.dtype()));
+  TVM_FFI_ICHECK_EQ(rank_data.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(rank_data.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(rank_data.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(rank_data.size(0), kMaxRanks);
+  TVM_FFI_ICHECK_EQ(signal_ptrs_cpu.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(signal_ptrs_cpu.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(signal_ptrs_cpu.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(signal_ptrs_cpu.size(0), world_size);
+  TVM_FFI_ICHECK(rank >= 0 && rank < world_size);
+
+  RankSignals sg{};
+  const auto* sig_ptrs = static_cast<const int64_t*>(signal_ptrs_cpu.data_ptr());
+  for (int i = 0; i < world_size; ++i) {
+    sg.signals[i] = reinterpret_cast<Signal*>(sig_ptrs[i]);
+  }
+
+  RankData data{};
+  const auto* rank_ptrs = static_cast<const int64_t*>(rank_data.data_ptr());
+  for (int i = 0; i < kMaxRanks; ++i) {
+    data.ptrs[i] = reinterpret_cast<const void*>(rank_ptrs[i]);
+  }
+
+  auto* self_sg = reinterpret_cast<Signal*>(self_signal_ptr);
+  auto stream = get_stream(inp.device());
+  const int64_t numel64 = tensor_numel(inp);
+  TVM_FFI_ICHECK_LE(numel64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  const int64_t nbytes = numel64 * ((static_cast<int64_t>(inp.dtype().bits) * inp.dtype().lanes + 7) / 8);
+  TVM_FFI_ICHECK_LE(nbytes, max_size_bytes);
+
+  const int rows = static_cast<int>(inp.size(0));
+  const int hidden = static_cast<int>(inp.size(1));
+  constexpr int configured_push_slots = SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_SLOTS;
+  constexpr int push_slots =
+      SGL_CUSTOM_AR_FUSED_RMSNORM_LAMPORT_PUSH ? 3 : configured_push_slots;
+  static_assert(push_slots >= 2, "push polling needs at least two slots");
+  const bool use_push_polling =
+      SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_POLLING &&
+      (world_size == 2 || world_size == 4) && hidden == 4096 &&
+      rows >= SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_MIN_ROWS &&
+      rows <= SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_MAX_ROWS &&
+      rows <= kOneShotMaxToken &&
+      nbytes * push_slots * world_size <= max_size_bytes;
+  if (SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_POLLING &&
+      (world_size == 2 || world_size == 4) && hidden == 4096 &&
+      rows >= SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_MIN_ROWS &&
+      rows <= SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_MAX_ROWS &&
+      rows <= kOneShotMaxToken) {
+    TVM_FFI_ICHECK_LE(nbytes * push_slots * world_size, max_size_bytes);
+  }
+  if (!use_push_polling) {
+    const musaError_t copy_err = musaMemcpyAsync(
+        reinterpret_cast<void*>(self_buffer_ptr),
+        inp.data_ptr(),
+        static_cast<size_t>(nbytes),
+        musaMemcpyDeviceToDevice,
+        stream);
+    TVM_FFI_ICHECK_EQ(copy_err, musaSuccess)
+        << "MUSA custom AR fused RMSNorm copy failed: "
+        << musaGetErrorString(copy_err);
+  }
+  const int slot_stride_packed = static_cast<int>(
+      max_size_bytes / (static_cast<int64_t>(push_slots) *
+                        static_cast<int64_t>(world_size) * 16));
+
+  if (dtype_equal(inp.dtype(), dl_float16)) {
+#if SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_POLLING && SGL_CUSTOM_AR_FUSED_RMSNORM_LAMPORT_PUSH
+    if (use_push_polling && reset_lamport) {
+      constexpr int init_threads = 512;
+      const int packed_size = static_cast<int>(numel64 / packed_t<half>::P::size);
+      const int total_packets = push_slots * static_cast<int>(world_size) * packed_size;
+      const int init_blocks =
+          std::min(32, (total_packets + init_threads - 1) / init_threads);
+      if (init_blocks > 0) {
+        if (world_size == 2) {
+          custom_all_reduce_residual_rmsnorm_lamport_init_kernel<half, 2>
+              <<<init_blocks, init_threads, 0, stream>>>(
+                  data, sg, self_sg, static_cast<int>(rank), packed_size,
+                  slot_stride_packed);
+        } else {
+          custom_all_reduce_residual_rmsnorm_lamport_init_kernel<half, 4>
+              <<<init_blocks, init_threads, 0, stream>>>(
+                  data, sg, self_sg, static_cast<int>(rank), packed_size,
+                  slot_stride_packed);
+        }
+      }
+    }
+#endif
+    dispatch_world_size(
+        data, nullptr, sg, self_sg,
+        use_push_polling ? static_cast<const half*>(inp.data_ptr()) : nullptr,
+        static_cast<const half*>(residual_in.data_ptr()),
+        static_cast<half*>(residual_out.data_ptr()),
+        static_cast<half*>(norm_out.data_ptr()),
+        static_cast<const half*>(weight.data_ptr()),
+        static_cast<int>(rank), static_cast<int>(world_size),
+        rows, hidden, eps, slot_stride_packed, stream);
+  } else if (dtype_equal(inp.dtype(), dl_bfloat16)) {
+#if SGL_CUSTOM_AR_FUSED_RMSNORM_PUSH_POLLING && SGL_CUSTOM_AR_FUSED_RMSNORM_LAMPORT_PUSH
+    if (use_push_polling && reset_lamport) {
+      constexpr int init_threads = 512;
+      const int packed_size =
+          static_cast<int>(numel64 / packed_t<__mt_bfloat16>::P::size);
+      const int total_packets = push_slots * static_cast<int>(world_size) * packed_size;
+      const int init_blocks =
+          std::min(32, (total_packets + init_threads - 1) / init_threads);
+      if (init_blocks > 0) {
+        if (world_size == 2) {
+          custom_all_reduce_residual_rmsnorm_lamport_init_kernel<__mt_bfloat16, 2>
+              <<<init_blocks, init_threads, 0, stream>>>(
+                  data, sg, self_sg, static_cast<int>(rank), packed_size,
+                  slot_stride_packed);
+        } else {
+          custom_all_reduce_residual_rmsnorm_lamport_init_kernel<__mt_bfloat16, 4>
+              <<<init_blocks, init_threads, 0, stream>>>(
+                  data, sg, self_sg, static_cast<int>(rank), packed_size,
+                  slot_stride_packed);
+        }
+      }
+    }
+#endif
+    dispatch_world_size(
+        data, nullptr, sg, self_sg,
+        use_push_polling ? static_cast<const __mt_bfloat16*>(inp.data_ptr()) : nullptr,
+        static_cast<const __mt_bfloat16*>(residual_in.data_ptr()),
+        static_cast<__mt_bfloat16*>(residual_out.data_ptr()),
+        static_cast<__mt_bfloat16*>(norm_out.data_ptr()),
+        static_cast<const __mt_bfloat16*>(weight.data_ptr()),
+        static_cast<int>(rank), static_cast<int>(world_size),
+        rows, hidden, eps, slot_stride_packed, stream);
+  } else {
+    TVM_FFI_THROW(ValueError) << "custom AR fused RMSNorm only supports fp16/bf16";
+  }
+
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess)
+      << "MUSA custom AR fused RMSNorm kernel failed: " << musaGetErrorString(err);
+}
+
+void sgl_musa_custom_ar_fused_allreduce_residual_unregistered(
+    ffi::TensorView rank_data,
+    ffi::TensorView signal_ptrs_cpu,
+    ffi::TensorView inp,
+    ffi::TensorView residual_in,
+    ffi::TensorView residual_out,
+    int64_t self_signal_ptr,
+    int64_t self_buffer_ptr,
+    int64_t max_size_bytes,
+    int64_t rank,
+    int64_t world_size) {
+  CHECK_MUSA_CONTIGUOUS(inp);
+  CHECK_MUSA_CONTIGUOUS(residual_in);
+  CHECK_MUSA_CONTIGUOUS(residual_out);
+  TVM_FFI_ICHECK_EQ(tensor_numel(inp), tensor_numel(residual_in));
+  TVM_FFI_ICHECK_EQ(tensor_numel(inp), tensor_numel(residual_out));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), residual_in.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), residual_out.dtype()));
+  TVM_FFI_ICHECK_EQ(rank_data.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(rank_data.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(rank_data.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(rank_data.size(0), kMaxRanks);
+  TVM_FFI_ICHECK_EQ(signal_ptrs_cpu.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(signal_ptrs_cpu.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(signal_ptrs_cpu.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(signal_ptrs_cpu.size(0), world_size);
+  TVM_FFI_ICHECK(rank >= 0 && rank < world_size);
+
+  RankSignals sg{};
+  const auto* sig_ptrs = static_cast<const int64_t*>(signal_ptrs_cpu.data_ptr());
+  for (int i = 0; i < world_size; ++i) {
+    sg.signals[i] = reinterpret_cast<Signal*>(sig_ptrs[i]);
+  }
+
+  RankData data{};
+  const auto* rank_ptrs = static_cast<const int64_t*>(rank_data.data_ptr());
+  for (int i = 0; i < kMaxRanks; ++i) {
+    data.ptrs[i] = reinterpret_cast<const void*>(rank_ptrs[i]);
+  }
+
+  auto* self_sg = reinterpret_cast<Signal*>(self_signal_ptr);
+  auto stream = get_stream(inp.device());
+  const int64_t numel64 = tensor_numel(inp);
+  TVM_FFI_ICHECK_LE(numel64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  const int64_t nbytes =
+      numel64 * ((static_cast<int64_t>(inp.dtype().bits) * inp.dtype().lanes + 7) / 8);
+  TVM_FFI_ICHECK_LE(nbytes, max_size_bytes);
+
+  const musaError_t copy_err = musaMemcpyAsync(
+      reinterpret_cast<void*>(self_buffer_ptr),
+      inp.data_ptr(),
+      static_cast<size_t>(nbytes),
+      musaMemcpyDeviceToDevice,
+      stream);
+  TVM_FFI_ICHECK_EQ(copy_err, musaSuccess)
+      << "MUSA custom AR fused residual copy failed: " << musaGetErrorString(copy_err);
+
+  const int size = static_cast<int>(numel64);
+  if (dtype_equal(inp.dtype(), dl_float16)) {
+    dispatch_residual_world_size(
+        data, nullptr, sg, self_sg,
+        static_cast<const half*>(residual_in.data_ptr()),
+        static_cast<half*>(residual_out.data_ptr()),
+        static_cast<int>(rank), static_cast<int>(world_size), size, stream);
+  } else if (dtype_equal(inp.dtype(), dl_bfloat16)) {
+    dispatch_residual_world_size(
+        data, nullptr, sg, self_sg,
+        static_cast<const __mt_bfloat16*>(residual_in.data_ptr()),
+        static_cast<__mt_bfloat16*>(residual_out.data_ptr()),
+        static_cast<int>(rank), static_cast<int>(world_size), size, stream);
+  } else {
+    TVM_FFI_THROW(ValueError) << "custom AR fused residual only supports fp16/bf16";
+  }
+
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess)
+      << "MUSA custom AR fused residual kernel failed: " << musaGetErrorString(err);
+}
+
+void sgl_musa_custom_ar_fused_allreduce_residual_registered(
+    ffi::TensorView rank_data,
+    ffi::TensorView signal_ptrs_cpu,
+    ffi::TensorView residual_in,
+    ffi::TensorView residual_out,
+    int64_t self_signal_ptr,
+    int64_t rank,
+    int64_t world_size) {
+  CHECK_MUSA_CONTIGUOUS(residual_in);
+  CHECK_MUSA_CONTIGUOUS(residual_out);
+  TVM_FFI_ICHECK_EQ(tensor_numel(residual_in), tensor_numel(residual_out));
+  TVM_FFI_ICHECK(dtype_equal(residual_in.dtype(), residual_out.dtype()));
+  TVM_FFI_ICHECK_EQ(
+      rank_data.device().device_type, residual_in.device().device_type);
+  TVM_FFI_ICHECK_EQ(
+      rank_data.device().device_id, residual_in.device().device_id);
+  TVM_FFI_ICHECK(rank_data.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(rank_data.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(rank_data.size(0), kMaxRanks);
+  TVM_FFI_ICHECK_EQ(signal_ptrs_cpu.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(signal_ptrs_cpu.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(signal_ptrs_cpu.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(signal_ptrs_cpu.size(0), world_size);
+  TVM_FFI_ICHECK(rank >= 0 && rank < world_size);
+
+  RankSignals sg{};
+  const auto* sig_ptrs = static_cast<const int64_t*>(signal_ptrs_cpu.data_ptr());
+  for (int i = 0; i < world_size; ++i) {
+    sg.signals[i] = reinterpret_cast<Signal*>(sig_ptrs[i]);
+  }
+
+  RankData data{};
+  const auto* device_data_ptr =
+      reinterpret_cast<const RankData*>(rank_data.data_ptr());
+
+  auto* self_sg = reinterpret_cast<Signal*>(self_signal_ptr);
+  auto stream = get_stream(residual_in.device());
+  const int64_t numel64 = tensor_numel(residual_in);
+  TVM_FFI_ICHECK_LE(numel64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+
+  const int size = static_cast<int>(numel64);
+  if (dtype_equal(residual_in.dtype(), dl_float16)) {
+    dispatch_residual_world_size(
+        data, device_data_ptr, sg, self_sg,
+        static_cast<const half*>(residual_in.data_ptr()),
+        static_cast<half*>(residual_out.data_ptr()),
+        static_cast<int>(rank), static_cast<int>(world_size), size, stream);
+  } else if (dtype_equal(residual_in.dtype(), dl_bfloat16)) {
+    dispatch_residual_world_size(
+        data, device_data_ptr, sg, self_sg,
+        static_cast<const __mt_bfloat16*>(residual_in.data_ptr()),
+        static_cast<__mt_bfloat16*>(residual_out.data_ptr()),
+        static_cast<int>(rank), static_cast<int>(world_size), size, stream);
+  } else {
+    TVM_FFI_THROW(ValueError) << "custom AR fused residual only supports fp16/bf16";
+  }
+
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess)
+      << "MUSA custom AR fused residual registered kernel failed: "
+      << musaGetErrorString(err);
+}
+
+void sgl_musa_custom_ar_fused_allreduce_rmsnorm_registered(
+    ffi::TensorView rank_data,
+    ffi::TensorView signal_ptrs_cpu,
+    ffi::TensorView residual_in,
+    ffi::TensorView residual_out,
+    ffi::TensorView norm_out,
+    ffi::TensorView weight,
+    int64_t self_signal_ptr,
+    int64_t rank,
+    int64_t world_size,
+    float eps) {
+  CHECK_MUSA_CONTIGUOUS(residual_in);
+  CHECK_MUSA_CONTIGUOUS(residual_out);
+  CHECK_MUSA_CONTIGUOUS(norm_out);
+  CHECK_MUSA_CONTIGUOUS(weight);
+  CHECK_CONTIGUOUS_2D(residual_in);
+  CHECK_CONTIGUOUS_2D(residual_out);
+  CHECK_CONTIGUOUS_2D(norm_out);
+  TVM_FFI_ICHECK_EQ(weight.ndim(), 1);
+  TVM_FFI_ICHECK_EQ(residual_in.size(0), residual_out.size(0));
+  TVM_FFI_ICHECK_EQ(residual_in.size(1), residual_out.size(1));
+  TVM_FFI_ICHECK_EQ(residual_in.size(0), norm_out.size(0));
+  TVM_FFI_ICHECK_EQ(residual_in.size(1), norm_out.size(1));
+  TVM_FFI_ICHECK_EQ(residual_in.size(1), weight.size(0));
+  TVM_FFI_ICHECK(dtype_equal(residual_in.dtype(), residual_out.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(residual_in.dtype(), norm_out.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(residual_in.dtype(), weight.dtype()));
+  TVM_FFI_ICHECK_EQ(
+      rank_data.device().device_type, residual_in.device().device_type);
+  TVM_FFI_ICHECK_EQ(
+      rank_data.device().device_id, residual_in.device().device_id);
+  TVM_FFI_ICHECK(rank_data.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(rank_data.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(rank_data.size(0), kMaxRanks);
+  TVM_FFI_ICHECK_EQ(signal_ptrs_cpu.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(signal_ptrs_cpu.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(signal_ptrs_cpu.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(signal_ptrs_cpu.size(0), world_size);
+  TVM_FFI_ICHECK(rank >= 0 && rank < world_size);
+
+  RankSignals sg{};
+  const auto* sig_ptrs = static_cast<const int64_t*>(signal_ptrs_cpu.data_ptr());
+  for (int i = 0; i < world_size; ++i) {
+    sg.signals[i] = reinterpret_cast<Signal*>(sig_ptrs[i]);
+  }
+
+  RankData data{};
+  const auto* device_data_ptr =
+      reinterpret_cast<const RankData*>(rank_data.data_ptr());
+
+  auto* self_sg = reinterpret_cast<Signal*>(self_signal_ptr);
+  auto stream = get_stream(residual_in.device());
+  const int rows = static_cast<int>(residual_in.size(0));
+  const int hidden = static_cast<int>(residual_in.size(1));
+  const int64_t numel64 = tensor_numel(residual_in);
+  TVM_FFI_ICHECK_LE(numel64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+
+  if (dtype_equal(residual_in.dtype(), dl_float16)) {
+    dispatch_world_size(
+        data, device_data_ptr, sg, self_sg,
+        static_cast<const half*>(nullptr),
+        static_cast<const half*>(residual_in.data_ptr()),
+        static_cast<half*>(residual_out.data_ptr()),
+        static_cast<half*>(norm_out.data_ptr()),
+        static_cast<const half*>(weight.data_ptr()),
+        static_cast<int>(rank), static_cast<int>(world_size),
+        rows, hidden, eps, 0, stream);
+  } else if (dtype_equal(residual_in.dtype(), dl_bfloat16)) {
+    dispatch_world_size(
+        data, device_data_ptr, sg, self_sg,
+        static_cast<const __mt_bfloat16*>(nullptr),
+        static_cast<const __mt_bfloat16*>(residual_in.data_ptr()),
+        static_cast<__mt_bfloat16*>(residual_out.data_ptr()),
+        static_cast<__mt_bfloat16*>(norm_out.data_ptr()),
+        static_cast<const __mt_bfloat16*>(weight.data_ptr()),
+        static_cast<int>(rank), static_cast<int>(world_size),
+        rows, hidden, eps, 0, stream);
+  } else {
+    TVM_FFI_THROW(ValueError) << "custom AR fused RMSNorm only supports fp16/bf16";
+  }
+
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess)
+      << "MUSA custom AR fused RMSNorm registered kernel failed: "
+      << musaGetErrorString(err);
+}
+
+void sgl_musa_custom_ar_fused_allreduce_rmsnorm_row_unregistered(
+    ffi::TensorView rank_data,
+    ffi::TensorView signal_ptrs_cpu,
+    ffi::TensorView inp,
+    ffi::TensorView residual_in,
+    ffi::TensorView residual_out,
+    ffi::TensorView norm_out,
+    ffi::TensorView weight,
+    int64_t self_signal_ptr,
+    int64_t self_buffer_ptr,
+    int64_t max_size_bytes,
+    int rank,
+    int world_size,
+    int hidden,
+    double eps) {
+  CHECK_MUSA_CONTIGUOUS(inp);
+  CHECK_MUSA_CONTIGUOUS(residual_in);
+  CHECK_MUSA_CONTIGUOUS(residual_out);
+  CHECK_MUSA_CONTIGUOUS(norm_out);
+  CHECK_MUSA_CONTIGUOUS(weight);
+  CHECK_CONTIGUOUS_2D(inp);
+  CHECK_CONTIGUOUS_2D(residual_in);
+  CHECK_CONTIGUOUS_2D(residual_out);
+  CHECK_CONTIGUOUS_2D(norm_out);
+  TVM_FFI_ICHECK_EQ(weight.ndim(), 1);
+  TVM_FFI_ICHECK_EQ(inp.size(0), residual_in.size(0));
+  TVM_FFI_ICHECK_EQ(inp.size(1), residual_in.size(1));
+  TVM_FFI_ICHECK_EQ(inp.size(0), residual_out.size(0));
+  TVM_FFI_ICHECK_EQ(inp.size(1), residual_out.size(1));
+  TVM_FFI_ICHECK_EQ(inp.size(0), norm_out.size(0));
+  TVM_FFI_ICHECK_EQ(inp.size(1), norm_out.size(1));
+  TVM_FFI_ICHECK_EQ(inp.size(1), hidden);
+  TVM_FFI_ICHECK_EQ(weight.size(0), hidden);
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), residual_in.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), residual_out.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), norm_out.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), weight.dtype()));
+  TVM_FFI_ICHECK_EQ(residual_in.device().device_id, inp.device().device_id);
+  TVM_FFI_ICHECK_EQ(residual_out.device().device_id, inp.device().device_id);
+  TVM_FFI_ICHECK_EQ(norm_out.device().device_id, inp.device().device_id);
+  TVM_FFI_ICHECK_EQ(weight.device().device_id, inp.device().device_id);
+  TVM_FFI_ICHECK_EQ(rank_data.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(rank_data.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(rank_data.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(rank_data.size(0), kMaxRanks);
+  TVM_FFI_ICHECK_EQ(signal_ptrs_cpu.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(signal_ptrs_cpu.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(signal_ptrs_cpu.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(signal_ptrs_cpu.size(0), world_size);
+  TVM_FFI_ICHECK(rank >= 0 && rank < world_size);
+
+  RankData data{};
+  const auto* rank_ptrs = static_cast<const int64_t*>(rank_data.data_ptr());
+  for (int i = 0; i < kMaxRanks; ++i) {
+    data.ptrs[i] = reinterpret_cast<const void*>(rank_ptrs[i]);
+  }
+
+  RankSignals sg{};
+  const auto* sig_ptrs = static_cast<const int64_t*>(signal_ptrs_cpu.data_ptr());
+  for (int i = 0; i < world_size; ++i) {
+    sg.signals[i] = reinterpret_cast<Signal*>(sig_ptrs[i]);
+  }
+
+  auto* self_sg = reinterpret_cast<Signal*>(self_signal_ptr);
+  auto stream = get_stream(inp.device());
+  const int64_t numel64 = tensor_numel(inp);
+  TVM_FFI_ICHECK_LE(numel64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  const int64_t nbytes =
+      numel64 * ((static_cast<int64_t>(inp.dtype().bits) * inp.dtype().lanes + 7) / 8);
+  TVM_FFI_ICHECK_LE(nbytes, max_size_bytes);
+
+  const musaError_t copy_err = musaMemcpyAsync(
+      reinterpret_cast<void*>(self_buffer_ptr),
+      inp.data_ptr(),
+      static_cast<size_t>(nbytes),
+      musaMemcpyDeviceToDevice,
+      stream);
+  TVM_FFI_ICHECK_EQ(copy_err, musaSuccess)
+      << "MUSA custom AR fused rmsnorm row copy failed: "
+      << musaGetErrorString(copy_err);
+
+  const int rows = static_cast<int>(inp.size(0));
+  bool launched = false;
+  if (dtype_equal(inp.dtype(), dl_float16)) {
+    launched = dispatch_residual_rmsnorm_row_world_size(
+        data, nullptr, sg, self_sg,
+        static_cast<const half*>(residual_in.data_ptr()),
+        static_cast<half*>(residual_out.data_ptr()),
+        static_cast<half*>(norm_out.data_ptr()),
+        static_cast<const half*>(weight.data_ptr()), rank, world_size, rows,
+        hidden, static_cast<float>(eps), stream);
+  } else if (dtype_equal(inp.dtype(), dl_bfloat16)) {
+    launched = dispatch_residual_rmsnorm_row_world_size(
+        data, nullptr, sg, self_sg,
+        static_cast<const __mt_bfloat16*>(residual_in.data_ptr()),
+        static_cast<__mt_bfloat16*>(residual_out.data_ptr()),
+        static_cast<__mt_bfloat16*>(norm_out.data_ptr()),
+        static_cast<const __mt_bfloat16*>(weight.data_ptr()), rank, world_size,
+        rows, hidden, static_cast<float>(eps), stream);
+  } else {
+    TVM_FFI_THROW(ValueError)
+        << "custom AR fused rmsnorm row only supports fp16/bf16";
+  }
+  TVM_FFI_ICHECK(launched)
+      << "MUSA custom AR fused rmsnorm row unsupported shape";
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess)
+      << "MUSA custom AR fused rmsnorm row unregistered kernel failed: "
+      << musaGetErrorString(err);
+}
+
+void sgl_musa_custom_ar_fused_allreduce_rmsnorm_row_registered(
+    ffi::TensorView rank_data,
+    ffi::TensorView signal_ptrs_cpu,
+    ffi::TensorView residual_in,
+    ffi::TensorView residual_out,
+    ffi::TensorView norm_out,
+    ffi::TensorView weight,
+    int64_t self_signal_ptr,
+    int rank,
+    int world_size,
+    int hidden,
+    double eps) {
+  CHECK_MUSA_CONTIGUOUS(residual_in);
+  CHECK_MUSA_CONTIGUOUS(residual_out);
+  CHECK_MUSA_CONTIGUOUS(norm_out);
+  CHECK_MUSA_CONTIGUOUS(weight);
+  TVM_FFI_ICHECK_EQ(residual_in.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(residual_out.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(norm_out.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(weight.ndim(), 1);
+  TVM_FFI_ICHECK_EQ(residual_in.size(0), residual_out.size(0));
+  TVM_FFI_ICHECK_EQ(residual_in.size(1), residual_out.size(1));
+  TVM_FFI_ICHECK_EQ(residual_in.size(0), norm_out.size(0));
+  TVM_FFI_ICHECK_EQ(residual_in.size(1), norm_out.size(1));
+  TVM_FFI_ICHECK_EQ(residual_in.size(1), hidden);
+  TVM_FFI_ICHECK_EQ(weight.size(0), hidden);
+  TVM_FFI_ICHECK(dtype_equal(residual_in.dtype(), residual_out.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(residual_in.dtype(), norm_out.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(residual_in.dtype(), weight.dtype()));
+  TVM_FFI_ICHECK_EQ(norm_out.device().device_id, residual_in.device().device_id);
+  TVM_FFI_ICHECK_EQ(weight.device().device_id, residual_in.device().device_id);
+  TVM_FFI_ICHECK_EQ(
+      rank_data.device().device_type, residual_in.device().device_type);
+  TVM_FFI_ICHECK_EQ(
+      rank_data.device().device_id, residual_in.device().device_id);
+  TVM_FFI_ICHECK(rank_data.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(rank_data.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(rank_data.size(0), kMaxRanks);
+  TVM_FFI_ICHECK_EQ(signal_ptrs_cpu.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(signal_ptrs_cpu.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(signal_ptrs_cpu.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(signal_ptrs_cpu.size(0), world_size);
+
+  RankData data{};
+  const auto* device_data_ptr =
+      reinterpret_cast<const RankData*>(rank_data.data_ptr());
+  const auto* sig_ptrs = static_cast<const int64_t*>(signal_ptrs_cpu.data_ptr());
+  RankSignals sg{};
+  for (int i = 0; i < world_size; ++i) {
+    sg.signals[i] = reinterpret_cast<Signal*>(sig_ptrs[i]);
+  }
+  auto* self_sg = reinterpret_cast<Signal*>(self_signal_ptr);
+  auto stream = get_stream(residual_in.device());
+  const int rows = static_cast<int>(residual_in.size(0));
+  bool launched = false;
+  if (dtype_equal(residual_in.dtype(), dl_float16)) {
+    launched = dispatch_residual_rmsnorm_row_world_size(
+        data, device_data_ptr, sg, self_sg, static_cast<const half*>(residual_in.data_ptr()),
+        static_cast<half*>(residual_out.data_ptr()),
+        static_cast<half*>(norm_out.data_ptr()),
+        static_cast<const half*>(weight.data_ptr()), rank, world_size, rows,
+        hidden, static_cast<float>(eps), stream);
+  } else if (dtype_equal(residual_in.dtype(), dl_bfloat16)) {
+    launched = dispatch_residual_rmsnorm_row_world_size(
+        data, device_data_ptr, sg, self_sg,
+        static_cast<const __mt_bfloat16*>(residual_in.data_ptr()),
+        static_cast<__mt_bfloat16*>(residual_out.data_ptr()),
+        static_cast<__mt_bfloat16*>(norm_out.data_ptr()),
+        static_cast<const __mt_bfloat16*>(weight.data_ptr()), rank, world_size,
+        rows, hidden, static_cast<float>(eps), stream);
+  } else {
+    TVM_FFI_THROW(ValueError) << "custom AR fused rmsnorm row only supports fp16/bf16";
+  }
+  TVM_FFI_ICHECK(launched)
+      << "MUSA custom AR fused rmsnorm row unsupported shape";
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess)
+      << "MUSA custom AR fused rmsnorm row registered kernel failed: "
+      << musaGetErrorString(err);
+}
+
+void sgl_musa_custom_ar_reset_signal(
+    int64_t self_signal_ptr,
+    ffi::TensorView stream_ref) {
+  TVM_FFI_ICHECK_EQ(stream_ref.device().device_type, kDLExtDev);
+  auto* self_sg = reinterpret_cast<Signal*>(self_signal_ptr);
+  auto stream = get_stream(stream_ref.device());
+  reset_signal_kernel<<<1, 256, 0, stream>>>(self_sg);
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess)
+      << "MUSA custom AR signal reset failed: " << musaGetErrorString(err);
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    sgl_musa_custom_ar_fused_allreduce_rmsnorm_unregistered,
+    sgl_musa_custom_ar_fused_allreduce_rmsnorm_unregistered);
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    sgl_musa_custom_ar_fused_allreduce_residual_unregistered,
+    sgl_musa_custom_ar_fused_allreduce_residual_unregistered);
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    sgl_musa_custom_ar_fused_allreduce_residual_registered,
+    sgl_musa_custom_ar_fused_allreduce_residual_registered);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    sgl_musa_custom_ar_fused_allreduce_rmsnorm_registered,
+    sgl_musa_custom_ar_fused_allreduce_rmsnorm_registered);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    sgl_musa_custom_ar_fused_allreduce_rmsnorm_row_unregistered,
+    sgl_musa_custom_ar_fused_allreduce_rmsnorm_row_unregistered);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    sgl_musa_custom_ar_fused_allreduce_rmsnorm_row_registered,
+    sgl_musa_custom_ar_fused_allreduce_rmsnorm_row_registered);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    sgl_musa_custom_ar_reset_signal,
+    sgl_musa_custom_ar_reset_signal);

--- a/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/jit.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/jit.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import functools
+import hashlib
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+import tvm_ffi
+import tvm_ffi.cpp.extension as tvm_ffi_ext
+from tvm_ffi.libinfo import find_dlpack_include_path, find_include_path, find_libtvm_ffi
+from tvm_ffi.utils import FileLock
+
+_CSRC_DIR = Path(__file__).resolve().parent
+_CACHE_DIR = Path(
+    os.getenv("SGLANG_MUSA_JIT_CACHE_DIR", Path.home() / ".cache" / "sglang_musa_jit")
+)
+
+
+def _parse_env_flags(name: str) -> list[str]:
+    value = os.environ.get(name)
+    if not value:
+        return []
+    try:
+        return shlex.split(value)
+    except ValueError:
+        return value.split()
+
+
+@functools.cache
+def _musa_home() -> Path:
+    return Path(tvm_ffi_ext._find_musa_home())
+
+
+def _mcc() -> str:
+    return os.environ.get("SGLANG_MUSA_MCC", str(_musa_home() / "bin" / "mcc"))
+
+
+def _normalize_musa_arch(arch: str) -> str:
+    arch = arch.strip().lower().replace("mp", "").replace("_", "").replace(".", "")
+    if not arch.isdigit():
+        raise ValueError(f"Invalid MUSA arch value: {arch!r}")
+    return f"mp_{arch}"
+
+
+@functools.cache
+def _musa_arch_names() -> tuple[str, ...]:
+    arch_list = os.environ.get("SGLANG_MUSA_ARCH_LIST") or os.environ.get(
+        "MATE_MUSA_ARCH_LIST"
+    )
+    if arch_list:
+        return tuple(_normalize_musa_arch(arch) for arch in arch_list.split())
+    try:
+        import torch_musa
+
+        props = torch_musa.get_device_properties(torch_musa.current_device())
+        arch = f"{int(props.major)}{int(props.minor)}"
+        return (_normalize_musa_arch(arch),)
+    except Exception:
+        return ("mp_31",)
+
+
+def _musa_arch_flags() -> list[str]:
+    return [f"--offload-arch={arch}" for arch in _musa_arch_names()]
+
+
+def _escape(path: Path) -> str:
+    return path.resolve().as_posix().replace(":", "$:")
+
+
+def _write_if_different(path: Path, content: str) -> None:
+    if path.exists() and path.read_text() == content:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def _object_path(build_dir: Path, source: Path) -> Path:
+    suffix = ".musa.o" if source.suffix in {".mu", ".cu"} else ".o"
+    return build_dir / f"{source.parent.name}_{source.stem}{suffix}"
+
+
+def _sources_digest(sources: Sequence[Path]) -> str:
+    digest = hashlib.sha256()
+    for source in sources:
+        digest.update(source.as_posix().encode())
+        digest.update(b"\0")
+        digest.update(source.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()[:16]
+
+
+def _musa_arch_cache_dir() -> Path:
+    return _CACHE_DIR / "_".join(_musa_arch_names())
+
+
+def musa_jit_build_dir(name: str) -> Path:
+    return _musa_arch_cache_dir() / name
+
+
+def _ninja_content(
+    name: str,
+    sources: Sequence[Path],
+    extra_cflags: Sequence[str],
+    extra_musa_cflags: Sequence[str],
+    extra_ldflags: Sequence[str],
+) -> str:
+    source_digest_flag = f"-DSGLANG_MUSA_JIT_SOURCE_HASH=0x{_sources_digest(sources)}"
+    include_flags = [
+        f"-I{find_include_path()}",
+        f"-I{find_dlpack_include_path()}",
+        f"-I{_musa_home() / 'include'}",
+    ]
+    cflags = [
+        "-std=c++17",
+        "-fPIC",
+        "-O3",
+        source_digest_flag,
+        *extra_cflags,
+        *_parse_env_flags("SGLANG_MUSA_EXTRA_CFLAGS"),
+        *include_flags,
+    ]
+    musa_cflags = [
+        "-std=c++17",
+        "-fPIC",
+        "-O3",
+        "-ffast-math",
+        *_musa_arch_flags(),
+        source_digest_flag,
+        *extra_musa_cflags,
+        *_parse_env_flags("SGLANG_MUSA_EXTRA_MUSAFLAGS"),
+        *include_flags,
+    ]
+    libtvm = Path(find_libtvm_ffi())
+    ldflags = [
+        "-shared",
+        f"-L{libtvm.parent}",
+        "-ltvm_ffi",
+        f"-L{_musa_home() / 'lib'}",
+        "-lmusa",
+        "-lmusart",
+        *extra_ldflags,
+        *_parse_env_flags("SGLANG_MUSA_EXTRA_LDFLAGS"),
+    ]
+
+    build_dir = musa_jit_build_dir(name)
+    lines = [
+        "ninja_required_version = 1.3",
+        f"cxx = {os.environ.get('CXX', 'c++')}",
+        f"mcc = {_mcc()}",
+        f"cflags = {' '.join(cflags)}",
+        f"musa_cflags = {' '.join(musa_cflags)}",
+        f"ldflags = {' '.join(ldflags)}",
+        "",
+        "rule compile",
+        "  depfile = $out.d",
+        "  deps = gcc",
+        "  command = $cxx -MMD -MF $out.d $cflags -c $in -o $out",
+        "",
+        "rule compile_musa",
+        "  depfile = $out.d",
+        "  deps = gcc",
+        "  command = $mcc -MD -MF $out.d $musa_cflags -c $in -o $out",
+        "",
+        "rule link",
+        "  command = $cxx $in $ldflags -o $out",
+        "",
+    ]
+    objects: list[str] = []
+    for source in sources:
+        obj = _object_path(build_dir, source)
+        objects.append(_escape(obj))
+        rule = "compile_musa" if source.suffix in {".mu", ".cu"} else "compile"
+        lines.append(f"build {objects[-1]}: {rule} {_escape(source)}")
+    output_so = _escape(build_dir / f"{name}.so")
+    lines += [
+        "",
+        f"build {output_so}: link {' '.join(objects)}",
+        f"default {output_so}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+@functools.lru_cache(maxsize=16)
+def load_musa_jit(
+    name: str,
+    sources: tuple[str, ...],
+    extra_cflags: tuple[str, ...] = (),
+    extra_musa_cflags: tuple[str, ...] = (),
+    extra_ldflags: tuple[str, ...] = (),
+):
+    resolved_sources = tuple((_CSRC_DIR / source).resolve() for source in sources)
+    build_dir = musa_jit_build_dir(name)
+    ninja_path = build_dir / "build.ninja"
+    so_path = build_dir / f"{name}.so"
+    lock_path = _musa_arch_cache_dir() / "tmp" / f"{name}.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with FileLock(str(lock_path)):
+        build_dir.mkdir(parents=True, exist_ok=True)
+        _write_if_different(
+            ninja_path,
+            _ninja_content(
+                name,
+                resolved_sources,
+                extra_cflags,
+                extra_musa_cflags,
+                extra_ldflags,
+            ),
+        )
+        command = ["ninja", "-C", str(build_dir), "-f", str(ninja_path)]
+        if os.environ.get("SGLANG_MUSA_JIT_VERBOSE") == "1":
+            command.insert(1, "-v")
+        sys.stdout.flush()
+        sys.stderr.flush()
+        subprocess.run(command, check=True)
+    return tvm_ffi.load_module(str(so_path))
+
+
+@functools.lru_cache(maxsize=16)
+def load_musa_pybind(
+    name: str,
+    sources: tuple[str, ...],
+    extra_cflags: tuple[str, ...] = (),
+    extra_musa_cflags: tuple[str, ...] = (),
+    extra_ldflags: tuple[str, ...] = (),
+):
+    from torch_musa.utils.musa_extension import load
+
+    resolved_sources = tuple(str((_CSRC_DIR / source).resolve()) for source in sources)
+    build_dir = musa_jit_build_dir(name)
+    lock_path = _musa_arch_cache_dir() / "tmp" / f"{name}.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    build_dir.mkdir(parents=True, exist_ok=True)
+    libtvm = Path(find_libtvm_ffi())
+    include_paths = [
+        str(find_include_path()),
+        str(find_dlpack_include_path()),
+        str(_musa_home() / "include"),
+    ]
+    ldflags = [
+        f"-L{libtvm.parent}",
+        "-ltvm_ffi",
+        f"-L{_musa_home() / 'lib'}",
+        "-lmusa",
+        "-lmusart",
+        *extra_ldflags,
+        *_parse_env_flags("SGLANG_MUSA_EXTRA_LDFLAGS"),
+    ]
+    with FileLock(str(lock_path)):
+        return load(
+            name=name,
+            sources=list(resolved_sources),
+            extra_cflags=[
+                "-O3",
+                "-std=c++17",
+                *extra_cflags,
+                *_parse_env_flags("SGLANG_MUSA_EXTRA_CFLAGS"),
+            ],
+            extra_musa_cflags=[
+                "-O3",
+                "-std=c++17",
+                "-ffast-math",
+                *_musa_arch_flags(),
+                *extra_musa_cflags,
+                *_parse_env_flags("SGLANG_MUSA_EXTRA_MUSAFLAGS"),
+            ],
+            extra_ldflags=ldflags,
+            extra_include_paths=include_paths,
+            build_directory=str(build_dir),
+            verbose=os.environ.get("SGLANG_MUSA_JIT_VERBOSE") == "1",
+            with_musa=True,
+            is_python_module=True,
+        )

--- a/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/norm/__init__.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/norm/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged MUSA normalization kernel headers."""

--- a/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/norm/common.mu
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/csrc/norm/common.mu
@@ -1,0 +1,158 @@
+template <typename T>
+struct __align__(16) Vec8Storage {
+  T elem[8];
+};
+
+struct __align__(32) Float8Storage {
+  float elem[8];
+};
+
+template <typename T>
+struct __align__(16) Vec8 {
+  union {
+    Vec8Storage<T> storage;
+    T elem[8];
+  } val;
+
+  __device__ __forceinline__ Vec8() {}
+
+  template <typename Offset>
+  static __device__ __forceinline__ Vec8 load(const T* ptr, Offset idx) {
+    return *(const Vec8*)(ptr + idx);
+  }
+
+  template <typename Offset>
+  static __device__ __forceinline__ Vec8 load_byp_slc(const T* ptr, Offset idx) {
+#if ((defined __MUSA_ARCH__) && (__MUSA_ARCH__ == 310))
+    Vec8 dst;
+    const T* addr = ptr + idx;
+    asm volatile(
+        "LSU.LD.B128 %0, %1, _, 16, 1, 1, inner_persist=0, outer_persist=2, "
+        "chrnt=l2_l3, slc=byp, persist=0, stride_add_first=0"
+        : "=R"(dst)
+        : "R"(addr));
+    return dst;
+#else
+    return *(const Vec8*)(ptr + idx);
+#endif
+  }
+};
+
+struct __align__(32) Float8 {
+  union {
+    Float8Storage storage;
+    float elem[8];
+  } val;
+
+  __device__ __forceinline__ Float8() {}
+};
+
+__device__ __forceinline__ int mrope_24_20_20_interleaved_axis(int rot_offset) {
+  constexpr unsigned long long axis1_mask = 0x492492492492492ULL;
+  constexpr unsigned long long axis2_mask = 0x924924924924924ULL;
+  const unsigned long long bit = 1ULL << rot_offset;
+  return ((axis1_mask & bit) != 0ULL) + (((axis2_mask & bit) != 0ULL) << 1);
+}
+
+__device__ __forceinline__ int mrope_11_11_10_interleaved_axis(int rot_offset) {
+  constexpr unsigned int axis1_mask = 0x92492492U;
+  constexpr unsigned int axis2_mask = 0x24924924U;
+  const unsigned int bit = 1U << rot_offset;
+  return ((axis1_mask & bit) != 0U) + (((axis2_mask & bit) != 0U) << 1);
+}
+
+__device__ __forceinline__ float fast_rsqrt(float value) {
+#if ((defined __MUSA_ARCH__) && (__MUSA_ARCH__ == 310))
+  const float half_value = 0.5f * value;
+  float y = __frsqrt_rn(value);
+  y = y * (1.5f - half_value * y * y);
+  return y;
+#else
+  return rsqrtf(value);
+#endif
+}
+
+__device__ __forceinline__ float block_sum(float value, float* warp_sums) {
+  const int tid = (int)threadIdx.x;
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int num_warps = ((int)blockDim.x + 31) >> 5;
+
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_down_sync(0xffffffff, value, offset, 32);
+  }
+  if (lane == 0) {
+    warp_sums[warp] = value;
+  }
+  __syncthreads_lm();
+
+  value = tid < num_warps ? warp_sums[lane] : 0.0f;
+  if (warp == 0) {
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      value += __shfl_down_sync(0xffffffff, value, offset, 32);
+    }
+    if (lane == 0) {
+      warp_sums[0] = value;
+    }
+  }
+  __syncthreads_lm();
+  return warp_sums[0];
+}
+
+__device__ __forceinline__ float block_sum_8warps(float value, float* warp_sums) {
+  const int tid = (int)threadIdx.x;
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_down_sync(0xffffffff, value, offset, 32);
+  }
+  if (lane == 0) {
+    warp_sums[warp] = value;
+  }
+  __syncthreads_lm();
+
+  value = lane < 8 ? warp_sums[lane] : 0.0f;
+  if (warp == 0) {
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      value += __shfl_down_sync(0xffffffff, value, offset, 32);
+    }
+    if (lane == 0) {
+      warp_sums[0] = value;
+    }
+  }
+  __syncthreads_lm();
+  return warp_sums[0];
+}
+
+__device__ __forceinline__ float block_sum_4warps(float value, float* warp_sums) {
+  const int tid = (int)threadIdx.x;
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_down_sync(0xffffffff, value, offset, 32);
+  }
+  if (lane == 0) {
+    warp_sums[warp] = value;
+  }
+  __syncthreads_lm();
+
+  value = lane < 4 ? warp_sums[lane] : 0.0f;
+  if (warp == 0) {
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      value += __shfl_down_sync(0xffffffff, value, offset, 32);
+    }
+    if (lane == 0) {
+      warp_sums[0] = value;
+    }
+  }
+  __syncthreads_lm();
+  return warp_sums[0];
+}

--- a/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/fused_rmsnorm.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/jit_custom_ar/fused_rmsnorm.py
@@ -1,0 +1,574 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from functools import lru_cache
+from typing import Any, Optional
+
+import torch
+
+from sglang.srt.distributed.device_communicators.custom_all_reduce_utils import (
+    is_weak_contiguous,
+)
+
+
+@lru_cache(maxsize=None)
+def _env_flag(names: tuple[str, ...], default: bool) -> bool:
+    for name in names:
+        value = os.environ.get(name)
+        if value is not None:
+            return value.lower() in ("1", "true", "yes", "on")
+    return default
+
+
+def _fused_rmsnorm_multi_rank_enabled() -> bool:
+    return _env_flag(
+        (
+            "SGLANG_CUSTOM_AR_FUSED_RMSNORM_MULTI_RANK",
+            "SGL_CUSTOM_AR_FUSED_RMSNORM_MULTI_RANK",
+        ),
+        True,
+    )
+
+
+def _is_power_of_2(value: int) -> bool:
+    return value > 0 and (value & (value - 1)) == 0
+
+
+def _fused_rmsnorm_tp2_single_kernel_shape(rows: int, hidden: int) -> bool:
+    if not (1 <= hidden <= 16384):
+        return False
+    if hidden <= 8192 and _is_power_of_2(hidden):
+        return True
+    if hidden % 8 != 0:
+        return rows <= 8192
+    return rows <= 512
+
+
+def _fused_rmsnorm_tp2_row_one_shape(rows: int, hidden: int) -> bool:
+    if not (1 <= rows <= 131072):
+        return False
+    # The row-one kernel assigns one vec8 chunk to each thread. Keep the
+    # Python dispatch aligned with the kernel's 1024-thread launch limit.
+    return hidden % 8 == 0 and 0 < hidden <= 8 * 1024
+
+
+def _fused_rmsnorm_tp2_default_shape(rows: int, hidden: int) -> bool:
+    if not (1 <= rows <= 131072):
+        return False
+    if hidden % 8 != 0:
+        return False
+    if 0 < hidden <= 16384:
+        return True
+    return _fused_rmsnorm_tp2_single_kernel_shape(
+        rows, hidden
+    ) or _fused_rmsnorm_tp2_row_one_shape(rows, hidden)
+
+
+def _fused_rmsnorm_tp8_row_one_shape(rows: int, hidden: int) -> bool:
+    if not (1 <= rows <= 131072):
+        return False
+    return hidden % 8 == 0 and 0 < hidden <= 8 * 1024
+
+
+def _fused_rmsnorm_tp8_shape(rows: int, hidden: int) -> bool:
+    return hidden % 8 == 0 and 0 < hidden <= 16384 and 1 <= rows <= 131072
+
+
+def _fused_rmsnorm_tp4_row_one_shape(rows: int, hidden: int) -> bool:
+    if not (1 <= rows <= 131072):
+        return False
+    return hidden % 8 == 0 and 0 < hidden <= 8 * 1024
+
+
+def _fused_rmsnorm_tp4_shape(rows: int, hidden: int) -> bool:
+    return hidden % 8 == 0 and 0 < hidden <= 16384 and 1 <= rows <= 131072
+
+
+def _fused_rmsnorm_default_shape(world_size: int, rows: int, hidden: int) -> bool:
+    if rows < 1:
+        return False
+    if world_size == 2:
+        return _fused_rmsnorm_tp2_default_shape(rows, hidden)
+    if world_size == 4:
+        return _fused_rmsnorm_tp4_shape(rows, hidden)
+    if world_size == 8:
+        return _fused_rmsnorm_tp8_shape(rows, hidden)
+    return False
+
+
+class MusaJitCustomAllreduceRMSNorm:
+    def __init__(self, comm: Any) -> None:
+        self._comm = comm
+        self._fused_rmsnorm_unregistered_launchers = {}
+        self._fused_rmsnorm_registered_launchers = {}
+        self._fused_rmsnorm_row_registered_launchers = {}
+        self._fused_rmsnorm_row_unregistered_launchers = {}
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._comm, name)
+
+    def _should_fused_rmsnorm_custom_ar(self, inp: torch.Tensor):
+        if self.disabled:
+            return False
+        if inp.dtype not in (torch.float16, torch.bfloat16):
+            return False
+        if inp.numel() * inp.element_size() > self.max_size:
+            return False
+        return is_weak_contiguous(inp)
+
+    def fused_allreduce_rmsnorm(
+        self,
+        input_: torch.Tensor,
+        residual_inp_: torch.Tensor,
+        weight_: torch.Tensor,
+        eps: float,
+    ) -> Optional[tuple[torch.Tensor, torch.Tensor]]:
+        if self.world_size not in (2, 4, 8):
+            return None
+        if self.world_size != 2 and not _fused_rmsnorm_multi_rank_enabled():
+            return None
+        if input_.dtype not in (torch.float16, torch.bfloat16):
+            return None
+        if input_.dim() != 2:
+            return None
+        if residual_inp_.shape != input_.shape:
+            return None
+        if weight_.dim() != 1 or weight_.numel() != input_.shape[-1]:
+            return None
+        if residual_inp_.dtype != input_.dtype or weight_.dtype != input_.dtype:
+            return None
+        if residual_inp_.device != input_.device or weight_.device != input_.device:
+            return None
+        if not is_weak_contiguous(residual_inp_) or not weight_.is_contiguous():
+            return None
+
+        if not input_.is_contiguous() or not residual_inp_.is_contiguous():
+            return None
+        if not self._should_fused_rmsnorm_custom_ar(input_):
+            return None
+        rows, hidden = input_.shape
+        if hidden % 8 != 0:
+            return None
+        is_graph_launch = (
+            self._IS_CAPTURING
+            and torch.get_device_module().is_current_stream_capturing()
+        )
+        graph_registered_input_enabled = getattr(
+            self, "_graph_registered_input_enabled", False
+        )
+        use_row_single_kernel = (
+            (
+                self.world_size == 2
+                and _fused_rmsnorm_tp2_row_one_shape(int(rows), int(hidden))
+                and (
+                    not _fused_rmsnorm_tp2_single_kernel_shape(int(rows), int(hidden))
+                    or (int(hidden) == 1536 and 256 <= int(rows) <= 512)
+                )
+            )
+            or (
+                self.world_size == 4
+                and _fused_rmsnorm_tp4_row_one_shape(int(rows), int(hidden))
+            )
+            or (
+                self.world_size == 8
+                and _fused_rmsnorm_tp8_row_one_shape(int(rows), int(hidden))
+            )
+        )
+        if self.world_size == 4 and int(hidden) == 8192 and int(rows) <= 16:
+            use_row_single_kernel = False
+        if not _fused_rmsnorm_default_shape(self.world_size, rows, hidden):
+            return None
+
+        norm_out = None
+        residual_out = residual_inp_
+        if use_row_single_kernel:
+            rows, hidden = input_.shape
+            use_h8192_sum_sidecar = hidden == 8192 and _fused_rmsnorm_default_shape(
+                self.world_size, int(rows), int(hidden)
+            )
+            use_h8192_row_one = hidden == 8192 and (
+                (
+                    self.world_size == 4
+                    and _fused_rmsnorm_tp4_row_one_shape(int(rows), int(hidden))
+                )
+                or (
+                    self.world_size == 8
+                    and _fused_rmsnorm_tp8_row_one_shape(int(rows), int(hidden))
+                )
+            )
+            use_small_hidden_row_one = hidden in (512, 1024, 2048)
+            use_tp8_small_row_one = self.world_size == 8 and (
+                hidden == 2048
+                or (hidden == 512 and (rows < 128 or rows >= 8192))
+                or (hidden == 1024 and rows >= 8192)
+            )
+            use_tp8_row_one = (
+                self.world_size == 8
+                and (
+                    (hidden == 4096 and rows >= 512)
+                    or use_tp8_small_row_one
+                    or _fused_rmsnorm_tp8_row_one_shape(int(rows), int(hidden))
+                )
+                and _fused_rmsnorm_tp8_row_one_shape(int(rows), int(hidden))
+            )
+            use_tp2_row_one = (
+                self.world_size == 2
+                and _fused_rmsnorm_tp2_row_one_shape(int(rows), int(hidden))
+                and _fused_rmsnorm_default_shape(
+                    self.world_size, int(rows), int(hidden)
+                )
+            )
+            use_tp4_row_one_default = (
+                self.world_size == 4
+                and _fused_rmsnorm_tp4_row_one_shape(int(rows), int(hidden))
+            )
+            use_tp4_sum_sidecar = (
+                (self.world_size in (4, 8) and use_h8192_sum_sidecar)
+                or (
+                    self.world_size == 4
+                    and (hidden in (512, 1024, 2048, 4096) or use_h8192_sum_sidecar)
+                )
+                or use_tp4_row_one_default
+                or use_tp8_row_one
+                or use_tp2_row_one
+            )
+            sidecar_use_registered_rank_data = (
+                is_graph_launch and graph_registered_input_enabled
+            )
+            # Align with CUDA/sgl-kernel semantics: graph decode may use
+            # pre-registered activation rank data, while eager prefill stages
+            # through the communicator workspace.
+            if use_tp4_sum_sidecar:
+                try:
+                    use_row_one_kernel = (
+                        use_tp4_row_one_default
+                        or use_h8192_row_one
+                        or use_tp8_row_one
+                        or use_tp2_row_one
+                    )
+                    if use_row_one_kernel:
+                        if norm_out is None and self.world_size == 4:
+                            norm_out = torch.empty_like(input_)
+                        use_tuned_module = (
+                            use_tp4_row_one_default
+                            and self.world_size == 4
+                            and (
+                                (int(rows) >= 1024 and int(hidden) == 1024)
+                                or (int(rows) == 128 and int(hidden) == 4096)
+                            )
+                        )
+                        use_small_rows_module = (
+                            self.world_size == 4
+                            and (
+                                (int(hidden) == 1024 and int(rows) <= 128)
+                                or (int(hidden) == 2048 and 32 <= int(rows) <= 128)
+                                or (int(hidden) == 4096 and int(rows) <= 512)
+                            )
+                        ) or (
+                            self.world_size == 8
+                            and (
+                                (int(hidden) == 512 and int(rows) <= 512)
+                                or (int(hidden) == 1024 and 128 <= int(rows) <= 512)
+                                or (int(hidden) == 2048 and int(rows) <= 512)
+                            )
+                        )
+                        use_row_skip_end_barrier = (
+                            self.world_size in (2, 4, 8) and int(hidden) <= 16384
+                        )
+                        row_token_2stage_override = 1
+                        row_warp_inv_rms_override = (
+                            1
+                            if (
+                                self.world_size == 4
+                                and int(hidden) in (512, 1024, 2048, 3072)
+                            )
+                            else -1
+                        )
+                        if norm_out is None:
+                            norm_out = torch.empty_like(input_)
+                        launched = self._launch_fused_allreduce_rmsnorm_row(
+                            input_,
+                            residual_inp_,
+                            residual_out,
+                            norm_out,
+                            weight_,
+                            int(hidden),
+                            use_tuned_module,
+                            use_small_rows_module,
+                            use_row_skip_end_barrier,
+                            row_token_2stage_override,
+                            row_warp_inv_rms_override,
+                            float(eps),
+                            sidecar_use_registered_rank_data,
+                        )
+                        if not launched:
+                            # A registered graph-input miss must preserve the
+                            # collective result. Fall back to the explicit-input
+                            # row launcher, matching the normal custom-AR path.
+                            launched = self._launch_fused_allreduce_rmsnorm_row(
+                                input_,
+                                residual_inp_,
+                                residual_out,
+                                norm_out,
+                                weight_,
+                                int(hidden),
+                                use_tuned_module,
+                                use_small_rows_module,
+                                use_row_skip_end_barrier,
+                                row_token_2stage_override,
+                                row_warp_inv_rms_override,
+                                float(eps),
+                                False,
+                            )
+                        if not launched:
+                            return None
+                        return norm_out, residual_out
+                    return None
+                except Exception:
+                    raise
+            return None
+
+        rows, hidden = input_.shape
+        use_tp2_h4096_default = (
+            self.world_size == 2 and int(hidden) == 4096 and 1 <= int(rows) <= 4096
+        )
+        use_tp2_h4096_short_default = (
+            self.world_size == 2 and int(hidden) == 4096 and 1 <= int(rows) <= 512
+        )
+        use_tp2_registered_default = use_tp2_h4096_default
+        use_capture_registered_default = (
+            is_graph_launch and graph_registered_input_enabled
+        )
+        use_registered_input = use_capture_registered_default or (
+            is_graph_launch
+            and graph_registered_input_enabled
+            and use_tp2_registered_default
+        )
+        use_short_rows_module = (
+            (
+                self.world_size == 2
+                and (
+                    (int(hidden) == 4096 and int(rows) < 2048)
+                    or (int(hidden) == 1024 and int(rows) < 512)
+                    or (
+                        512 <= int(hidden) <= 8192
+                        and int(hidden) % 8 == 0
+                        and not _is_power_of_2(int(hidden))
+                        and int(rows) <= 128
+                    )
+                )
+                and (
+                    use_tp2_h4096_short_default
+                    or int(hidden) == 1024
+                    or (
+                        512 <= int(hidden) <= 8192
+                        and int(hidden) % 8 == 0
+                        and not _is_power_of_2(int(hidden))
+                        and int(rows) <= 128
+                    )
+                )
+            )
+            or (
+                self.world_size == 4
+                and (int(hidden) == 512 or (int(hidden) == 8192 and int(rows) <= 16))
+                and int(rows) < 1024
+            )
+            or (self.world_size == 8 and int(hidden) == 1536 and int(rows) <= 2048)
+        )
+        use_row_skip_end_barrier = self.world_size in (2, 4, 8) and int(hidden) <= 16384
+        cache_policy = 0
+        if use_registered_input and norm_out is None:
+            norm_out = torch.empty_like(input_)
+        row_warp_inv_rms_override = (
+            1
+            if (
+                self.world_size == 8 and int(rows) == 256 and int(hidden) in (512, 1024)
+            )
+            else -1
+        )
+        if use_registered_input:
+            rank_data_ready = False
+            try:
+                rank_data = self._rank_data_for_registered_input(input_)
+                if rank_data is None:
+                    raise RuntimeError("registered rank data is not ready")
+                rank_data_ready = True
+                launcher_key = (
+                    int(hidden),
+                    use_short_rows_module,
+                    cache_policy,
+                    use_row_skip_end_barrier,
+                    row_warp_inv_rms_override,
+                )
+                launcher = self._fused_rmsnorm_registered_launchers.get(launcher_key)
+                if launcher is None:
+                    launcher = (
+                        self._jit_ar.launch_fused_allreduce_rmsnorm_registered_func(
+                            self.world_size,
+                            int(hidden),
+                            use_short_rows_module,
+                            False,
+                            cache_policy,
+                            use_row_skip_end_barrier,
+                            row_warp_inv_rms_override,
+                        )
+                    )
+                    self._fused_rmsnorm_registered_launchers[launcher_key] = launcher
+                launcher(
+                    rank_data,
+                    self.signal_ptrs_cpu,
+                    residual_inp_,
+                    residual_out,
+                    norm_out,
+                    weight_,
+                    int(self.meta_ptrs[self.rank]),
+                    int(self.rank),
+                    int(self.world_size),
+                    float(eps),
+                )
+                return norm_out, residual_out
+            except Exception:
+                if (
+                    is_graph_launch
+                    and graph_registered_input_enabled
+                    and not rank_data_ready
+                ):
+                    # Registration can miss while the graph is being
+                    # recaptured. Continue into the explicit-input fused
+                    # launcher below instead of returning silent zeros.
+                    pass
+                else:
+                    raise
+
+        if norm_out is None:
+            norm_out = torch.empty_like(input_)
+        reset_lamport = False
+        push_polling_override = 0
+        lamport_push_override = 0
+        launcher_key = (
+            int(hidden),
+            use_short_rows_module,
+            cache_policy,
+            use_row_skip_end_barrier,
+            push_polling_override,
+            lamport_push_override,
+            row_warp_inv_rms_override,
+        )
+        launcher = self._fused_rmsnorm_unregistered_launchers.get(launcher_key)
+        if launcher is None:
+            launcher = self._jit_ar.launch_fused_allreduce_rmsnorm_unregistered_func(
+                self.world_size,
+                int(hidden),
+                use_short_rows_module,
+                False,
+                cache_policy,
+                use_row_skip_end_barrier,
+                push_polling_override,
+                lamport_push_override,
+                row_warp_inv_rms_override,
+            )
+            self._fused_rmsnorm_unregistered_launchers[launcher_key] = launcher
+        launcher(
+            self.rank_data,
+            self.signal_ptrs_cpu,
+            input_,
+            norm_out,
+            residual_inp_,
+            residual_out,
+            weight_,
+            int(self.meta_ptrs[self.rank]),
+            int(self.buffer_ptrs[self.rank]),
+            int(self.max_size),
+            int(self.rank),
+            int(self.world_size),
+            float(eps),
+            int(reset_lamport),
+        )
+        return norm_out, residual_out
+
+    def _launch_fused_allreduce_rmsnorm_row(
+        self,
+        input_: torch.Tensor,
+        residual_inp_: torch.Tensor,
+        residual_out: torch.Tensor,
+        norm_out: torch.Tensor,
+        weight_: torch.Tensor,
+        hidden: int,
+        use_tuned_module: bool,
+        use_small_rows_module: bool,
+        use_row_skip_end_barrier: bool,
+        token_2stage_override: int,
+        row_warp_inv_rms_override: int,
+        eps: float,
+        use_graph_registered_rank_data: bool,
+    ) -> bool:
+        launcher_key = (
+            int(hidden),
+            bool(use_tuned_module),
+            bool(use_small_rows_module),
+            bool(use_row_skip_end_barrier),
+            int(token_2stage_override),
+            int(row_warp_inv_rms_override),
+        )
+        if not use_graph_registered_rank_data:
+            launcher = self._fused_rmsnorm_row_unregistered_launchers.get(launcher_key)
+            if launcher is None:
+                launcher = (
+                    self._jit_ar.launch_fused_allreduce_rmsnorm_row_unregistered_func(
+                        self.world_size,
+                        hidden,
+                        use_tuned_module,
+                        use_small_rows_module,
+                        use_row_skip_end_barrier,
+                        token_2stage_override,
+                        row_warp_inv_rms_override,
+                    )
+                )
+                self._fused_rmsnorm_row_unregistered_launchers[launcher_key] = launcher
+            launcher(
+                self.rank_data,
+                self.signal_ptrs_cpu,
+                input_,
+                residual_inp_,
+                residual_out,
+                norm_out,
+                weight_,
+                int(self.meta_ptrs[self.rank]),
+                int(self.buffer_ptrs[self.rank]),
+                int(self.max_size),
+                int(self.rank),
+                int(self.world_size),
+                int(hidden),
+                float(eps),
+            )
+            return True
+
+        rank_data = self._rank_data_for_registered_input(input_)
+        if rank_data is None:
+            return False
+        launcher = self._fused_rmsnorm_row_registered_launchers.get(launcher_key)
+        if launcher is None:
+            launcher = self._jit_ar.launch_fused_allreduce_rmsnorm_row_registered_func(
+                self.world_size,
+                hidden,
+                use_tuned_module,
+                use_small_rows_module,
+                use_row_skip_end_barrier,
+                token_2stage_override,
+                row_warp_inv_rms_override,
+            )
+            self._fused_rmsnorm_row_registered_launchers[launcher_key] = launcher
+        launcher(
+            rank_data,
+            self.signal_ptrs_cpu,
+            residual_inp_,
+            residual_out,
+            norm_out,
+            weight_,
+            int(self.meta_ptrs[self.rank]),
+            int(self.rank),
+            int(self.world_size),
+            int(hidden),
+            float(eps),
+        )
+        return True

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
@@ -20,6 +20,7 @@ from functools import wraps
 from .patches.gdn import apply_musa_gdn_launch_patch
 from .patches.moe_schedule import apply_musa_moe_schedule_patch
 from .patches.mrope_positions import apply_musa_mrope_device_positions_patch
+from .patches.topk_schedule import apply_musa_topk_schedule_patch
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +120,7 @@ def apply_musa_patches() -> None:
     apply_musa_gdn_launch_patch()
     apply_musa_moe_schedule_patch()
     apply_musa_mrope_device_positions_patch()
+    apply_musa_topk_schedule_patch()
     _patches_applied = True
     logger.info("All MUSA vendor patches applied successfully")
 

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import logging
 from functools import wraps
 
+from .patches.gdn import apply_musa_gdn_launch_patch
+
 logger = logging.getLogger(__name__)
 
 _patches_applied = False
@@ -104,6 +106,7 @@ def _patch_pp_launch_batch_add_sync() -> None:
     SchedulerPPMixin._pp_launch_batch = pp_launch_batch_with_forward_stream_sync
     logger.info("MUSA PP launch forward_stream sync patch applied")
 
+
 def apply_musa_patches() -> None:
     global _patches_applied
     if _patches_applied:
@@ -111,8 +114,9 @@ def apply_musa_patches() -> None:
 
     _patch_pp_send_recv_order()
     _patch_pp_launch_batch_add_sync()
+    apply_musa_gdn_launch_patch()
     _patches_applied = True
-    logger.info("All MUSA PP patches applied successfully")
+    logger.info("All MUSA vendor patches applied successfully")
 
 
 apply_musa_patches()

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
@@ -18,6 +18,7 @@ import logging
 from functools import wraps
 
 from .patches.gdn import apply_musa_gdn_launch_patch
+from .patches.moe_schedule import apply_musa_moe_schedule_patch
 
 logger = logging.getLogger(__name__)
 
@@ -115,6 +116,7 @@ def apply_musa_patches() -> None:
     _patch_pp_send_recv_order()
     _patch_pp_launch_batch_add_sync()
     apply_musa_gdn_launch_patch()
+    apply_musa_moe_schedule_patch()
     _patches_applied = True
     logger.info("All MUSA vendor patches applied successfully")
 

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
@@ -17,6 +17,9 @@ from __future__ import annotations
 import logging
 from functools import wraps
 
+from .patches.custom_allreduce_rmsnorm import (
+    apply_musa_custom_allreduce_rmsnorm_patch,
+)
 from .patches.gdn import apply_musa_gdn_launch_patch
 from .patches.moe_schedule import apply_musa_moe_schedule_patch
 from .patches.mrope_positions import apply_musa_mrope_device_positions_patch
@@ -118,6 +121,7 @@ def apply_musa_patches() -> None:
     _patch_pp_send_recv_order()
     _patch_pp_launch_batch_add_sync()
     apply_musa_gdn_launch_patch()
+    apply_musa_custom_allreduce_rmsnorm_patch()
     apply_musa_moe_schedule_patch()
     apply_musa_mrope_device_positions_patch()
     apply_musa_topk_schedule_patch()

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
@@ -19,6 +19,7 @@ from functools import wraps
 
 from .patches.gdn import apply_musa_gdn_launch_patch
 from .patches.moe_schedule import apply_musa_moe_schedule_patch
+from .patches.mrope_positions import apply_musa_mrope_device_positions_patch
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +118,7 @@ def apply_musa_patches() -> None:
     _patch_pp_launch_batch_add_sync()
     apply_musa_gdn_launch_patch()
     apply_musa_moe_schedule_patch()
+    apply_musa_mrope_device_positions_patch()
     _patches_applied = True
     logger.info("All MUSA vendor patches applied successfully")
 

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
@@ -20,6 +20,7 @@ from functools import wraps
 from .patches.custom_allreduce_rmsnorm import (
     apply_musa_custom_allreduce_rmsnorm_patch,
 )
+from .patches.eventfd_completion import apply_musa_eventfd_completion_patch
 from .patches.gdn import apply_musa_gdn_launch_patch
 from .patches.moe_schedule import apply_musa_moe_schedule_patch
 from .patches.mrope_positions import apply_musa_mrope_device_positions_patch
@@ -122,6 +123,7 @@ def apply_musa_patches() -> None:
     _patch_pp_launch_batch_add_sync()
     apply_musa_gdn_launch_patch()
     apply_musa_custom_allreduce_rmsnorm_patch()
+    apply_musa_eventfd_completion_patch()
     apply_musa_moe_schedule_patch()
     apply_musa_mrope_device_positions_patch()
     apply_musa_topk_schedule_patch()

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patches/__init__.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patches/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Moore Threads-specific patches for SGLang internals."""

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patches/custom_allreduce_rmsnorm.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patches/custom_allreduce_rmsnorm.py
@@ -1,0 +1,149 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Enable the MTT S5000 custom all-reduce + residual/RMSNorm path.
+
+The MUSA vendor runtime carries a JIT custom all-reduce implementation that is
+newer than the SGLang revision used by the FlagOS image.  Keep the integration
+in the plugin: replace the custom-allreduce class before TP groups are created,
+then reuse SGLang's existing ``forward_with_allreduce_fusion`` seam.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_ENV_NAME = "SGLANG_MUSA_CUSTOM_AR_FUSED_RMSNORM"
+_patch_applied = False
+
+
+def _device_is_s5000() -> bool:
+    try:
+        import torch
+
+        return "S5000" in str(torch.musa.get_device_name()).upper()
+    except Exception:
+        return False
+
+
+def _enabled() -> bool:
+    value = os.environ.get(_ENV_NAME, "auto").strip().lower()
+    if value in ("0", "false", "no", "off"):
+        return False
+    if value in ("1", "true", "yes", "on"):
+        return True
+    if value != "auto":
+        raise ValueError(f"Unsupported {_ENV_NAME} value: {value!r}")
+    return _device_is_s5000()
+
+
+def _dispatch_musa_custom_allreduce():
+    from sglang_fl.dispatch.backends.vendor.mthreads.jit_custom_ar.communicator import (
+        MusaJitCustomAllreduce,
+    )
+
+    return MusaJitCustomAllreduce
+
+
+def _select_group(use_attn_tp_group: bool):
+    from sglang.srt.distributed.parallel_state import (
+        get_attn_tp_group,
+        get_moe_ep_group,
+        get_moe_tp_group,
+        get_tp_group,
+    )
+
+    if use_attn_tp_group:
+        return get_attn_tp_group()
+    moe_ep_group = get_moe_ep_group()
+    if moe_ep_group.world_size > 1:
+        return moe_ep_group
+    moe_tp_group = get_moe_tp_group()
+    if moe_tp_group.world_size > 1:
+        return moe_tp_group
+    return get_tp_group()
+
+
+def _forward_with_musa_allreduce_fusion(
+    norm_module,
+    x,
+    residual,
+    post_residual_addition,
+    weight,
+    use_attn_tp_group: bool = True,
+):
+    """Try the communicator-native fused path, with exact generic fallback."""
+    if residual is None:
+        return norm_module.forward(x, residual, post_residual_addition)
+
+    group = _select_group(use_attn_tp_group)
+    if group.world_size <= 1:
+        return norm_module.forward(x, residual, post_residual_addition)
+
+    if post_residual_addition is not None:
+        residual = residual + post_residual_addition
+
+    fused_result = group.fused_allreduce_rmsnorm(
+        x, residual, weight, norm_module.variance_epsilon
+    )
+    if fused_result is not None:
+        return fused_result
+
+    # Unsupported shapes, missing JIT dependencies, or an explicitly disabled
+    # communicator retain the pre-patch all-reduce then RMSNorm semantics.
+    x = group.all_reduce(x)
+    return norm_module.forward(x, residual, None)
+
+
+def _musa_fusion_gate(original_gate, batch_size: int) -> bool:
+    # The fused implementation performs the full dtype/shape/size checks.  This
+    # gate only avoids routing empty or impossible row counts through it.
+    if 0 < int(batch_size) <= 131072:
+        return True
+    return bool(original_gate(batch_size))
+
+
+def apply_musa_custom_allreduce_rmsnorm_patch() -> None:
+    global _patch_applied
+    if _patch_applied:
+        return
+    if not _enabled():
+        logger.info("MUSA custom AR + RMSNorm patch disabled by %s", _ENV_NAME)
+        return
+
+    try:
+        from sglang.srt.distributed import parallel_state
+        from sglang.srt.distributed.device_communicators import custom_all_reduce
+        from sglang.srt.layers import communicator, layernorm
+    except Exception as exc:
+        logger.warning("MUSA custom AR + RMSNorm patch skipped: %s", exc)
+        return
+
+    # GroupCoordinator imports this symbol into parallel_state, so update both
+    # bindings before any TP/attention/MoE group is constructed.
+    custom_all_reduce.dispatch_custom_allreduce = _dispatch_musa_custom_allreduce
+    parallel_state.dispatch_custom_allreduce = _dispatch_musa_custom_allreduce
+    layernorm._forward_with_allreduce_fusion = _forward_with_musa_allreduce_fusion
+
+    original_gate = communicator.apply_flashinfer_allreduce_fusion
+
+    def gate_with_musa(batch_size: int) -> bool:
+        return _musa_fusion_gate(original_gate, batch_size)
+
+    communicator.apply_flashinfer_allreduce_fusion = gate_with_musa
+    _patch_applied = True
+    logger.info(
+        "MUSA S5000 JIT custom all-reduce + residual/RMSNorm patch applied "
+        "(graph registered-input mode defaults off for SGLang compatibility)"
+    )
+
+
+__all__ = ["apply_musa_custom_allreduce_rmsnorm_patch"]

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patches/eventfd_completion.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patches/eventfd_completion.py
@@ -1,0 +1,99 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Replace MUSA output Event waits with native callback + eventfd waits."""
+
+from __future__ import annotations
+
+import logging
+import os
+from functools import wraps
+
+logger = logging.getLogger(__name__)
+
+_ENV_NAME = "SGLANG_MUSA_EVENTFD_COMPLETION"
+_PATCH_MARKER = "_sglang_fl_musa_eventfd_completion"
+
+
+def _device_is_s5000() -> bool:
+    try:
+        import torch
+
+        return "S5000" in str(torch.musa.get_device_name()).upper()
+    except Exception:
+        return False
+
+
+def _enabled() -> bool:
+    value = os.environ.get(_ENV_NAME, "auto").strip().lower()
+    if value in ("0", "false", "no", "off"):
+        return False
+    if value in ("1", "true", "yes", "on"):
+        return True
+    if value != "auto":
+        raise ValueError(f"Unsupported {_ENV_NAME} value: {value!r}")
+    return _device_is_s5000()
+
+
+def _wrap_copy_to_cpu(original):
+    if getattr(original, _PATCH_MARKER, False):
+        return original
+
+    @wraps(original)
+    def wrapped(result, return_logprob: bool):
+        next_token_ids = getattr(result, "next_token_ids", None)
+        copy_device = getattr(next_token_ids, "device", None)
+        value = original(result, return_logprob)
+        fallback_event = getattr(result, "copy_done", None)
+        if copy_device is None or fallback_event is None:
+            return value
+        from ..eventfd_completion import (
+            MusaCompletionEventProxy,
+            try_enqueue_musa_completion,
+        )
+
+        completion = try_enqueue_musa_completion(copy_device)
+        if completion is not None:
+            result.copy_done = MusaCompletionEventProxy(
+                completion, fallback_event
+            )
+        return value
+
+    setattr(wrapped, _PATCH_MARKER, True)
+    return wrapped
+
+
+def apply_musa_eventfd_completion_patch() -> bool:
+    if not _enabled():
+        logger.info("MUSA eventfd completion disabled by %s", _ENV_NAME)
+        return False
+    try:
+        from sglang.srt.managers import utils as manager_utils
+    except Exception as exc:
+        logger.warning("MUSA eventfd completion patch skipped: %s", exc)
+        return False
+
+    original = manager_utils.GenerationBatchResult.copy_to_cpu
+    if getattr(original, _PATCH_MARKER, False):
+        return True
+    manager_utils.GenerationBatchResult.copy_to_cpu = _wrap_copy_to_cpu(original)
+    logger.info(
+        "MUSA eventfd output completion enabled with Event fallback "
+        "(pool size=%s)",
+        os.environ.get("SGLANG_MUSA_EVENTFD_COMPLETION_POOL_SIZE", "64"),
+    )
+    return True
+
+
+__all__ = ["apply_musa_eventfd_completion_patch"]

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patches/gdn.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patches/gdn.py
@@ -1,0 +1,105 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MTT S5000 launch policy for SGLang's packed GDN decode kernel."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+
+import torch
+
+from sglang_fl.patches.triton_kernel import patch_kernel_launch_meta
+
+logger = logging.getLogger(__name__)
+
+_KERNEL_MODULE = "sglang.srt.layers.attention.fla.fused_recurrent"
+_KERNEL_NAME = "fused_recurrent_gated_delta_rule_packed_decode_kernel"
+_ENV = "SGLANG_FL_MUSA_GDN_PACKED_DECODE_NUM_WARPS"
+_LEGACY_ENV = "SGLANG_MUSA_GDN_PACKED_DECODE_NUM_WARPS"
+_VALID_NUM_WARPS = {1, 2, 4, 8, 16}
+_DEVICE_DEFAULTS = {"S5000": 8}
+
+
+def _get_musa_device_name() -> str | None:
+    try:
+        musa = getattr(torch, "musa", None)
+        if musa is None or not musa.is_available() or musa.device_count() < 1:
+            return None
+        return str(musa.get_device_name(0))
+    except Exception as exc:
+        logger.warning("MUSA device-name query failed; GDN tuning skipped: %s", exc)
+        return None
+
+
+def _platform_default(device_name: str | None) -> int | None:
+    normalized = (device_name or "").upper()
+    for model, num_warps in _DEVICE_DEFAULTS.items():
+        if model in normalized:
+            return num_warps
+    return None
+
+
+def _resolve_num_warps(device_name: str | None) -> int | None:
+    raw = os.environ.get(_ENV)
+    source = _ENV
+    if raw is None:
+        raw = os.environ.get(_LEGACY_ENV)
+        source = _LEGACY_ENV
+
+    if raw is None or raw.strip().lower() == "auto":
+        return _platform_default(device_name)
+    if raw.strip().lower() in {"0", "off", "false", "disable", "disabled"}:
+        return None
+
+    try:
+        num_warps = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"{source} must be auto/off/1/2/4/8/16, got {raw!r}"
+        ) from exc
+    if num_warps not in _VALID_NUM_WARPS:
+        raise ValueError(f"{source} must be auto/off/1/2/4/8/16, got {raw!r}")
+    return num_warps
+
+
+def apply_musa_gdn_launch_patch() -> None:
+    """Apply the S5000-tuned packed-decode launch policy without editing SGLang."""
+
+    device_name = _get_musa_device_name()
+    num_warps = _resolve_num_warps(device_name)
+    if num_warps is None:
+        logger.info(
+            "MUSA packed GDN decode launch tuning skipped for device=%s",
+            device_name or "unknown",
+        )
+        return
+
+    try:
+        module = importlib.import_module(_KERNEL_MODULE)
+        patch_kernel_launch_meta(module, _KERNEL_NAME, {"num_warps": num_warps})
+    except (ImportError, AttributeError) as exc:
+        logger.warning(
+            "MUSA packed GDN decode launch tuning is unavailable in this "
+            "SGLang revision: %s",
+            exc,
+        )
+        return
+    logger.info(
+        "Patched MUSA packed GDN decode launch meta for device=%s: num_warps=%d",
+        device_name or "unknown",
+        num_warps,
+    )

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patches/moe_schedule.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patches/moe_schedule.py
@@ -1,0 +1,199 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Robust fused-MoE scheduling for MTT S5000 decode.
+
+TorchAda's bundled Triton 3.2 configuration uses eight warps and a K=128
+tile for the Qwen3.6-35B-A3B TP2 decode shape.  That configuration has a
+large performance cliff on some S5000 systems with Triton 3.6.  A four-warp,
+K=64 configuration is within a few percent of the old-system optimum and is
+about three times faster on the affected systems.
+
+Keep this as a vendor monkeypatch: SGLang and TorchAda remain unmodified, and
+operators can disable it with ``SGLANG_MUSA_MOE_DECODE_SCHEDULE=off``.  Patch
+both resolvers because SGLang v0.5.11 carries its own copy while some MUSA
+integration versions call TorchAda's runtime copy directly.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+from functools import wraps
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+_ENV_NAME = "SGLANG_MUSA_MOE_DECODE_SCHEDULE"
+_PATCH_MARKER = "_sglang_fl_musa_moe_schedule"
+_match_logged = False
+_S5000_DECODE_CONFIG = {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 1,
+}
+
+
+def _enabled() -> bool:
+    return os.environ.get(_ENV_NAME, "auto").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+        "disable",
+        "disabled",
+    }
+
+
+def _device_name() -> str:
+    try:
+        import torch
+
+        if hasattr(torch, "musa") and torch.musa.is_available():
+            return str(torch.musa.get_device_name())
+    except Exception:
+        pass
+    return ""
+
+
+def _matches_s5000_decode(
+    w1_shape,
+    w2_shape,
+    top_k: int,
+    dtype,
+    M: int,
+    *,
+    block_shape=None,
+    per_channel_quant: bool = False,
+) -> bool:
+    """Match only the measured Qwen3.6-35B-A3B TP2 BF16 decode shape."""
+
+    return (
+        _enabled()
+        and "S5000" in _device_name().upper()
+        and len(w1_shape) == 3
+        and len(w2_shape) == 3
+        and w1_shape[0] == w2_shape[0] == 256
+        and w1_shape[2] == w2_shape[1] == 2048
+        and w1_shape[1] == 2 * w2_shape[2]
+        and w2_shape[2] in (256, 512)
+        and top_k == 8
+        and dtype is None
+        and M == 64
+        and block_shape is None
+        and not per_channel_quant
+    )
+
+
+def _wrap_try_get_optimal_moe_config(original: Callable[..., Any]):
+    if getattr(original, _PATCH_MARKER, False):
+        return original
+
+    @wraps(original)
+    def wrapped(
+        w1_shape,
+        w2_shape,
+        top_k,
+        dtype,
+        M,
+        is_marlin=False,
+        block_shape=None,
+        per_channel_quant=False,
+        return_down_config=False,
+    ):
+        global _match_logged
+        if _matches_s5000_decode(
+            w1_shape,
+            w2_shape,
+            top_k,
+            dtype,
+            M,
+            block_shape=block_shape,
+            per_channel_quant=per_channel_quant,
+        ):
+            config = dict(_S5000_DECODE_CONFIG)
+            if not _match_logged:
+                logger.info(
+                    "MUSA S5000 MoE decode schedule selected for "
+                    "w1=%s, w2=%s, top_k=%s, M=%s",
+                    tuple(w1_shape),
+                    tuple(w2_shape),
+                    top_k,
+                    M,
+                )
+                _match_logged = True
+            if return_down_config:
+                return config, (dict(config), config["BLOCK_SIZE_M"])
+            return config
+        return original(
+            w1_shape,
+            w2_shape,
+            top_k,
+            dtype,
+            M,
+            is_marlin=is_marlin,
+            block_shape=block_shape,
+            per_channel_quant=per_channel_quant,
+            return_down_config=return_down_config,
+        )
+
+    setattr(wrapped, _PATCH_MARKER, True)
+    return wrapped
+
+
+def _patch_resolver(config_module_name: str, fused_moe_module_name: str) -> bool:
+    try:
+        config_module = importlib.import_module(config_module_name)
+        fused_moe_module = importlib.import_module(fused_moe_module_name)
+    except ImportError as exc:
+        logger.debug("MUSA MoE resolver %s unavailable: %s", config_module_name, exc)
+        return False
+
+    wrapped = _wrap_try_get_optimal_moe_config(
+        config_module.try_get_optimal_moe_config
+    )
+    config_module.try_get_optimal_moe_config = wrapped
+    fused_moe_module.try_get_optimal_moe_config = wrapped
+    return True
+
+
+def apply_musa_moe_schedule_patch() -> bool:
+    """Patch SGLang/TorchAda config resolvers and already-imported aliases."""
+
+    if not _enabled():
+        logger.info("MUSA S5000 MoE decode schedule patch disabled by %s", _ENV_NAME)
+        return False
+
+    patched = False
+    patched |= _patch_resolver(
+        "sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe_triton_config",
+        "sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe",
+    )
+    patched |= _patch_resolver(
+        "torchada.triton.runtime.fused_moe.config",
+        "torchada.triton.runtime.fused_moe.fused_moe",
+    )
+    if not patched:
+        logger.warning("MUSA S5000 MoE decode schedule patch skipped: no resolver")
+        return False
+
+    logger.info(
+        "MUSA S5000 MoE decode schedule patch applied: M=64, "
+        "BLOCK_M=32, BLOCK_N=32, BLOCK_K=64, warps=4, stages=1"
+    )
+    return True

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patches/mrope_positions.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patches/mrope_positions.py
@@ -1,0 +1,114 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Keep text-only decode MRoPE positions on the MUSA device.
+
+SGLang v0.5.11 builds a ``[3, batch]`` CPU tensor on every decode step and
+copies it to the accelerator.  The copy is only 1.5 KiB at batch size 64, but
+MUSA's pageable-memory ``musaMemcpyAsync`` waits for the preceding graph and
+blocks the scheduler thread.  Text-only MRoPE axes are identical, so a
+zero-stride view of the already resident decode positions is equivalent and
+avoids both the allocation and the host-to-device transfer.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from functools import wraps
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+_ENV_NAME = "SGLANG_MUSA_DECODE_MROPE_DEVICE_POSITIONS"
+_PATCH_MARKER = "_sglang_fl_musa_mrope_device_positions"
+
+
+def _enabled() -> bool:
+    return os.environ.get(_ENV_NAME, "auto").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+        "disable",
+        "disabled",
+    }
+
+
+def _can_reuse_device_positions(
+    forward_batch: Any,
+    model_worker_batch: Any,
+    *,
+    rl_on_policy_target: Any,
+) -> bool:
+    """Return whether decode MRoPE is exactly ``positions.expand(3, -1)``."""
+
+    try:
+        is_decode = forward_batch.forward_mode.is_decode()
+        multimodal_inputs = model_worker_batch.multimodal_inputs
+    except AttributeError:
+        return False
+
+    return bool(
+        is_decode
+        and (
+            rl_on_policy_target is not None
+            or all(mm_input is None for mm_input in multimodal_inputs)
+        )
+    )
+
+
+def _wrap_compute_mrope_positions(
+    original: Callable[..., Any], get_global_server_args: Callable[[], Any]
+):
+    if getattr(original, _PATCH_MARKER, False):
+        return original
+
+    @wraps(original)
+    def wrapped(self, model_runner, batch):
+        if _enabled() and _can_reuse_device_positions(
+            self,
+            batch,
+            rl_on_policy_target=get_global_server_args().rl_on_policy_target,
+        ):
+            self.mrope_positions = self.positions.unsqueeze(0).expand(3, -1)
+            return None
+        return original(self, model_runner, batch)
+
+    setattr(wrapped, _PATCH_MARKER, True)
+    return wrapped
+
+
+def apply_musa_mrope_device_positions_patch() -> bool:
+    """Monkeypatch SGLang's decode MRoPE producer without modifying SGLang."""
+
+    if not _enabled():
+        logger.info("MUSA decode MRoPE device positions disabled by %s", _ENV_NAME)
+        return False
+
+    try:
+        from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+        from sglang.srt.server_args import get_global_server_args
+    except ImportError as exc:
+        logger.warning("MUSA decode MRoPE device positions skipped: %s", exc)
+        return False
+
+    original = ForwardBatch._compute_mrope_positions
+    wrapped = _wrap_compute_mrope_positions(original, get_global_server_args)
+    if wrapped is original:
+        return True
+
+    ForwardBatch._compute_mrope_positions = wrapped
+    logger.info("MUSA decode MRoPE device positions patch applied")
+    return True

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patches/topk_schedule.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patches/topk_schedule.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 _ENV_NAME = "SGLANG_MUSA_TOPK_SCHEDULE"
 _PATCH_MARKER = "_sglang_fl_musa_topk_schedule"
-_TARGET_TOKEN_COUNTS = frozenset(
+_TARGET_GRAPH_TOKEN_COUNTS = frozenset(
     {
         # CUDA-graph capture batches.
         1,
@@ -49,12 +49,9 @@ _TARGET_TOKEN_COUNTS = frozenset(
         48,
         56,
         64,
-        # Chunked-prefill shapes observed with 1K-token prompts.
-        1024,
-        7168,
-        8192,
     }
 )
+_TARGET_PREFILL_TOKEN_RANGE = range(1024, 16385)
 
 
 def _enabled() -> bool:
@@ -89,9 +86,13 @@ def _is_target_shape(
     correction_bias: Any,
 ) -> bool:
     try:
+        num_tokens = int(gating_output.shape[0])
         return (
             gating_output.ndim == 2
-            and int(gating_output.shape[0]) in _TARGET_TOKEN_COUNTS
+            and (
+                num_tokens in _TARGET_GRAPH_TOKEN_COUNTS
+                or num_tokens in _TARGET_PREFILL_TOKEN_RANGE
+            )
             and int(gating_output.shape[1]) == 256
             and int(topk_weights.shape[-1]) == 8
             and not moe_softcapping
@@ -176,7 +177,7 @@ def apply_musa_topk_schedule_patch() -> bool:
     # This alias may already have been imported before vendor patches run.
     layer_topk.topk_softmax = wrapped
     logger.info(
-        "MUSA S5000 softmax TopK schedule enabled for E=256, K=8 measured shapes: "
-        "warps=1, stages=1"
+        "MUSA S5000 softmax TopK schedule enabled for E=256, K=8 graph shapes "
+        "and 1K-16K prefill: warps=1, stages=1"
     )
     return True

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patches/topk_schedule.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patches/topk_schedule.py
@@ -1,0 +1,182 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skip cold softmax-TopK autotuning for measured MTT S5000 shapes.
+
+The MUSA kernel carries fifteen launch configurations.  Autotuning them also
+flushes a 256 MiB cache buffer between candidates, making the first large
+prefill wave several seconds slower.  On MP31, ``warps=1, stages=1`` is the
+validated choice for Qwen3.6-35B-A3B's ``E=256, K=8`` graph and prefill shapes.
+
+Only those exact shapes are pinned.  Other models and shapes keep SGLang's
+normal autotuner.  Set ``SGLANG_MUSA_TOPK_SCHEDULE=off`` to disable the patch.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from functools import wraps
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+_ENV_NAME = "SGLANG_MUSA_TOPK_SCHEDULE"
+_PATCH_MARKER = "_sglang_fl_musa_topk_schedule"
+_TARGET_TOKEN_COUNTS = frozenset(
+    {
+        # CUDA-graph capture batches.
+        1,
+        2,
+        4,
+        8,
+        12,
+        16,
+        24,
+        32,
+        40,
+        48,
+        56,
+        64,
+        # Chunked-prefill shapes observed with 1K-token prompts.
+        1024,
+        7168,
+        8192,
+    }
+)
+
+
+def _enabled() -> bool:
+    return os.environ.get(_ENV_NAME, "auto").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+        "disable",
+        "disabled",
+    }
+
+
+def _device_name() -> str:
+    try:
+        import torch
+    except ImportError:
+        return ""
+
+    try:
+        if hasattr(torch, "musa") and torch.musa.is_available():
+            return str(torch.musa.get_device_name())
+    except RuntimeError:
+        logger.debug("Unable to query MUSA device name", exc_info=True)
+    return ""
+
+
+def _is_target_shape(
+    topk_weights: Any,
+    gating_output: Any,
+    moe_softcapping: float,
+    correction_bias: Any,
+) -> bool:
+    try:
+        return (
+            gating_output.ndim == 2
+            and int(gating_output.shape[0]) in _TARGET_TOKEN_COUNTS
+            and int(gating_output.shape[1]) == 256
+            and int(topk_weights.shape[-1]) == 8
+            and not moe_softcapping
+            and correction_bias is None
+        )
+    except (AttributeError, IndexError, TypeError, ValueError):
+        return False
+
+
+def _make_topk_wrapper(
+    original: Callable[..., Any], kernel: Any, selected_config: Any
+) -> Callable[..., Any]:
+    @wraps(original)
+    def wrapped(
+        topk_weights: Any,
+        topk_ids: Any,
+        gating_output: Any,
+        renormalize: bool = False,
+        moe_softcapping: float = 0,
+        correction_bias: Any = None,
+    ) -> Any:
+        if not _is_target_shape(
+            topk_weights, gating_output, moe_softcapping, correction_bias
+        ):
+            return original(
+                topk_weights,
+                topk_ids,
+                gating_output,
+                renormalize,
+                moe_softcapping,
+                correction_bias,
+            )
+
+        original_configs = kernel.configs
+        kernel.configs = [selected_config]
+        try:
+            return original(
+                topk_weights,
+                topk_ids,
+                gating_output,
+                renormalize,
+                moe_softcapping,
+                correction_bias,
+            )
+        finally:
+            kernel.configs = original_configs
+
+    setattr(wrapped, _PATCH_MARKER, True)
+    return wrapped
+
+
+def apply_musa_topk_schedule_patch() -> bool:
+    """Pin only the measured MP31 softmax-TopK shapes to one launch config."""
+
+    if not _enabled():
+        logger.info("MUSA TopK schedule disabled by %s", _ENV_NAME)
+        return False
+
+    device_name = _device_name()
+    if "S5000" not in device_name.upper():
+        logger.info("MUSA TopK schedule skipped on device %s", device_name)
+        return False
+
+    try:
+        import triton
+        from sglang.srt.hardware_backend.musa.kernels import topk as musa_topk
+        from sglang.srt.layers.moe import topk as layer_topk
+    except ImportError as exc:
+        logger.warning("MUSA TopK schedule skipped: %s", exc)
+        return False
+
+    if getattr(musa_topk.topk_softmax, _PATCH_MARKER, False):
+        return True
+
+    selected_config = triton.Config({}, num_warps=1, num_stages=1)
+    wrapped = _make_topk_wrapper(
+        musa_topk.topk_softmax,
+        musa_topk.topk_softmax_triton_kernel,
+        selected_config,
+    )
+    musa_topk.topk_softmax = wrapped
+    # This alias may already have been imported before vendor patches run.
+    layer_topk.topk_softmax = wrapped
+    logger.info(
+        "MUSA S5000 softmax TopK schedule enabled for E=256, K=8 measured shapes: "
+        "warps=1, stages=1"
+    )
+    return True

--- a/sglang_fl/dispatch/config/musa.yaml
+++ b/sglang_fl/dispatch/config/musa.yaml
@@ -25,3 +25,7 @@ flagos_blacklist:
   - _unique2
   - unique_dim
   - unique_consecutive
+  # On MTT S5000, FlagGems' rank-specialized pointwise copy kernels dominate
+  # long-prefill traces.  The native MUSA path is faster after its one-time
+  # shape specialization and also improves the graph-captured decode path.
+  - copy_

--- a/sglang_fl/dispatch/config/musa.yaml
+++ b/sglang_fl/dispatch/config/musa.yaml
@@ -29,3 +29,10 @@ flagos_blacklist:
   # long-prefill traces.  The native MUSA path is faster after its one-time
   # shape specialization and also improves the graph-captured decode path.
   - copy_
+  # FlagGems' generated index-put kernel is especially slow for the large
+  # prefill KV-cache writes used by Qwen3.6 on S5000.  Keep all three ATen
+  # entry points on the native MUSA implementation so indexing syntax,
+  # index_put_(), and the internal unsafe overload follow one policy.
+  - index_put
+  - index_put_
+  - _index_put_impl_

--- a/sglang_fl/distributed/communicator.py
+++ b/sglang_fl/distributed/communicator.py
@@ -111,8 +111,11 @@ class CommunicatorFL:
         if self._flagcx_comm and not self._flagcx_comm.disabled:
             out = self._flagcx_comm.all_reduce(input_)
             if out is not None:
-                # FlagCX all_reduce returns a new tensor; copy back for in-place semantics
-                input_.copy_(out)
+                # Device communicators may either return a new result or update
+                # ``input_`` in place.  FlagCX currently does the latter; avoid
+                # launching a redundant device-to-device self-copy in that case.
+                if out is not input_:
+                    input_.copy_(out)
                 return input_
         # Fallback: torch.distributed
         dist.all_reduce(input_, group=self.device_group)

--- a/sglang_fl/patches/__init__.py
+++ b/sglang_fl/patches/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reusable monkey-patch helpers for vendor backends."""

--- a/sglang_fl/patches/triton_kernel.py
+++ b/sglang_fl/patches/triton_kernel.py
@@ -1,0 +1,65 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reusable Triton kernel launch-meta overrides."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+class KernelLaunchMetaProxy:
+    """Override selected launch parameters while preserving the kernel API."""
+
+    def __init__(self, kernel: Any, launch_overrides: Mapping[str, Any]) -> None:
+        if not launch_overrides:
+            raise ValueError("At least one kernel launch override is required.")
+        self._kernel = kernel
+        self._launch_overrides = dict(launch_overrides)
+
+    @property
+    def launch_overrides(self) -> dict[str, Any]:
+        return self._launch_overrides.copy()
+
+    def __getitem__(self, grid: Any) -> Any:
+        launch = self._kernel[grid]
+
+        def launch_with_overrides(*args: Any, **kwargs: Any) -> Any:
+            kwargs.update(self._launch_overrides)
+            return launch(*args, **kwargs)
+
+        return launch_with_overrides
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._kernel, name)
+
+
+def patch_kernel_launch_meta(
+    module: Any,
+    kernel_name: str,
+    launch_overrides: Mapping[str, Any],
+) -> None:
+    """Apply launch overrides to a module's kernel attribute exactly once."""
+
+    kernel = getattr(module, kernel_name)
+    if isinstance(kernel, KernelLaunchMetaProxy):
+        expected = dict(launch_overrides)
+        if kernel.launch_overrides != expected:
+            raise RuntimeError(
+                f"Kernel {kernel_name} already has launch overrides "
+                f"{kernel.launch_overrides}, expected {expected}."
+            )
+        return
+    setattr(module, kernel_name, KernelLaunchMetaProxy(kernel, launch_overrides))

--- a/sglang_fl/platform.py
+++ b/sglang_fl/platform.py
@@ -49,7 +49,7 @@ _DIST_BACKEND_MAP = {
     "cambricon": "cncl",
     "mthreads": "mccl",
     "thead": "nccl",
-    "enflame": "eccl"
+    "enflame": "eccl",
     "tsingmicro": "tccl",
 }
 
@@ -59,7 +59,7 @@ _ATTN_BACKEND_MAP = {
     "nvidia": "flashinfer",
     "ascend": "ascend",
     "mthreads": "fa3",
-    "enflame": "fa3"
+    "enflame": "fa3",
     "kunlunxin": "kunlunxin",
     "iluvatar": "triton",
 }

--- a/tests/unit_tests/dispatch/backends/test_mthreads_fla.py
+++ b/tests/unit_tests/dispatch/backends/test_mthreads_fla.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Unit tests for the MTT S5000 FLA adapters."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import torch
+
+
+def _packed_inputs(*, state_dtype=torch.float32):
+    batch, qk_heads, value_heads, dim = 2, 2, 4, 128
+    packed_dim = 2 * qk_heads * dim + value_heads * dim
+    return {
+        "mixed_qkv": torch.randn(batch, packed_dim, dtype=torch.bfloat16),
+        "a": torch.randn(batch, value_heads, dtype=torch.bfloat16),
+        "b": torch.randn(batch, value_heads, dtype=torch.bfloat16),
+        "A_log": torch.randn(value_heads, dtype=torch.float32),
+        "dt_bias": torch.randn(value_heads, dtype=torch.float32),
+        "scale": dim**-0.5,
+        "initial_state": torch.randn(8, value_heads, dim, dim, dtype=state_dtype),
+        "out": torch.empty(batch, 1, value_heads, dim, dtype=torch.bfloat16),
+        "ssm_state_indices": torch.tensor([1, 5], dtype=torch.int64),
+        "use_qk_l2norm_in_kernel": True,
+    }
+
+
+def test_mate_packed_decode_uses_strided_views_and_caller_buffers(monkeypatch) -> None:
+    from sglang_fl.dispatch.backends.vendor.mthreads.impl import fla
+
+    inputs = _packed_inputs()
+    captured = {}
+
+    def fake_mate_gdn_decode(**kwargs):
+        captured.update(kwargs)
+        kwargs["output"].fill_(3)
+        return kwargs["output"], kwargs["state"]
+
+    monkeypatch.setattr(fla, "_is_s5000", lambda device: True)
+    monkeypatch.setattr(fla, "_load_mate_gdn_decode", lambda: fake_mate_gdn_decode)
+
+    result, state = fla.fused_recurrent_gated_delta_rule_packed_decode_musa(**inputs)
+
+    assert result is inputs["out"]
+    assert state is inputs["initial_state"]
+    assert captured["q"].shape == (2, 1, 2, 128)
+    assert captured["k"].shape == (2, 1, 2, 128)
+    assert captured["v"].shape == (2, 1, 4, 128)
+    assert captured["a"].shape == (2, 1, 4)
+    assert captured["b"].shape == (2, 1, 4)
+    assert captured["q"]._base is not None
+    assert captured["k"]._base is not None
+    assert captured["v"]._base is not None
+    assert captured["state_layout"] == "VK"
+    assert captured["state_indices"] is inputs["ssm_state_indices"]
+    assert captured["scale"] == inputs["scale"]
+    assert captured["output"] is inputs["out"]
+    assert captured["use_qk_l2norm"] is True
+    assert torch.all(result == 3)
+
+
+def test_mate_packed_decode_falls_back_for_unsupported_state(monkeypatch) -> None:
+    from sglang_fl.dispatch.backends.vendor.mthreads.impl import fla
+
+    inputs = _packed_inputs(state_dtype=torch.bfloat16)
+    fallback_result = (torch.empty(1), torch.empty(1))
+    original = Mock(return_value=fallback_result)
+
+    monkeypatch.setattr(fla, "_is_s5000", lambda device: True)
+    monkeypatch.setattr(fla, "_load_mate_gdn_decode", Mock())
+    monkeypatch.setattr(fla, "_original", lambda name: original)
+
+    assert (
+        fla.fused_recurrent_gated_delta_rule_packed_decode_musa(**inputs)
+        is fallback_result
+    )
+    fla._load_mate_gdn_decode.assert_not_called()
+    original.assert_called_once_with(**inputs)
+
+
+def test_mate_packed_decode_can_be_disabled(monkeypatch) -> None:
+    from sglang_fl.dispatch.backends.vendor.mthreads.impl import fla
+
+    inputs = _packed_inputs()
+    fallback_result = (torch.empty(1), torch.empty(1))
+    original = Mock(return_value=fallback_result)
+
+    monkeypatch.setenv("SGLANG_MUSA_MATE_GDN", "off")
+    monkeypatch.setattr(fla, "_is_s5000", lambda device: True)
+    monkeypatch.setattr(fla, "_load_mate_gdn_decode", Mock())
+    monkeypatch.setattr(fla, "_original", lambda name: original)
+
+    assert (
+        fla.fused_recurrent_gated_delta_rule_packed_decode_musa(**inputs)
+        is fallback_result
+    )
+    fla._load_mate_gdn_decode.assert_not_called()
+    original.assert_called_once_with(**inputs)

--- a/tests/unit_tests/dispatch/backends/test_mthreads_fla.py
+++ b/tests/unit_tests/dispatch/backends/test_mthreads_fla.py
@@ -26,6 +26,96 @@ def _packed_inputs(*, state_dtype=torch.float32):
     }
 
 
+def _prefill_inputs(*, gate_dtype=torch.float32):
+    total, qk_heads, value_heads, dim = 65, 2, 4, 128
+    return {
+        "q": torch.randn(1, total, qk_heads, dim, dtype=torch.bfloat16),
+        "k": torch.randn(1, total, qk_heads, dim, dtype=torch.bfloat16),
+        "v": torch.randn(1, total, value_heads, dim, dtype=torch.bfloat16),
+        "g": torch.randn(1, total, value_heads, dtype=gate_dtype),
+        "beta": torch.rand(1, total, value_heads, dtype=gate_dtype),
+        "scale": dim**-0.5,
+        "initial_state": torch.randn(8, value_heads, dim, dim, dtype=torch.float32),
+        "initial_state_indices": torch.tensor([1, 5], dtype=torch.int64),
+        "cu_seqlens": torch.tensor([0, 32, total], dtype=torch.int32),
+        "head_first": False,
+        "use_qk_l2norm_in_kernel": True,
+    }
+
+
+def test_mate_chunk_prefill_gathers_and_writes_back_state(monkeypatch) -> None:
+    from sglang_fl.dispatch.backends.vendor.mthreads.impl import fla
+
+    inputs = _prefill_inputs()
+    original_state = inputs["initial_state"].clone()
+    captured = {}
+
+    def fake_mate_gdn_prefill(**kwargs):
+        captured.update(kwargs)
+        output = torch.full_like(kwargs["v"], 3)
+        final_state = torch.full_like(kwargs["initial_state"], 7)
+        return output, final_state
+
+    monkeypatch.setattr(fla, "_is_s5000", lambda device: True)
+    monkeypatch.setattr(fla, "_mamba_radix_cache_disabled", lambda: True)
+    monkeypatch.setattr(fla, "_load_mate_gdn_prefill", lambda: fake_mate_gdn_prefill)
+
+    output, final_state, h = fla.chunk_gated_delta_rule_musa(**inputs)
+
+    assert output.shape == inputs["v"].shape
+    assert torch.all(output == 3)
+    assert final_state is None
+    assert h is None
+    assert captured["q"].shape == (65, 2, 128)
+    assert captured["k"].shape == (65, 2, 128)
+    assert captured["v"].shape == (65, 4, 128)
+    assert captured["g"].shape == (65, 4)
+    assert captured["beta"].shape == (65, 4)
+    assert captured["initial_state"].shape == (2, 4, 128, 128)
+    assert captured["cu_seqlens"] is inputs["cu_seqlens"]
+    assert captured["use_qk_l2norm_in_kernel"] is True
+    assert captured["chunk_size"] == 64
+    assert captured["is_log_space"] is True
+    assert torch.all(inputs["initial_state"][[1, 5]] == 7)
+    assert torch.equal(inputs["initial_state"][[0, 2]], original_state[[0, 2]])
+
+
+def test_mate_chunk_prefill_falls_back_when_radix_cache_is_enabled(
+    monkeypatch,
+) -> None:
+    from sglang_fl.dispatch.backends.vendor.mthreads.impl import fla
+
+    inputs = _prefill_inputs()
+    fallback_result = (torch.empty(1), torch.empty(1), torch.empty(1))
+    original = Mock(return_value=fallback_result)
+
+    monkeypatch.setattr(fla, "_is_s5000", lambda device: True)
+    monkeypatch.setattr(fla, "_mamba_radix_cache_disabled", lambda: False)
+    monkeypatch.setattr(fla, "_load_mate_gdn_prefill", Mock())
+    monkeypatch.setattr(fla, "_original", lambda name: original)
+
+    assert fla.chunk_gated_delta_rule_musa(**inputs) is fallback_result
+    fla._load_mate_gdn_prefill.assert_not_called()
+    original.assert_called_once_with(**inputs)
+
+
+def test_mate_chunk_prefill_falls_back_for_non_fp32_gates(monkeypatch) -> None:
+    from sglang_fl.dispatch.backends.vendor.mthreads.impl import fla
+
+    inputs = _prefill_inputs(gate_dtype=torch.bfloat16)
+    fallback_result = (torch.empty(1), torch.empty(1), torch.empty(1))
+    original = Mock(return_value=fallback_result)
+
+    monkeypatch.setattr(fla, "_is_s5000", lambda device: True)
+    monkeypatch.setattr(fla, "_mamba_radix_cache_disabled", lambda: True)
+    monkeypatch.setattr(fla, "_load_mate_gdn_prefill", Mock())
+    monkeypatch.setattr(fla, "_original", lambda name: original)
+
+    assert fla.chunk_gated_delta_rule_musa(**inputs) is fallback_result
+    fla._load_mate_gdn_prefill.assert_not_called()
+    original.assert_called_once_with(**inputs)
+
+
 def test_mate_packed_decode_uses_strided_views_and_caller_buffers(monkeypatch) -> None:
     from sglang_fl.dispatch.backends.vendor.mthreads.impl import fla
 

--- a/tests/unit_tests/distributed/test_communicator.py
+++ b/tests/unit_tests/distributed/test_communicator.py
@@ -121,6 +121,20 @@ def test_all_reduce_uses_flagcx_and_copies_back(monkeypatch) -> None:
     comm_mod.dist.all_reduce.assert_not_called()
 
 
+def test_all_reduce_skips_copy_when_flagcx_updates_in_place(monkeypatch) -> None:
+    from sglang_fl.distributed import communicator as comm_mod
+
+    monkeypatch.setattr(comm_mod.dist, "all_reduce", Mock())
+    tensor = Mock(spec=torch.Tensor)
+    flagcx = _FakeFlagCX()
+    flagcx.all_reduce = Mock(return_value=tensor)
+    comm = _make_comm(flagcx=flagcx)
+
+    assert comm.all_reduce(tensor) is tensor
+    tensor.copy_.assert_not_called()
+    comm_mod.dist.all_reduce.assert_not_called()
+
+
 def test_all_reduce_without_flagcx_uses_dist(monkeypatch) -> None:
     from sglang_fl.distributed import communicator as comm_mod
 

--- a/tests/unit_tests/flaggems/test_setup_flaggems.py
+++ b/tests/unit_tests/flaggems/test_setup_flaggems.py
@@ -312,3 +312,12 @@ def test_build_config_env_flagos_blacklist_overrides_yaml(
     config = sglang_fl_module._build_config()
 
     assert config["flagos_blacklist"] == ["env_op", "other_op"]
+
+
+def test_musa_platform_uses_native_copy() -> None:
+    from sglang_fl.dispatch.config.utils import load_platform_config
+
+    config = load_platform_config("musa")
+
+    assert config is not None
+    assert "copy_" in config["flagos_blacklist"]

--- a/tests/unit_tests/flaggems/test_setup_flaggems.py
+++ b/tests/unit_tests/flaggems/test_setup_flaggems.py
@@ -314,10 +314,13 @@ def test_build_config_env_flagos_blacklist_overrides_yaml(
     assert config["flagos_blacklist"] == ["env_op", "other_op"]
 
 
-def test_musa_platform_uses_native_copy() -> None:
+def test_musa_platform_uses_native_copy_and_index_put() -> None:
     from sglang_fl.dispatch.config.utils import load_platform_config
 
     config = load_platform_config("musa")
 
     assert config is not None
     assert "copy_" in config["flagos_blacklist"]
+    assert {"index_put", "index_put_", "_index_put_impl_"}.issubset(
+        config["flagos_blacklist"]
+    )

--- a/tests/unit_tests/patches/__init__.py
+++ b/tests/unit_tests/patches/__init__.py
@@ -1,0 +1,1 @@
+# Copyright 2026 FlagOS Contributors

--- a/tests/unit_tests/patches/test_triton_kernel.py
+++ b/tests/unit_tests/patches/test_triton_kernel.py
@@ -1,0 +1,75 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from sglang_fl.patches.triton_kernel import (
+    KernelLaunchMetaProxy,
+    patch_kernel_launch_meta,
+)
+
+
+class _FakeKernel:
+    marker = "wrapped"
+
+    def __getitem__(self, grid):
+        def launch(*args, **kwargs):
+            return grid, args, kwargs
+
+        return launch
+
+
+def test_kernel_launch_meta_proxy_overrides_multiple_parameters():
+    proxy = KernelLaunchMetaProxy(
+        _FakeKernel(),
+        {"BLOCK_N": 2048, "num_warps": 4, "num_stages": 2},
+    )
+
+    grid, args, kwargs = proxy["grid"](
+        1,
+        BLOCK_N=256,
+        num_warps=8,
+        other=True,
+    )
+
+    assert grid == "grid"
+    assert args == (1,)
+    assert kwargs == {
+        "BLOCK_N": 2048,
+        "num_warps": 4,
+        "num_stages": 2,
+        "other": True,
+    }
+    assert proxy.marker == "wrapped"
+
+
+def test_patch_kernel_launch_meta_is_idempotent():
+    module = SimpleNamespace(kernel=_FakeKernel())
+    overrides = {"num_warps": 8}
+
+    patch_kernel_launch_meta(module, "kernel", overrides)
+    proxy = module.kernel
+    patch_kernel_launch_meta(module, "kernel", overrides)
+
+    assert module.kernel is proxy
+
+
+def test_patch_kernel_launch_meta_rejects_conflicting_overrides():
+    module = SimpleNamespace(kernel=_FakeKernel())
+    patch_kernel_launch_meta(module, "kernel", {"num_warps": 8})
+
+    with pytest.raises(RuntimeError, match="already has launch overrides"):
+        patch_kernel_launch_meta(module, "kernel", {"num_warps": 4})

--- a/tests/unit_tests/platform/test_musa_custom_allreduce_rmsnorm.py
+++ b/tests/unit_tests/platform/test_musa_custom_allreduce_rmsnorm.py
@@ -1,0 +1,94 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+from types import SimpleNamespace
+
+from sglang_fl.dispatch.backends.vendor.mthreads.patches import (
+    custom_allreduce_rmsnorm as patch,
+)
+
+
+class _Norm:
+    variance_epsilon = 1e-6
+
+    def __init__(self):
+        self.calls = []
+
+    def forward(self, x, residual, post_residual_addition):
+        self.calls.append((x, residual, post_residual_addition))
+        return "norm", residual
+
+
+class _Group:
+    world_size = 2
+
+    def __init__(self, fused_result):
+        self.fused_result = fused_result
+        self.fused_calls = []
+        self.all_reduce_calls = []
+
+    def fused_allreduce_rmsnorm(self, x, residual, weight, eps):
+        self.fused_calls.append((x, residual, weight, eps))
+        return self.fused_result
+
+    def all_reduce(self, x):
+        self.all_reduce_calls.append(x)
+        return f"reduced:{x}"
+
+
+def test_fused_result_bypasses_generic_path(monkeypatch):
+    group = _Group(("fused-norm", "fused-residual"))
+    monkeypatch.setattr(patch, "_select_group", lambda _: group)
+    norm = _Norm()
+
+    result = patch._forward_with_musa_allreduce_fusion(
+        norm, "x", "residual", None, "weight"
+    )
+
+    assert result == ("fused-norm", "fused-residual")
+    assert group.all_reduce_calls == []
+    assert norm.calls == []
+
+
+def test_unsupported_shape_keeps_allreduce_then_norm_fallback(monkeypatch):
+    group = _Group(None)
+    monkeypatch.setattr(patch, "_select_group", lambda _: group)
+    norm = _Norm()
+
+    result = patch._forward_with_musa_allreduce_fusion(
+        norm, "x", "residual", "post", "weight"
+    )
+
+    assert result == ("norm", "residualpost")
+    assert group.all_reduce_calls == ["x"]
+    assert norm.calls == [("reduced:x", "residualpost", None)]
+
+
+def test_world_size_one_keeps_original_norm_semantics(monkeypatch):
+    group = SimpleNamespace(world_size=1)
+    monkeypatch.setattr(patch, "_select_group", lambda _: group)
+    norm = _Norm()
+
+    result = patch._forward_with_musa_allreduce_fusion(
+        norm, "x", "residual", "post", "weight"
+    )
+
+    assert result == ("norm", "residual")
+    assert norm.calls == [("x", "residual", "post")]
+
+
+def test_auto_mode_is_s5000_only(monkeypatch):
+    monkeypatch.delenv(patch._ENV_NAME, raising=False)
+    monkeypatch.setattr(patch, "_device_is_s5000", lambda: True)
+    assert patch._enabled()
+    monkeypatch.setattr(patch, "_device_is_s5000", lambda: False)
+    assert not patch._enabled()
+
+
+def test_gate_preserves_original_for_out_of_range_rows():
+    original = lambda rows: rows == 0
+    assert patch._musa_fusion_gate(original, 64)
+    assert patch._musa_fusion_gate(original, 0)
+    assert not patch._musa_fusion_gate(original, 131073)

--- a/tests/unit_tests/platform/test_musa_eventfd_completion.py
+++ b/tests/unit_tests/platform/test_musa_eventfd_completion.py
@@ -1,0 +1,117 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+from sglang_fl.dispatch.backends.vendor.mthreads import eventfd_completion
+from sglang_fl.dispatch.backends.vendor.mthreads.eventfd_completion import provider
+from sglang_fl.dispatch.backends.vendor.mthreads.patches import (
+    eventfd_completion as patch,
+)
+
+
+class _FallbackEvent:
+    def __init__(self):
+        self.sync_calls = 0
+
+    def synchronize(self):
+        self.sync_calls += 1
+
+
+class _Completion:
+    def __init__(self, error=None):
+        self.error = error
+        self.wait_calls = 0
+
+    def wait(self):
+        self.wait_calls += 1
+        if self.error is not None:
+            raise self.error
+
+
+class _Result:
+    def __init__(self):
+        self.next_token_ids = SimpleNamespace(
+            device=SimpleNamespace(type="musa")
+        )
+        self.copy_done = None
+
+
+def test_copy_wrapper_replaces_recorded_event_with_completion_proxy(monkeypatch):
+    fallback = _FallbackEvent()
+    completion = _Completion()
+
+    def original(result, return_logprob):
+        assert return_logprob is False
+        result.next_token_ids = "cpu-output"
+        result.copy_done = fallback
+        return "copied"
+
+    monkeypatch.setattr(
+        eventfd_completion,
+        "try_enqueue_musa_completion",
+        lambda device: completion,
+    )
+    result = _Result()
+    value = patch._wrap_copy_to_cpu(original)(result, False)
+
+    assert value == "copied"
+    assert isinstance(result.copy_done, provider.MusaCompletionEventProxy)
+    result.copy_done.synchronize()
+    result.copy_done.synchronize()
+    assert completion.wait_calls == 1
+    assert fallback.sync_calls == 0
+
+
+def test_completion_wait_failure_uses_original_event():
+    fallback = _FallbackEvent()
+    completion = _Completion(RuntimeError("wait failed"))
+    proxy = provider.MusaCompletionEventProxy(completion, fallback)
+
+    proxy.synchronize()
+    proxy.synchronize()
+
+    assert completion.wait_calls == 1
+    assert fallback.sync_calls == 1
+
+
+def test_pool_exhaustion_keeps_original_event(monkeypatch):
+    fallback = _FallbackEvent()
+
+    def original(result, _return_logprob):
+        result.copy_done = fallback
+
+    monkeypatch.setattr(
+        eventfd_completion,
+        "try_enqueue_musa_completion",
+        lambda device: None,
+    )
+    result = _Result()
+    patch._wrap_copy_to_cpu(original)(result, False)
+
+    assert result.copy_done is fallback
+
+
+def test_auto_mode_is_s5000_only(monkeypatch):
+    monkeypatch.delenv(patch._ENV_NAME, raising=False)
+    monkeypatch.setattr(patch, "_device_is_s5000", lambda: True)
+    assert patch._enabled()
+    monkeypatch.setattr(patch, "_device_is_s5000", lambda: False)
+    assert not patch._enabled()
+
+
+def test_explicit_off_wins_over_device(monkeypatch):
+    monkeypatch.setenv(patch._ENV_NAME, "off")
+    monkeypatch.setattr(patch, "_device_is_s5000", lambda: True)
+    assert not patch._enabled()

--- a/tests/unit_tests/platform/test_musa_gdn_tuning.py
+++ b/tests/unit_tests/platform/test_musa_gdn_tuning.py
@@ -1,0 +1,130 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from sglang_fl.dispatch.backends.vendor.mthreads.patches import gdn
+from sglang_fl.patches.triton_kernel import KernelLaunchMetaProxy
+
+
+class _FakeKernel:
+    def __getitem__(self, grid):
+        def launch(*args, **kwargs):
+            return grid, args, kwargs
+
+        return launch
+
+
+def _fake_module():
+    return SimpleNamespace(
+        fused_recurrent_gated_delta_rule_packed_decode_kernel=_FakeKernel()
+    )
+
+
+def test_s5000_defaults_to_eight_warps(monkeypatch):
+    module = _fake_module()
+    monkeypatch.delenv(gdn._ENV, raising=False)
+    monkeypatch.delenv(gdn._LEGACY_ENV, raising=False)
+    monkeypatch.setattr(gdn, "_get_musa_device_name", lambda: "MTT S5000")
+    monkeypatch.setattr(gdn.importlib, "import_module", lambda _name: module)
+
+    gdn.apply_musa_gdn_launch_patch()
+    proxy = module.fused_recurrent_gated_delta_rule_packed_decode_kernel
+    assert isinstance(proxy, KernelLaunchMetaProxy)
+    assert proxy.launch_overrides == {"num_warps": 8}
+
+    gdn.apply_musa_gdn_launch_patch()
+    assert module.fused_recurrent_gated_delta_rule_packed_decode_kernel is proxy
+
+
+def test_non_s5000_keeps_sglang_launch_policy(monkeypatch):
+    module = _fake_module()
+    monkeypatch.delenv(gdn._ENV, raising=False)
+    monkeypatch.delenv(gdn._LEGACY_ENV, raising=False)
+    monkeypatch.setattr(gdn, "_get_musa_device_name", lambda: "MTT S4000")
+    monkeypatch.setattr(gdn.importlib, "import_module", lambda _name: module)
+
+    gdn.apply_musa_gdn_launch_patch()
+
+    assert not isinstance(
+        module.fused_recurrent_gated_delta_rule_packed_decode_kernel,
+        KernelLaunchMetaProxy,
+    )
+
+
+@pytest.mark.parametrize("env_name", [gdn._ENV, gdn._LEGACY_ENV])
+def test_explicit_override_has_priority(monkeypatch, env_name):
+    module = _fake_module()
+    monkeypatch.delenv(gdn._ENV, raising=False)
+    monkeypatch.delenv(gdn._LEGACY_ENV, raising=False)
+    monkeypatch.setenv(env_name, "4")
+    monkeypatch.setattr(gdn, "_get_musa_device_name", lambda: "MTT S5000")
+    monkeypatch.setattr(gdn.importlib, "import_module", lambda _name: module)
+
+    gdn.apply_musa_gdn_launch_patch()
+
+    proxy = module.fused_recurrent_gated_delta_rule_packed_decode_kernel
+    assert proxy.launch_overrides == {"num_warps": 4}
+
+
+def test_plugin_override_takes_priority_over_legacy_override(monkeypatch):
+    module = _fake_module()
+    monkeypatch.setenv(gdn._ENV, "8")
+    monkeypatch.setenv(gdn._LEGACY_ENV, "4")
+    monkeypatch.setattr(gdn, "_get_musa_device_name", lambda: "MTT S5000")
+    monkeypatch.setattr(gdn.importlib, "import_module", lambda _name: module)
+
+    gdn.apply_musa_gdn_launch_patch()
+
+    proxy = module.fused_recurrent_gated_delta_rule_packed_decode_kernel
+    assert proxy.launch_overrides == {"num_warps": 8}
+
+
+def test_off_disables_platform_default(monkeypatch):
+    module = _fake_module()
+    monkeypatch.setenv(gdn._ENV, "off")
+    monkeypatch.setattr(gdn, "_get_musa_device_name", lambda: "MTT S5000")
+    monkeypatch.setattr(gdn.importlib, "import_module", lambda _name: module)
+
+    gdn.apply_musa_gdn_launch_patch()
+
+    assert not isinstance(
+        module.fused_recurrent_gated_delta_rule_packed_decode_kernel,
+        KernelLaunchMetaProxy,
+    )
+
+
+def test_invalid_override_fails_fast(monkeypatch):
+    monkeypatch.setenv(gdn._ENV, "3")
+    monkeypatch.setattr(gdn, "_get_musa_device_name", lambda: "MTT S5000")
+
+    with pytest.raises(ValueError, match="auto/off/1/2/4/8/16"):
+        gdn.apply_musa_gdn_launch_patch()
+
+
+def test_missing_sglang_kernel_fails_open(monkeypatch, caplog):
+    monkeypatch.delenv(gdn._ENV, raising=False)
+    monkeypatch.delenv(gdn._LEGACY_ENV, raising=False)
+    monkeypatch.setattr(gdn, "_get_musa_device_name", lambda: "MTT S5000")
+    monkeypatch.setattr(
+        gdn.importlib,
+        "import_module",
+        lambda _name: SimpleNamespace(),
+    )
+
+    gdn.apply_musa_gdn_launch_patch()
+
+    assert "unavailable in this SGLang revision" in caplog.text

--- a/tests/unit_tests/platform/test_musa_moe_schedule.py
+++ b/tests/unit_tests/platform/test_musa_moe_schedule.py
@@ -1,0 +1,71 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sglang_fl.dispatch.backends.vendor.mthreads.patches import moe_schedule
+
+
+W1_SHAPE = (256, 512, 2048)
+W2_SHAPE = (256, 2048, 256)
+
+
+def test_s5000_decode_shape_uses_robust_schedule(monkeypatch):
+    monkeypatch.setattr(moe_schedule, "_device_name", lambda: "MTT S5000")
+    monkeypatch.delenv("SGLANG_MUSA_MOE_DECODE_SCHEDULE", raising=False)
+
+    calls = []
+
+    def original(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {"original": True}
+
+    wrapped = moe_schedule._wrap_try_get_optimal_moe_config(original)
+    config, (down_config, max_block_m) = wrapped(
+        W1_SHAPE,
+        W2_SHAPE,
+        8,
+        None,
+        64,
+        return_down_config=True,
+    )
+
+    assert config == moe_schedule._S5000_DECODE_CONFIG
+    assert down_config == config
+    assert down_config is not config
+    assert max_block_m == 32
+    assert calls == []
+
+
+def test_non_target_shape_delegates(monkeypatch):
+    monkeypatch.setattr(moe_schedule, "_device_name", lambda: "MTT S5000")
+
+    sentinel = object()
+
+    def original(*args, **kwargs):
+        return sentinel
+
+    wrapped = moe_schedule._wrap_try_get_optimal_moe_config(original)
+    assert wrapped(W1_SHAPE, W2_SHAPE, 8, None, 32) is sentinel
+
+
+def test_schedule_can_be_disabled(monkeypatch):
+    monkeypatch.setattr(moe_schedule, "_device_name", lambda: "MTT S5000")
+    monkeypatch.setenv("SGLANG_MUSA_MOE_DECODE_SCHEDULE", "off")
+
+    sentinel = object()
+
+    def original(*args, **kwargs):
+        return sentinel
+
+    wrapped = moe_schedule._wrap_try_get_optimal_moe_config(original)
+    assert wrapped(W1_SHAPE, W2_SHAPE, 8, None, 64) is sentinel

--- a/tests/unit_tests/platform/test_musa_mrope_positions.py
+++ b/tests/unit_tests/platform/test_musa_mrope_positions.py
@@ -1,0 +1,97 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import torch
+
+from sglang_fl.dispatch.backends.vendor.mthreads.patches import mrope_positions
+
+
+class _ForwardMode:
+    def __init__(self, is_decode: bool):
+        self._is_decode = is_decode
+
+    def is_decode(self):
+        return self._is_decode
+
+
+def _make_forward_batch(batch_size: int, *, is_decode: bool = True):
+    return SimpleNamespace(
+        forward_mode=_ForwardMode(is_decode),
+        positions=torch.arange(batch_size, dtype=torch.int64),
+        mrope_positions=None,
+    )
+
+
+def test_text_decode_reuses_device_positions(monkeypatch):
+    monkeypatch.delenv(
+        "SGLANG_MUSA_DECODE_MROPE_DEVICE_POSITIONS", raising=False
+    )
+    forward_batch = _make_forward_batch(64)
+    worker_batch = SimpleNamespace(multimodal_inputs=[None] * 64)
+    calls = []
+
+    def original(*args):
+        calls.append(args)
+
+    wrapped = mrope_positions._wrap_compute_mrope_positions(
+        original,
+        lambda: SimpleNamespace(rl_on_policy_target=None),
+    )
+    wrapped(forward_batch, object(), worker_batch)
+
+    expected = forward_batch.positions.unsqueeze(0).repeat(3, 1)
+    torch.testing.assert_close(forward_batch.mrope_positions, expected, rtol=0, atol=0)
+    assert forward_batch.mrope_positions.shape == (3, 64)
+    assert forward_batch.mrope_positions.stride() == (0, 1)
+    assert calls == []
+
+
+def test_multimodal_and_prefill_delegate():
+    sentinel = object()
+
+    def original(*args):
+        return sentinel
+
+    wrapped = mrope_positions._wrap_compute_mrope_positions(
+        original,
+        lambda: SimpleNamespace(rl_on_policy_target=None),
+    )
+
+    multimodal_decode = _make_forward_batch(1)
+    worker_batch = SimpleNamespace(multimodal_inputs=[object()])
+    assert wrapped(multimodal_decode, object(), worker_batch) is sentinel
+
+    text_prefill = _make_forward_batch(1, is_decode=False)
+    worker_batch = SimpleNamespace(multimodal_inputs=[None])
+    assert wrapped(text_prefill, object(), worker_batch) is sentinel
+
+
+def test_device_positions_can_be_disabled(monkeypatch):
+    monkeypatch.setenv("SGLANG_MUSA_DECODE_MROPE_DEVICE_POSITIONS", "off")
+    sentinel = object()
+
+    def original(*args):
+        return sentinel
+
+    wrapped = mrope_positions._wrap_compute_mrope_positions(
+        original,
+        lambda: SimpleNamespace(rl_on_policy_target=None),
+    )
+    forward_batch = _make_forward_batch(8)
+    worker_batch = SimpleNamespace(multimodal_inputs=[None] * 8)
+
+    assert wrapped(forward_batch, object(), worker_batch) is sentinel
+    assert forward_batch.mrope_positions is None

--- a/tests/unit_tests/platform/test_musa_topk_schedule.py
+++ b/tests/unit_tests/platform/test_musa_topk_schedule.py
@@ -33,6 +33,15 @@ def test_target_shape_requires_measured_dimensions():
     weights = _tensor_shape(64, 8)
     assert topk_schedule._is_target_shape(weights, _tensor_shape(64, 256), 0, None)
     assert not topk_schedule._is_target_shape(weights, _tensor_shape(65, 256), 0, None)
+    assert topk_schedule._is_target_shape(
+        _tensor_shape(4095, 8), _tensor_shape(4095, 256), 0, None
+    )
+    assert topk_schedule._is_target_shape(
+        _tensor_shape(15360, 8), _tensor_shape(15360, 256), 0, None
+    )
+    assert not topk_schedule._is_target_shape(
+        _tensor_shape(16385, 8), _tensor_shape(16385, 256), 0, None
+    )
     assert not topk_schedule._is_target_shape(weights, _tensor_shape(64, 128), 0, None)
     assert not topk_schedule._is_target_shape(
         _tensor_shape(64, 4), _tensor_shape(64, 256), 0, None

--- a/tests/unit_tests/platform/test_musa_topk_schedule.py
+++ b/tests/unit_tests/platform/test_musa_topk_schedule.py
@@ -1,0 +1,79 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+from sglang_fl.dispatch.backends.vendor.mthreads.patches import topk_schedule
+
+
+def _tensor_shape(*shape):
+    return SimpleNamespace(ndim=len(shape), shape=shape)
+
+
+def test_topk_schedule_is_enabled_by_default_but_can_be_disabled(monkeypatch):
+    monkeypatch.delenv("SGLANG_MUSA_TOPK_SCHEDULE", raising=False)
+    assert topk_schedule._enabled()
+
+    monkeypatch.setenv("SGLANG_MUSA_TOPK_SCHEDULE", "off")
+    assert not topk_schedule._enabled()
+
+
+def test_target_shape_requires_measured_dimensions():
+    weights = _tensor_shape(64, 8)
+    assert topk_schedule._is_target_shape(weights, _tensor_shape(64, 256), 0, None)
+    assert not topk_schedule._is_target_shape(weights, _tensor_shape(65, 256), 0, None)
+    assert not topk_schedule._is_target_shape(weights, _tensor_shape(64, 128), 0, None)
+    assert not topk_schedule._is_target_shape(
+        _tensor_shape(64, 4), _tensor_shape(64, 256), 0, None
+    )
+    assert not topk_schedule._is_target_shape(
+        weights, _tensor_shape(64, 256), 1.0, None
+    )
+    assert not topk_schedule._is_target_shape(
+        weights, _tensor_shape(64, 256), 0, object()
+    )
+
+
+def test_wrapper_temporarily_pins_target_and_restores_configs():
+    configs = [object(), object()]
+    selected = object()
+    kernel = SimpleNamespace(configs=configs)
+    seen = []
+
+    def original(*args):
+        seen.append(kernel.configs)
+        return "result"
+
+    wrapped = topk_schedule._make_topk_wrapper(original, kernel, selected)
+    result = wrapped(_tensor_shape(64, 8), object(), _tensor_shape(64, 256))
+
+    assert result == "result"
+    assert seen == [[selected]]
+    assert kernel.configs is configs
+    assert getattr(wrapped, topk_schedule._PATCH_MARKER)
+
+
+def test_wrapper_leaves_unmeasured_shape_on_autotuner():
+    configs = [object(), object()]
+    kernel = SimpleNamespace(configs=configs)
+    seen = []
+
+    def original(*args):
+        seen.append(kernel.configs)
+
+    wrapped = topk_schedule._make_topk_wrapper(original, kernel, object())
+    wrapped(_tensor_shape(65, 8), object(), _tensor_shape(65, 256))
+
+    assert seen == [configs]
+    assert kernel.configs is configs


### PR DESCRIPTION
## Summary

This PR adds plugin-side performance policies for Qwen3.6-35B-A3B serving on MTT S5000 / MP31 without modifying SGLang source code:

- set the packed GDN decode kernel to the measured `num_warps=8` launch policy;
- select the validated S5000 MoE decode schedule (`BLOCK_M=32`, `BLOCK_N=32`, `BLOCK_K=64`, `GROUP_SIZE_M=1`, `num_warps=4`, `num_stages=1`);
- keep text-only decode MRoPE positions on device and remove the per-step pageable `3 x B x int64` H2D copy;
- bypass TopK autotuning with the measured `num_warps=1`, `num_stages=1` policy for covered decode/graph and dynamic prefill shapes;
- retain the Enflame vendor-map syntax repair required by the branch base.

All policies are Moore Threads vendor monkeypatches. Unsupported SGLang revisions, devices, models, dtypes, TP sizes, or tensor shapes fall back to the original SGLang path.

The implementation follows the vendor launch-policy pattern used by [vllm-plugin-FL PR #395](https://github.com/flagos-ai/vllm-plugin-FL/pull/395).

## Commits

- `6368ed0` `feat(mthreads): tune S5000 GDN launch metadata`
- `2c3daa5` `perf(musa): tune S5000 MoE decode schedule`
- `753dcd4` `perf(musa): keep decode MRoPE positions on device`
- `a69dc33` `perf(musa): skip TopK autotuning for S5000 shapes`
- `43d3afb` `perf(musa): cover dynamic TopK prefill shapes`
- `f04905e` `fix: repair enflame platform maps`

## End-to-end performance

Fixed contract: Qwen3.6-35B-A3B BF16, TP=2, 1024 input tokens, 1024 output tokens, concurrency 64, 256 requests, full graph. All reported runs completed 256/256 requests successfully. Profiler-instrumented throughput is excluded.

| Configuration | Output tok/s | Median TPOT | Median TTFT | Change vs stock |
|---|---:|---:|---:|---:|
| Vendor image stock plugin | 675.86 | 89.22 ms | 5067.49 ms | baseline |
| GDN w8; MoE resolver intentionally missed | 731.13 | 82.72 ms | 4927.49 ms | +8.18% output tok/s |
| GDN w8 + S5000 MoE schedule | 1195.44 | 49.19 ms | 4316.61 ms | +76.88% output tok/s |
| + device-resident decode MRoPE positions | 1208.13 | 48.30 ms | - | +78.76% output tok/s |

The committed path therefore improved output throughput from `675.86` to `1208.13 tok/s` (`+78.76%`) and reduced median TPOT from `89.22` to `48.30 ms` (`-45.86%`) in the stepped comparison.

The current best observed run is `1226.21 output tok/s` with median TPOT `47.72 ms`, or `+81.43%` over stock. This is a single best-observed run and is not presented as a three-round stable result.

Additional same-card A/B evidence:

- GDN w8: `680.21 -> 746.32 output tok/s` (`+9.72%`), median TPOT `88.56 -> 81.91 ms` (`-7.50%`).
- MRoPE device positions, two-run mean: `1084.64 -> 1110.88 output tok/s` (`+2.42%`). In the stepped run above it contributed `1195.44 -> 1208.13 tok/s` (`+1.06%`).
- TopK `w1/s1`: first admitted 64-request TTFT improved by `27.88%`; one full-run throughput comparison was `-1.13%`, so this PR claims cold-start/prefill scheduling benefit, not steady-state throughput gain, for TopK.

The MoE schedule is the dominant gain. In the paired system trace it saved `29.35 ms` cumulatively across 40 layers per decode step and explained `95.35%` of the measured `30.79 ms/step` reduction.

## Validation

- combined PR branch targeted suite in the MUSA/SGLang environment: `21 passed`;
- Python `compileall` and `git diff --check` passed;
- packed GDN output/state correctness matched the reference implementation;
- GDN graph replay for B=1/8/32/64: w8 vs w1 speedup `1.049x / 1.218x / 1.778x / 2.053x`, with no low-batch regression;
- MRoPE B=1/8/32/64 eager and MUSA Graph results matched exactly;
- covered TopK decode, graph and dynamic prefill cases matched the original output;
- end-to-end benchmark completed 256/256 requests without non-empty errors.

## Controls and compatibility

- `SGLANG_FL_MUSA_GDN_PACKED_DECODE_NUM_WARPS=off` disables the S5000 GDN default. The legacy `SGLANG_MUSA_GDN_PACKED_DECODE_NUM_WARPS` override remains supported.
- `SGLANG_MUSA_MOE_DECODE_SCHEDULE=off` disables the MoE schedule.
- `SGLANG_MUSA_DECODE_MROPE_DEVICE_POSITIONS=off` disables device-resident decode MRoPE positions.
- `SGLANG_MUSA_TOPK_SCHEDULE=off` disables the TopK schedule.

This PR intentionally excludes msys/mcu profiling endpoints and artifacts, eventfd completion experiments, deferred D2H prototypes, fused future-token resolver experiments, and rejected fused/persistent MoE candidates.
