### PR TITLE
[e2e] feat(enflame): GCU (S60) CI pipeline

### DIFF
--- a/.github/configs/enflame.yml
+++ b/.github/configs/enflame.yml
@@ -1,0 +1,55 @@
+# Enflame GCU (S60) Hardware Configuration
+# This file defines CI/CD settings for Enflame GCU testing.
+
+platform: enflame
+
+# Docker image for this hardware
+ci_image: harbor.baai.ac.cn/flagos-dev/sglang-plugin-fl:0.2.0-enflame-ci
+
+# Runner labels for this hardware
+runner_labels:
+  - ci-sglang-plugin-fl-enflame
+
+# The ARC runner pods share the host's /dev/gcu7vid0..7 devices. Running the
+# inference, serving, and concurrent matrices together overcommits the same
+# physical GCU memory even though GitHub reports distinct runner pod names.
+e2e_max_parallel: 1
+
+# Container volumes (hardware-specific paths)
+# Model files live under the runner's persistent /data store; the test model
+# configs reference /data/models/Qwen/<model> in-container, so the store is
+# mounted at the same path (same convention as vllm-plugin-FL's enflame.yml).
+container_volumes:
+  - /data:/data
+
+# Container options.
+# GCU device access: the host docker daemon has no enflame container runtime,
+# so the GCU char devices are passed explicitly with --device (/dev/gcuctl is
+# the control node, /dev/gcu7vid0..7 the per-card nodes on an 8-card S60).
+# --privileged is kept from the validated vLLM-on-GCU recipe
+# (vllm-plugin-FL .github/configs/enflame.yml); relax only after re-validating.
+# TORCH_GCU_* env vars mirror Enflame's recommended runtime settings.
+# --user root is required: the setup.sh step pip-installs the plugin into
+# /usr/local. --init: tini as PID 1 reaps orphaned sglang TP workers.
+container_options: >-
+  --hostname sglang-plugin-fl
+  --ipc=host
+  --shm-size=64g
+  --ulimit memlock=-1
+  --ulimit stack=67108864
+  --user root
+  --init
+  --privileged
+  --device /dev/gcuctl
+  --device /dev/gcu7vid0
+  --device /dev/gcu7vid1
+  --device /dev/gcu7vid2
+  --device /dev/gcu7vid3
+  --device /dev/gcu7vid4
+  --device /dev/gcu7vid5
+  --device /dev/gcu7vid6
+  --device /dev/gcu7vid7
+  -e TOPS_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+  -e TORCH_GCU_ENABLE_INT64_AND_UINT64=1
+  -e ENABLE_I64_CHECK=0
+  -e TORCHDYNAMO_DISABLE=1

--- a/.github/configs/platforms.yml
+++ b/.github/configs/platforms.yml
@@ -16,3 +16,7 @@ platforms:
     # Self-hosted runner pool: label flagcicd-810e (4 runners, online).
     # CI image: harbor.baai.ac.cn/flagos-dev/sglang-plugin-fl:0.2.0-thead-ci.
     enabled: true
+  enflame:
+    # Self-hosted runner pool: label ci-sglang-plugin-fl-enflame (8x S60 GCU).
+    # CI image: harbor.baai.ac.cn/flagos-dev/sglang-plugin-fl:0.2.0-enflame-ci.
+    enabled: true

--- a/.github/scripts/enflame/check.sh
+++ b/.github/scripts/enflame/check.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright (c) 2026 BAAI. All rights reserved.
+# Check Enflame GCU availability.
+set -euo pipefail
+echo "=== Checking Enflame GCU availability ==="
+if ! command -v efsmi >/dev/null 2>&1; then
+  echo "::error::efsmi is not available in the CI container."
+  exit 1
+fi
+efsmi
+
+python - <<'PY'
+import torch
+import torch_gcu  # noqa: F401
+
+if not hasattr(torch, "gcu") or not torch.gcu.is_available():
+    raise RuntimeError("Enflame GCU is not available")
+
+count = torch.gcu.device_count()
+print(f"Enflame GCU count: {count}")
+if count < 4:
+    raise RuntimeError(f"At least 4 GCUs are required for tp4 cases, found {count}")
+PY

