### PR TITLE
[MUSA]: bypass torch_musa isin op and fix vl accuracy

### DIFF
--- a/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
@@ -15,11 +15,16 @@
 from __future__ import annotations
 
 import logging
+import os
 from functools import wraps
 
 logger = logging.getLogger(__name__)
 
 _patches_applied = False
+
+_MUSA_FP32_TP_ALLREDUCE = os.environ.get(
+    "SGLANG_MUSA_FP32_TP_ALLREDUCE", "0"
+).lower() in ("1", "true")
 
 
 def _patch_pp_send_recv_order() -> None:
@@ -104,6 +109,140 @@ def _patch_pp_launch_batch_add_sync() -> None:
     SchedulerPPMixin._pp_launch_batch = pp_launch_batch_with_forward_stream_sync
     logger.info("MUSA PP launch forward_stream sync patch applied")
 
+
+def _patch_multimodal_mask() -> None:
+    try:
+        from sglang.srt.managers import mm_utils
+    except Exception as e:
+        logger.warning("MUSA multimodal mask patch skipped: %s", e)
+        return
+
+    import torch
+
+    def _get_multimodal_mask_loop(
+        input_ids: torch.Tensor, placeholder_tensor: torch.Tensor
+    ) -> torch.Tensor:
+        mask = torch.zeros_like(input_ids, dtype=torch.bool)
+        for token in placeholder_tensor:
+            mask |= input_ids == token
+        return mask.unsqueeze(-1)
+
+    mm_utils._get_multimodal_mask = _get_multimodal_mask_loop
+    logger.info("MUSA multimodal mask patch applied")
+
+
+def _patch_communication_op_fp32_all_reduce() -> None:
+    """Patch communication_op.py TP all-reduce functions to use FP32 accumulation.
+
+    Wraps tensor_model_parallel_all_reduce, attention_tensor_model_parallel_all_reduce,
+    and moe_tensor_model_parallel_all_reduce to convert BF16 inputs to FP32 before
+    all-reduce and convert back to BF16 after.
+
+    Also patches imported references in all consuming modules.
+    """
+    try:
+        import sglang.srt.distributed as dist_pkg
+        import sglang.srt.distributed.communication_op as comm_op
+        import sglang.srt.layers.communicator as communicator
+    except Exception as e:
+        logger.warning("MUSA FP32 communication_op patch skipped: %s", e)
+        return
+
+    import torch
+
+    def _tp_all_reduce_fp32(group, input_: torch.Tensor) -> torch.Tensor:
+        if input_.dtype == torch.bfloat16:
+            reduced = group.all_reduce(input_.float())
+            return reduced.to(dtype=input_.dtype)
+        return group.all_reduce(input_)
+
+    def tensor_model_parallel_all_reduce_fp32(input_: torch.Tensor) -> torch.Tensor:
+        from sglang.srt.distributed.parallel_state import get_tp_group
+
+        return _tp_all_reduce_fp32(get_tp_group(), input_)
+
+    def attention_tensor_model_parallel_all_reduce_fp32(
+        input_: torch.Tensor,
+    ) -> torch.Tensor:
+        from sglang.srt.distributed.parallel_state import get_attn_tp_group
+
+        return _tp_all_reduce_fp32(get_attn_tp_group(), input_)
+
+    def moe_tensor_model_parallel_all_reduce_fp32(
+        input_: torch.Tensor,
+    ) -> torch.Tensor:
+        from sglang.srt.distributed.parallel_state import get_moe_tp_group
+
+        return _tp_all_reduce_fp32(get_moe_tp_group(), input_)
+
+    # Patch source module, the re-exported references in the package __init__, and
+    # the names already bound by eager importers.
+    for mod in (comm_op, dist_pkg, communicator):
+        mod.tensor_model_parallel_all_reduce = tensor_model_parallel_all_reduce_fp32
+        mod.attention_tensor_model_parallel_all_reduce = (
+            attention_tensor_model_parallel_all_reduce_fp32
+        )
+        mod.moe_tensor_model_parallel_all_reduce = (
+            moe_tensor_model_parallel_all_reduce_fp32
+        )
+
+    _modules_to_patch = [
+        "sglang.srt.lora.layers",
+        "sglang.srt.lora.triton_ops.fused_moe_lora_kernel",
+    ]
+    for mod_name in _modules_to_patch:
+        try:
+            mod = __import__(mod_name, fromlist=[""])
+        except ImportError:
+            continue
+        if hasattr(mod, "tensor_model_parallel_all_reduce"):
+            mod.tensor_model_parallel_all_reduce = tensor_model_parallel_all_reduce_fp32
+
+    logger.info("MUSA FP32 communication_op all-reduce patch applied")
+
+
+def _patch_parallel_state_fp32_reduce_scatter() -> None:
+    """Patch GroupCoordinator.reduce_scatter_tensor to use FP32 accumulation.
+
+    Converts BF16 inputs to FP32 before reduce-scatter and converts back to BF16 after.
+    """
+    try:
+        from sglang.srt.distributed.parallel_state import GroupCoordinator
+    except Exception as e:
+        logger.warning("MUSA FP32 parallel_state patch skipped: %s", e)
+        return
+
+    import torch
+
+    orig_reduce_scatter_tensor = GroupCoordinator.reduce_scatter_tensor
+
+    @wraps(orig_reduce_scatter_tensor)
+    def reduce_scatter_tensor_fp32(self, output: torch.Tensor, input: torch.Tensor):
+        if input.dtype == torch.bfloat16:
+            fp32_output = torch.empty_like(output, dtype=torch.float32)
+            self._reduce_scatter_tensor(fp32_output, input.float())
+            output.copy_(fp32_output.to(dtype=output.dtype))
+            return
+        orig_reduce_scatter_tensor(self, output, input)
+
+    GroupCoordinator.reduce_scatter_tensor = reduce_scatter_tensor_fp32
+    logger.info("MUSA FP32 parallel_state reduce_scatter patch applied")
+
+
+def _patch_fp32_tp_all_reduce() -> None:
+    """Apply all FP32 TP all-reduce patches when SGLANG_MUSA_FP32_TP_ALLREDUCE=1."""
+    if not _MUSA_FP32_TP_ALLREDUCE:
+        logger.info(
+            "MUSA FP32 TP all-reduce: disabled "
+            "(set SGLANG_MUSA_FP32_TP_ALLREDUCE=1 to enable)"
+        )
+        return
+
+    _patch_communication_op_fp32_all_reduce()
+    _patch_parallel_state_fp32_reduce_scatter()
+    logger.info("MUSA FP32 TP all-reduce patches applied")
+
+
 def apply_musa_patches() -> None:
     global _patches_applied
     if _patches_applied:
