### PR TITLE
[MUSA]: add reference fused_moe to support mthreads empty

### DIFF
--- a/sglang_fl/dispatch/backends/reference/impl/fused_moe.py
+++ b/sglang_fl/dispatch/backends/reference/impl/fused_moe.py
@@ -12,21 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SGLang-FL Dispatch Configuration for MUSA (Moore Threads) platform
-prefer: flagos
+# Reference implementation for fused MoE
 
-# FlagGems tag:    v5.3.0
-# FlagGems commit: 98fae44cdf2898f39c7f24f080d7c88b83d7c593
-flagos_blacklist:
-  - count_nonzero
-  - cumsum
-  - mm
-  - unique
-  - _unique2
-  - unique_dim
-  - unique_consecutive
-  - index
-  - to_copy
-  - copy_
-  - mul
-  - sort
+from __future__ import annotations
+
+import torch
+
+
+def fused_moe_torch(obj, layer: torch.nn.Module, dispatch_output):
+    """Fused MoE via sglang's native per-expert PyTorch loop."""
+    return obj.forward_cpu(layer, dispatch_output)

--- a/sglang_fl/dispatch/backends/reference/reference.py
+++ b/sglang_fl/dispatch/backends/reference/reference.py
@@ -127,3 +127,8 @@ class ReferenceBackend(Backend):
         from .impl.mrotary_embedding import mrotary_embedding_torch
 
         return mrotary_embedding_torch(obj, positions, query, key)
+
+    def fused_moe(self, obj, layer, dispatch_output):
+        from .impl.fused_moe import fused_moe_torch
+
+        return fused_moe_torch(obj, layer, dispatch_output)

--- a/sglang_fl/dispatch/backends/reference/register_ops.py
+++ b/sglang_fl/dispatch/backends/reference/register_ops.py
@@ -88,6 +88,14 @@ def register_builtins(registry) -> None:
             vendor=None,
             priority=BackendPriority.REFERENCE,
         ),
+        OpImpl(
+            op_name="fused_moe",
+            impl_id="reference.torch",
+            kind=BackendImplKind.REFERENCE,
+            fn=_bind_is_available(backend.fused_moe, is_avail),
+            vendor=None,
+            priority=BackendPriority.REFERENCE,
+        ),
     ]
 
     registry.register_many(impls)


### PR DESCRIPTION
## Summary

Supporting empty mode requires isolating the mthreads vendor op implementations, so inference runs entirely on the FlagOS and reference op layers instead. The reference layer currently has no `fused_moe` implementation, which leaves a hole in that path for MoE models.

This PR fills that hole by adding a reference `fused_moe` that delegates to sglang's native per-expert PyTorch loop.

## Changes

- Add `impl/fused_moe.py` with `fused_moe_torch()`, which forwards to sglang's `forward_cpu` per-expert loop, and expose it as `ReferenceBackend.fused_moe`.
- Register the `fused_moe` reference impl (`reference.torch`, `BackendPriority.REFERENCE`) in the reference `register_ops`, so it is only selected when no vendor or FlagGems impl is available.
- Add `index`, `to_copy`, `copy_`, `mul` and `sort` to `flagos_blacklist` in `config/musa.yaml`, falling those ops back to native ATen on MUSA.

## Test

- Tested on MTT S5000.
- Ran all examples under examples — all passing.