### PR TITLE
fix(examples): validate full prime sequence in multinode tests

### DIFF
--- a/examples/qwen3_6_27b_multinode.py
+++ b/examples/qwen3_6_27b_multinode.py
@@ -72,6 +72,7 @@ import base64
 import concurrent.futures
 import json
 import os
+import re
 import signal
 import socket
 import subprocess
@@ -342,8 +343,18 @@ def run_tests(
     print("\n=== Test 2: Longer Generation ===")
     r = chat_request(port, "List the first 5 prime numbers, separated by commas.", 64, timeout=request_timeout)
     print(f"  Q: First 5 primes  A: {r}")
-    t.check("Contains '2'", "2", r)
-    t.check("Contains '7'", "7", r)
+    expected_pattern = (
+        r"(?<!\d)2\s*,\s*3\s*,\s*5\s*,\s*7\s*,\s*11(?!\d)"
+    )
+
+    t.total += 1
+    if re.search(expected_pattern, r):
+        print("  PASS: First 5 primes = 2, 3, 5, 7, 11")
+        t.passed += 1
+    else:
+        print("  FAIL: Expected first 5 primes = 2, 3, 5, 7, 11")
+        print(f"        Actual response: {r}")
+        t.failed += 1
 
     # Test 3: Concurrent Text x4
     print("\n=== Test 3: Concurrent Text x4 ===")

--- a/examples/qwen3_6_35b_a3b_multinode.py
+++ b/examples/qwen3_6_35b_a3b_multinode.py
@@ -69,6 +69,7 @@ import base64
 import concurrent.futures
 import json
 import os
+import re
 import signal
 import socket
 import subprocess
@@ -340,8 +341,18 @@ def run_tests(
     print("\n=== Test 2: Longer Generation ===")
     r = chat_request(port, "List the first 5 prime numbers, separated by commas.", 64, timeout=request_timeout)
     print(f"  Q: First 5 primes  A: {r}")
-    t.check("Contains '2'", "2", r)
-    t.check("Contains '7'", "7", r)
+    expected_pattern = (
+        r"(?<!\d)2\s*,\s*3\s*,\s*5\s*,\s*7\s*,\s*11(?!\d)"
+    )
+
+    t.total += 1
+    if re.search(expected_pattern, r):
+        print("  PASS: First 5 primes = 2, 3, 5, 7, 11")
+        t.passed += 1
+    else:
+        print("  FAIL: Expected first 5 primes = 2, 3, 5, 7, 11")
+        print(f"        Actual response: {r}")
+        t.failed += 1
 
     # Test 3: Concurrent Text x4
     print("\n=== Test 3: Concurrent Text x4 ===")


### PR DESCRIPTION
## Summary

Improve Test 2 validation in the Qwen3.6 multinode examples.

The previous checks only verified that the response contained `2` and `7`,
so incorrect responses such as `2, 2, 3, 5, 7` could pass.

This change validates the complete ordered sequence:

`2, 3, 5, 7, 11`

The test prompt and generation parameters remain unchanged.

## Test

- `python3 -m py_compile examples/qwen3_6_27b_multinode.py`
- `python3 -m py_compile examples/qwen3_6_35b_a3b_multinode.py`