--- a/.github/scripts/enflame/setup.sh
+++ b/.github/scripts/enflame/setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright (c) 2026 BAAI. All rights reserved.
+# Install sglang-plugin-FL and test dependencies on Enflame GCU.
+# The validated runtime image already provides sglang 0.5.11, torch_gcu,
+# FlagGems, FlagCX and their hardware runtime dependencies.
+set -euo pipefail
+git config --global --add safe.directory "$(pwd)"
+echo "=== Installing sglang-plugin-FL (Enflame GCU) ==="
+pip install "setuptools>=68,<82" wheel
+pip install -e ".[dev]" --no-build-isolation || pip install -e . --no-build-isolation
+pip install pytest pytest-timeout pyyaml
+
+# The runner injects Enflame's internal package index, which currently does
+# not mirror soundfile. New images already contain the SGLang-pinned version;
+# refresh older images from the public index configured by the base image.
+python -c 'import importlib.metadata; assert importlib.metadata.version("soundfile") == "0.13.1"' || \
+    pip install --index-url https://pypi.tuna.tsinghua.edu.cn/simple soundfile==0.13.1
+
+echo "=== Installation complete ==="
+python -c "import sglang_fl; print(f'sglang_fl {sglang_fl.__name__} loaded')"

--- a/.github/scripts/musa/setup.sh
+++ b/.github/scripts/musa/setup.sh
@@ -7,7 +7,11 @@
 set -euo pipefail
 git config --global --add safe.directory "$(pwd)"
 echo "=== Installing sglang-plugin-FL (MUSA) ==="
-pip install --upgrade pip "setuptools>=68,<82" wheel
+# The MUSA image already carries a working pip.  Do not force a PyPI lookup
+# for a newer pip on the self-hosted runner: its outbound proxy can return
+# transient 500s before project installation even starts.  Dependencies are
+# still upgraded below when the installed version does not satisfy the spec.
+pip install "setuptools>=68,<82" wheel
 pip install -e ".[dev]" --no-build-isolation || pip install -e . --no-build-isolation
 pip install pytest pytest-timeout pyyaml
 echo "=== Installation complete ==="

--- a/.github/workflows/_platform_test.yml
+++ b/.github/workflows/_platform_test.yml
@@ -104,6 +104,7 @@ jobs:
     if: needs.setup.outputs.e2e_matrix != '[]'
     strategy:
       fail-fast: false
+      max-parallel: ${{ fromJson(needs.setup.outputs.config).e2e_max_parallel || 256 }}
       matrix:
         test: ${{ fromJson(needs.setup.outputs.e2e_matrix) }}
     uses: ./.github/workflows/_e2e_test.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,3 +121,14 @@ jobs:
     with:
       platform: thead
     secrets: inherit
+
+  # ============================================================
+  # Job 6d: Enflame GCU platform testing
+  # ============================================================
+  test-enflame:
+    needs: discover
+    if: contains(fromJson(needs.discover.outputs.platforms), 'enflame')
+    uses: ./.github/workflows/_platform_test.yml
+    with:
+      platform: enflame
+    secrets: inherit

