### PR TITLE
ci: add /rerun-failed-ci slash command for PR authors

### DIFF
--- a/.github/workflows/rerun-failed-ci.yml
+++ b/.github/workflows/rerun-failed-ci.yml
@@ -1,0 +1,84 @@
+# Re-run failed CI jobs when a PR author comments /rerun-failed-ci.
+# PR authors without write access cannot use GitHub's native "re-run failed
+# jobs" button; this workflow runs in the base repo context (issue_comment)
+# and performs the re-run on their behalf after verifying authorship.
+name: Rerun Failed CI
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: rerun-failed-ci-${{ github.event.comment.id }}
+  cancel-in-progress: false
+
+jobs:
+  rerun-failed-jobs:
+    if: |
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/rerun-failed-ci'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check commenter authorization
+        id: auth
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          PR_URL: ${{ github.event.issue.pull_request.url }}
+        run: |
+          set -euo pipefail
+          # Allow PR authors and anyone with write access to the repo.
+          pr_author=$(gh api "$PR_URL" --jq '.user.login')
+          if [ "$COMMENTER" = "$pr_author" ]; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if gh api "repos/${{ github.repository }}/collaborators/$COMMENTER/permission" --jq '.permission' | grep -qE 'admin|write|maintain'; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::error::$COMMENTER is neither the PR author nor a collaborator with write access."
+          exit 1
+
+      - name: React to comment (ack)
+        if: always() && steps.auth.outputs.authorized == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api -X POST repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions -f content='rocket'
+
+      - name: Re-run failed jobs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.issue.pull_request.url }}
+        run: |
+          set -euo pipefail
+          head_sha=$(gh api "$PR_URL" --jq '.head.sha')
+          # Latest run for the PR head SHA; any workflow, most recent first.
+          run_id=$(gh run list --repo "${{ github.repository }}" \
+            --commit "$head_sha" --status failure --limit 1 --json databaseId \
+            --jq '.[0].databaseId')
+          if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+            echo "::error::No failed workflow run found for head SHA $head_sha."
+            exit 1
+          fi
+          echo "Re-running failed jobs of run $run_id"
+          gh run rerun "$run_id" --repo "${{ github.repository }}" --failed
+
+      - name: Report result on PR
+        if: always() && steps.auth.outcome != 'cancelled'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            body="🚀 Re-triggered failed CI jobs for this PR (requested by @${{ github.event.comment.user.login }})."
+          else
+            body="❌ Failed to re-run CI for this PR (requested by @${{ github.event.comment.user.login }}). See [workflow log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          fi
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$body"


### PR DESCRIPTION
## Motivation

PR authors from forks without write access cannot click GitHub's native "Re-run failed jobs" button (GitHub only offers that to users with write access, or to maintainers when the setting is enabled).

## What this does

Adds `.github/workflows/rerun-failed-ci.yml`, an `issue_comment`-triggered workflow:

- Triggered when someone comments exactly `/rerun-failed-ci` on a PR.
- Authorization: allows the **PR author** or any collaborator with write/maintain/admin permission (checked via the collaborators API). Others get an error and a comment.
- Finds the latest failed workflow run at the PR head SHA and runs `gh run rerun <id> --failed` using the repo `actions: write` token.
- Reacts 🚀 to the command comment and posts a success/failure summary comment back on the PR.

## Notes

- `issue_comment` workflows always run in the base repo's default-branch context, so the token has the needed write permission even for fork PRs — this is why the authorization check is essential.
- Uses only `actions: write`, `pull-requests: write`, `contents: read`.