@@ -111,6 +250,8 @@ def apply_musa_patches() -> None:
 
     _patch_pp_send_recv_order()
     _patch_pp_launch_batch_add_sync()
+    _patch_multimodal_mask()
+    _patch_fp32_tp_all_reduce()
     _patches_applied = True
     logger.info("All MUSA PP patches applied successfully")
 


### PR DESCRIPTION
## Summary

- The `isin` ATen op in `torch_musa` has a bug and returns incorrect results; the real fix belongs in torch_musa. sglang's `mm_utils._get_multimodal_mask` relies on `isin` to locate image/video placeholder tokens, so the faulty op yields a wrong mask and multimodal embeddings get scattered into the wrong positions. This PR works around it on the plugin side and can be dropped once torch_musa is fixed.

- Under multi-card TP, BF16 accumulation error in all-reduce / reduce-scatter is amplified on VL models and degrades output quality, so an opt-in FP32 communication path is provided.

Both changes live in the MUSA vendor patch module and do not affect other vendors.

## Changes

- Add `_patch_multimodal_mask()`: temporarily bypasses `torch_musa`'s `isin` by comparing `input_ids == token` per placeholder token and OR-reducing the results, semantically equivalent to `torch.isin`. A workaround, not a root-cause fix.
- Add `_patch_fp32_tp_all_reduce()`, gated by `SGLANG_MUSA_FP32_TP_ALLREDUCE=1` (off by default): the three TP all-reduce entry points and `GroupCoordinator.reduce_scatter_tensor` cast BF16 inputs to FP32 for the collective and back afterwards. Re-exported references and eagerly-importing modules are rebound too, so no stale reference escapes the patch.
- Both patches are wired into `apply_musa_patches()`, following the existing skip-on-import-failure style and staying idempotent.

## Test
- Tested on MTT S5000.
- Ran all examples under examples — all passing.