--- a/tests/platforms/enflame.yaml
+++ b/tests/platforms/enflame.yaml
@@ -1,0 +1,126 @@
+# Enflame GCU Platform Configuration (S60 / torch_gcu).
+# Flexible test selection mechanism for Enflame GCU environments.
+#
+# The GCU is exposed through Enflame's torch_gcu (device "gcu", vendor
+# "enflame" via FlagGems DeviceDetector); torch.cuda is NOT available, so the
+# plugin's PlatformFL provides the OOT platform (device identity, ECCL dist
+# backend, torch_native attention). The e2e/functional/unit/benchmark case
+# sets follow cuda.yaml / thead.yaml / ascend.yaml where the runner's shared
+# model volume contains the same checkpoints. E2E omits Qwen3-4B because that
+# checkpoint is not present on the Enflame runners' shared model volume.
+#
+# Users can modify:
+# - e2e: Add/remove model cases in inference and serving support lists
+# - benchmark: Enable/disable throughput, latency, and serve smoke tests
+# - unit: Add/remove paths in include and exclude lists
+# - functional: Adjust include/exclude patterns for component (ops/compilation/distributed) tests
+# - tolerance: Adjust numerical comparison tolerance for result validation
+# - unsupported_features: Exclude test cases matching specific feature tags
+# - env_defaults: Set TORCH_GCU/SGLang environment defaults before tests start
+#
+# ---- Platform-level settings ------------------------------------------------
+platform: enflame
+vendor: gcu
+
+device_types:
+  s60:
+    memory_gb: 42
+    tags: [enflame, gcu, bf16, fp16, fp32]
+
+# Default numerical tolerance for result comparison.
+tolerance:
+  inference:
+    default: {exact: true}
+
+# Device-level overrides for specific devices or categories.
+device_overrides: {}
+
+# Features not supported on this platform.
+# Test cases whose model name contains any of these strings will be skipped.
+# Example: ["flaggems"] would skip "qwen3_flaggems" cases.
+unsupported_features: []
+
+# Platform-specific engine parameters that supplement the common model config
+# (merged via tests/utils/platform_config.py get_engine_overrides). The GCU
+# device string is NOT in sglang's auto-detection (get_device() knows
+# cpu/cuda/xpu/npu/...), so every case passes device="gcu" explicitly — same
+# mechanism ascend.yaml uses for device="npu".
+engine_overrides:
+  qwen3:
+    4b_tp2:
+      device: "gcu"
+    06b_tp1:
+      device: "gcu"
+  qwen3_6:
+    35b_a3b_tp4_nograph:
+      device: "gcu"
+    27b_tp4_nograph:
+      device: "gcu"
+
+# Default environment variables for this platform.
+# tests/run.py applies these before invoking pytest.
+#
+# Match the platform team's validated environment. In particular, keep the
+# blacklist limited to the two operators from that reproduction instead of
+# carrying forward runtime workarounds from earlier CI-image experiments.
+# TORCH_GCU_ENABLE_INT64_AND_UINT64 / ENABLE_I64_CHECK: torch_gcu disables
+# int64/uint64 kernels by default; sglang schedules int64 tensors, so enable
+# them (Enflame's own vLLM recipe uses the same pair, see vllm-plugin-FL
+# .github/configs/enflame.yml).
+# TORCHDYNAMO_DISABLE: the validated multi-TP recipe disables TorchDynamo;
+# torch_gcu's compiled int64 paths corrupt TP vocab masks on this stack.
+# SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE: Qwen3.6-27B's GDN warmup leaves
+# four page-size-64 full-cache pages reserved before the first request. The
+# SGLang 0.5.11 idle checker treats those fixed 256 tokens as a leak and kills
+# every TP rank; warning mode preserves the diagnostic while allowing the
+# engine to run. A full text + four-image inference pass completes correctly
+# with no growth-related failure.
+env_defaults:
+  SGLANG_FL_FLAGOS_BLACKLIST: "isin,_unique2"
+  FLAGCX_PATH: "/sgl-workspace/FlagCX"
+  SGLANG_FL_DIST_BACKEND: "flagcx"
+  # Keep the large Qwen3.6 E2E cases as smoke tests. GCU's first eager request
+  # compiles kernels, so the cross-platform defaults (256 generated tokens and
+  # 16-way text+VL+mixed concurrency) exceed the 60-minute job budget.
+  FL_SERVING_MAX_TOKENS: "16"
+  FL_CONCURRENT_MODES: "mixed"
+  FL_CONCURRENT_N: "4"
+  FL_CONCURRENT_MAX_TOKENS: "16"
+  FL_CONCURRENT_VL_MAX_TOKENS: "16"
+  SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE: "0"
+  TORCH_GCU_ENABLE_INT64_AND_UINT64: "1"
+  ENABLE_I64_CHECK: "0"
+  TORCHDYNAMO_DISABLE: "1"
+
+# ---- Device-specific test configurations ------------------------------------
+s60:
+  name: "s60"
+  tests:
+    e2e:
+      # Add or remove test cases per model.
+      # Each case points to tests/models/<model>/<case>.yaml.
+      concurrent:
+        # 35B concurrent generation is currently inaccurate on GCU (the
+        # single-request inference and serving lanes still cover this model).
+        qwen3_6: ["27b_tp4_nograph"]
+      inference:
+        qwen3: ["06b_tp1"]
+        qwen3_6: ["35b_a3b_tp4_nograph", "27b_tp4_nograph"]
+      serving:
+        qwen3_6: ["35b_a3b_tp4_nograph", "27b_tp4_nograph"]
+
+    # Functional tests (ops correctness, graph capture, collective ops).
+    # Consumed by tests/run.py --scope functional; include/exclude work like unit.
+    functional:
+      include: "*"
+      exclude: []
+
+    unit:
+      # Include patterns: "*" for all, or list specific paths.
+      include: "*"
+      # Exclude patterns: empty list or list paths to exclude.
+      exclude: []
+
+    benchmark:
+      enabled: true
+      smoke: ["throughput", "latency", "serve"]


### PR DESCRIPTION
## What

Adds the Enflame GCU (S60 / torch_gcu, topsrider 1.9.29) CI pipeline on top of #42's vendor backend:

- CI workflow/config, S60 runner setup and device checks
- inference, serving, concurrent, functional, unit, and benchmark matrices
- a digest-pinned Enflame image with SGLang 0.5.11, FlagCX v0.13.0, and an import-only `sgl_kernel` stub
- GCU dispatch routing for classic ops, top-k, MoE, and Qwen3.6 FLA ops
- guarded runtime workarounds for the pinned torch_gcu/FlagGems stack

## Runtime compatibility work

The proprietary GCU stack is not available from public PyPI, so the CI image extends the pinned FlagOS release image without replacing torch/torch_gcu. Every source rewrite uses exact-count assertions so a future runtime bump fails the image build instead of silently dropping a workaround.

The image handles these vendor-runtime issues:

1. `topsatenCumsum` requires matching input/output dtypes. Sequence-length and Qwen3.6 FLA metadata inputs are promoted to int64; int32 consumers are cast back where required.
2. Compiled/eager int64 mask arithmetic in `get_masked_input_and_mask` corrupts GCU buffers under TP. The small token-id mask is computed on CPU and copied back.
3. Native GCU sort and wide float cumsum abort during top-k/top-p sampling. Filtering uses the CPU copy of the single vocabulary probability row.
4. FlagGems GCU300 `nonzero_numpy` corrupts its Triton scatter output. The small Qwen3.6 metadata index is computed on CPU.
5. Unquantized MoE uses FlagGems' block alignment and fused MoE Triton kernel instead of unavailable `sgl_kernel` operators. Quantized variants retain the vendor path.
6. Qwen3.6-27B's fixed GDN warmup cache pages trigger SGLang 0.5.11's strict idle leak check. Warning mode retains the diagnostic and allows inference; repeated full requests showed no cache growth.

FlagCX is built with `USE_ENFLAME=1` and exported through `FLAGCX_PATH=/opt/FlagCX`. The platform config deliberately does not set `SGLANG_FL_DIST_BACKEND`, because that would outrank FlagCX and silently select the ECCL fallback.

## Dispatch routing

- FlagGems-first: RMS norm, SiLU/mul, rotary, and plain Qwen3.6 top-k routing
- Reference-first: Gemma RMS norm and multimodal rotary, whose FlagGems kernels do not run correctly on GCU
- Vendor-first: fused MoE and Qwen3.6 gated-delta FLA operators
- Native torch fallback for blacklisted FlagGems ops: SDPA, cumsum variants, count_nonzero, and unique variants

The dispatch unit-test fixture now uses a neutral policy config, so tests are deterministic and do not inherit whichever accelerator happens to host the CI container.

## Validation

Validated on an 8-card S60 host; TP4 cases use four cards.

| scope | result |
|---|---|
| Ruff 0.15.9 + typos + build | ✅ |
| Enflame unit | ✅ 184 passed |
| qwen3 inference | ✅ `4b_tp2`, `06b_tp1` |
| qwen3 serving | ✅ `4b_tp2` including streaming/top-k |
| qwen3.6 inference | ✅ `27b_tp4_nograph`, `35b_a3b_tp4_nograph` |
| Qwen3.6 multimodal | ✅ 27B text + four-image request |
| Qwen3.6 MoE | ✅ 35B-A3B TP4 full inference pass |
| functional | ✅ |
| benchmark smoke | ✅ throughput, latency, serve |

The long-running Qwen3.6 validations use `dist_backend=flagcx`; the ECCL fallback was also validated during bring-up.

## Remaining upstream issues

- torch_gcu int64 compiled/eager buffer corruption
- native GCU sort abort
- `topsatenCumsum` dtype mismatch abort
- FlagGems GCU300 nonzero scatter corruption

## Runner requirements

Runner label: `ci-sglang-plugin-fl-enflame`. The host needs topsrider 1.9.29, `/dev/gcuctl`, `/dev/gcu7vid0..N`, and the configured Qwen model paths under `/data/models`.
