### PR TITLE
feat(cambricon): add MLU vendor patches for sglang 0.5.18

### DIFF
--- a/sglang_fl/__init__.py
+++ b/sglang_fl/__init__.py
@@ -436,6 +436,33 @@ def _setup_flaggems(config: dict = None):
 # ─── Vendor-specific sglang patches ───────────────────────────────────────────
 
 
+def _apply_early_vendor_shims() -> None:
+    """Import vendor/<vendor_name>/shim.py to apply earliest-per-process facade
+    repairs (e.g. cambricon torch_mlu CUDA-migration gaps). Unlike patch.py,
+    the shim is reachable from activate_platform() — before sglang imports the
+    quantization → fp8_kernel → deep_gemm_wrapper → pynccl_allocator and
+    dsa/utils → breakable_cuda_graph chains — so the facade is in place before
+    those modules first access torch.cuda.memory / torch.Stream. The shim module
+    applies itself on import (module-body side effect); ImportError means the
+    vendor has no shim and is skipped.
+    """
+    import importlib
+
+    from sglang_fl.utils import get_device_info
+
+    info = get_device_info()
+    if info is None:
+        logger.warning("early vendor shim skipped: DeviceDetector unavailable")
+        return
+
+    module = f"sglang_fl.dispatch.backends.vendor.{info.vendor_name}.shim"
+    try:
+        importlib.import_module(module)
+        logger.info("early vendor shim loaded: %s", module)
+    except ImportError:
+        logger.debug("early vendor shim absent: %s", module)
+
+
 def _apply_vendor_patches() -> None:
     """Import vendor/<vendor_name>/patch.py to apply vendor monkey-patches
     on sglang internals. Called last in load_plugin(), after every sglang_fl
@@ -709,6 +736,12 @@ def activate_platform() -> str | None:
 
     Returns the fully-qualified class path of PlatformFL if hardware is detected,
     or None if FlagGems DeviceDetector fails (no supported hardware).
+
+    For cambricon, applies the early vendor shim here — the earliest per-process
+    hook (main + every spawned child) — before sglang imports the quantization →
+    fp8_kernel → deep_gemm_wrapper → pynccl_allocator and dsa/utils →
+    breakable_cuda_graph chains, so the torch_mlu CUDA-migration facade is
+    repaired before those modules first access torch.cuda.memory / torch.Stream.
     """
     from sglang_fl.utils import get_device_info
 
@@ -721,6 +754,8 @@ def activate_platform() -> str | None:
         info.vendor_name,
         info.device_type,
     )
+    if info.vendor_name == "cambricon":
+        _apply_early_vendor_shims()
     return "sglang_fl.platform:PlatformFL"
 
 
@@ -762,6 +797,9 @@ def load_plugin():
 
     # 1. FlagGems ATen ops
     _setup_flaggems(config)
+
+    # 1.5. Early vendor shim — safety net for the activate_platform hook above
+    _apply_early_vendor_shims()
 
     # 2. Initialize dispatch system (OpManager + backends + policy)
     _init_dispatch(config)

--- a/sglang_fl/dispatch/backends/vendor/cambricon/__init__.py
+++ b/sglang_fl/dispatch/backends/vendor/cambricon/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sglang_fl/dispatch/backends/vendor/cambricon/patch.py
+++ b/sglang_fl/dispatch/backends/vendor/cambricon/patch.py
@@ -1,0 +1,121 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cambricon MLU vendor patches for sglang — entrypoint.
+
+Auto-imported by ``sglang_fl._apply_vendor_patches()`` when FlagGems'
+DeviceDetector reports cambricon hardware. The module body runs at import,
+so each patch applies once per process at plugin load time.
+
+torch_mlu's CUDA-migration layer masquerades as CUDA but is stale relative to
+real CUDA, so code that assumes CUDA semantics trips on MLU. These patches fix
+the torch_mlu facade (not the sglang wheel) so unmodified sglang code works:
+
+1. ``_MLUDeviceProperties.is_integrated`` — sglang's
+   ``get_available_gpu_memory()`` reads ``props.is_integrated`` off
+   ``torch.cuda.get_device_properties()``; torch_mlu's properties class lacks
+   it. MLU590 has dedicated HBM, so False is correct. Class-level injection is
+   required: many sglang modules bind ``get_available_gpu_memory`` via
+   ``from sglang.srt.utils import ...`` before the plugin loads, so a getattr
+   guard on the sglang function would not reach every call site.
+2. ``torch.cuda.get_device_capability`` — MLU590 is bf16-capable but torch_mlu
+   reports ``(5,0)`` through the CUDA alias; sglang arch gates read that as
+   sm50 legacy, force a float16 downgrade and raise "SGLang only supports sm75
+   and above". Presenting an sm80-class capability keeps dtype untouched and
+   clears the gate (stays below (10,0) so sm100-only paths stay off).
+3. SDPA ``enable_gqa`` — sglang's torch_native backend calls
+   ``F.scaled_dot_product_attention(..., enable_gqa=True)`` for GQA models.
+   torch_mlu's fused SDPA kernels reject the gathered KV shape and torch falls
+   back to the mlu MATH backend, whose signature predates the ``enable_gqa``
+   kwarg (TypeError); it also cannot expand KV heads itself. Expand the KV
+   heads here (as torch's own GQA math path does) and drop ``enable_gqa``.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_patches_applied = False
+
+_CAPABILITY = (8, 0)  # see module docstring concern 2
+
+
+def _patch_device_properties_is_integrated() -> None:
+    from torch_mlu._MLUC import _MLUDeviceProperties
+
+    # pybind class attribute assignment is allowed (verified on neuware4.7.2 /
+    # torch_mlu 1.33.1+torch2.11.0). Instances resolve is_integrated through
+    # the class dict.
+    _MLUDeviceProperties.is_integrated = False
+
+
+def _patch_cuda_capability_facade() -> None:
+    import torch
+
+    fn = getattr(torch.cuda, "get_device_capability", None)
+    if fn is None or not fn.__module__.startswith("torch_mlu"):
+        logger.warning("cambricon capability facade skipped: %r", fn)
+        return
+
+    def _mlu_device_capability(device=None):
+        return _CAPABILITY
+
+    torch.cuda.get_device_capability = _mlu_device_capability
+
+
+def _patch_sdpa_gqa_fallback() -> None:
+    import torch
+    import torch.nn.functional as _F
+
+    _orig = _F.scaled_dot_product_attention
+
+    def _wrapped(query, key, value, *args, **kwargs):
+        if kwargs.get("enable_gqa") and getattr(query, "device", None) is not None:
+            if query.device.type == "mlu" and query.dim() >= 3:
+                nq = query.shape[-3]
+                nkv = key.shape[-3]
+                if nkv != nq:
+                    rep = nq // nkv
+                    key = key.repeat_interleave(rep, -3)
+                    value = value.repeat_interleave(rep, -3)
+                kwargs["enable_gqa"] = False
+        return _orig(query, key, value, *args, **kwargs)
+
+    _F.scaled_dot_product_attention = _wrapped
+    # torch_native_backend binds the function at module import
+    # (``from torch.nn.functional import scaled_dot_product_attention``), which
+    # happens at model-runner init — after load_plugins() in every process, so
+    # the binding picks up the wrapper. Rebinding here additionally covers a
+    # process where the backend was imported before this patch ran.
+    try:
+        import sglang.srt.layers.attention.torch_native_backend as _tnb
+
+        if getattr(_tnb, "scaled_dot_product_attention", None) is not _wrapped:
+            _tnb.scaled_dot_product_attention = _wrapped
+    except Exception as e:  # pragma: no cover - best-effort rebind
+        logger.info("cambricon sdpa rebind skipped: %r", e)
+
+
+def apply_cambricon_patches() -> None:
+    global _patches_applied
+    if _patches_applied:
+        return
+    _patches_applied = True
+    _patch_device_properties_is_integrated()
+    _patch_cuda_capability_facade()
+    _patch_sdpa_gqa_fallback()
+    logger.info("cambricon patches applied")
+
+
+apply_cambricon_patches()

--- a/sglang_fl/dispatch/backends/vendor/cambricon/patch.py
+++ b/sglang_fl/dispatch/backends/vendor/cambricon/patch.py
@@ -74,6 +74,22 @@ def _patch_cuda_capability_facade() -> None:
     torch.cuda.get_device_capability = _mlu_device_capability
 
 
+def _gqa_repeat_kv_heads(x, rep):
+    # Repeat each KV head rep times consecutively ([..., nkv, S, D] ->
+    # [..., nkv*rep, S, D]). Only view ops plus one contiguous copy, so it
+    # never depends on input shape. repeat_interleave would route through
+    # flag_gems, whose per-shape triton kernel recompiles on every decode step
+    # as the KV length grows (measured on neuware4.4.3: 0.04 tok/s).
+    if rep == 1:
+        return x
+    head = x.dim() - 3
+    return (
+        x.unsqueeze(head + 1)
+        .expand(*x.shape[: head + 1], rep, *x.shape[head + 1 :])
+        .reshape(*x.shape[:head], x.shape[head] * rep, *x.shape[head + 1 :])
+    )
+
+
 def _patch_sdpa_gqa_fallback() -> None:
     import torch
     import torch.nn.functional as _F
@@ -87,8 +103,8 @@ def _patch_sdpa_gqa_fallback() -> None:
                 nkv = key.shape[-3]
                 if nkv != nq:
                     rep = nq // nkv
-                    key = key.repeat_interleave(rep, -3)
-                    value = value.repeat_interleave(rep, -3)
+                    key = _gqa_repeat_kv_heads(key, rep)
+                    value = _gqa_repeat_kv_heads(value, rep)
                 kwargs["enable_gqa"] = False
         return _orig(query, key, value, *args, **kwargs)
 

--- a/sglang_fl/dispatch/backends/vendor/cambricon/shim.py
+++ b/sglang_fl/dispatch/backends/vendor/cambricon/shim.py
@@ -1,0 +1,112 @@
+"""Cambricon early torch_mlu facade shim (activation-time).
+
+neuware4.4.3's torch_mlu exposes only a partial CUDA-migration facade, so
+sglang's stock code paths that assume a full CUDA alias break before any of
+the cambricon vendor patches can run:
+
+  * `pynccl_allocator` imports the torch.cuda.memory mempool symbols
+    `_cuda_beginAllocateCurrentThreadToPool` / `_cuda_endAllocateToPool`,
+    which torch_mlu does not provide → ImportError during sglang import.
+  * `breakable_cuda_graph` does `isinstance(x, torch.Stream)`, but torch_mlu
+    exposes `torch.Stream` as a wrapper (not a class) → annotation-style
+    checks fail.
+
+This module applies itself on import (module-body side effect), so importing
+it from `activate_platform` — the earliest per-process hook, which fires in
+the main process and every spawned scheduler/detokenizer child before the
+quantization → fp8_kernel → deep_gemm_wrapper → pynccl_allocator and
+dsa/utils → breakable_cuda_graph chains — puts the facade in place before
+those symbols are first accessed. All injections are guarded (no-op when the
+symbol already exists), so this is safe on neuware4.7.2 and later.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_shim_applied = False
+
+
+def _mlu_pool_noop(*args, **kwargs):
+    return None
+
+
+def _inject_mempool_symbols() -> None:
+    import torch
+    import torch_mlu.mlu.memory as mlu_memory
+
+    for module in {getattr(torch.cuda, "memory", None), mlu_memory}:
+        if module is None:
+            continue
+        for name in ("_cuda_beginAllocateCurrentThreadToPool", "_cuda_endAllocateToPool"):
+            if not hasattr(module, name):
+                setattr(module, name, _mlu_pool_noop)
+
+
+def _rewrite_cuda_device(value):
+    import torch
+
+    if isinstance(value, str):
+        if "cuda" in value:
+            return value.replace("cuda", "mlu")
+        if "CUDA" in value:
+            return value.replace("CUDA", "MLU")
+    elif isinstance(value, torch.device) and value.type == "cuda":
+        index = f":{value.index}" if value.index is not None else ""
+        return torch.device(f"mlu{index}")
+    return value
+
+
+def _restore_stream_class() -> None:
+    import torch
+
+    stream = torch.Stream
+    if isinstance(stream, type):
+        return
+    orig = getattr(stream, "__wrapped__", None)
+    if not isinstance(orig, type):
+        logger.warning("cambricon shim: torch.Stream not restorable (%r)", stream)
+        return
+
+    class _MetaStream(type):
+        def __instancecheck__(cls, instance):
+            type_obj = type(instance)
+            return (
+                type_obj is cls
+                or type_obj is orig
+                or type_obj is torch.mlu.Stream
+                or issubclass(type_obj, cls)
+            )
+
+        def __subclasscheck__(cls, subclass):
+            if subclass is cls or subclass is orig:
+                return True
+            return type.__subclasscheck__(cls, subclass)
+
+    class MLUStream(orig, metaclass=_MetaStream):
+        base_class = orig
+
+        def __new__(cls, *args, **kwargs):
+            if args:
+                args = tuple(_rewrite_cuda_device(a) for a in args)
+            for key in ("device", "_device"):
+                if key in kwargs:
+                    kwargs[key] = _rewrite_cuda_device(kwargs[key])
+            if not args and "device" not in kwargs and "_device" not in kwargs:
+                kwargs["device"] = torch.device("mlu")
+            return super().__new__(cls, *args, **kwargs)
+
+    torch.Stream = MLUStream
+
+
+def apply_early_shim() -> None:
+    global _shim_applied
+    if _shim_applied:
+        return
+    _shim_applied = True
+    _inject_mempool_symbols()
+    _restore_stream_class()
+    logger.info("cambricon early shim applied")
+
+
+apply_early_shim()

--- a/sglang_fl/dispatch/config/cambricon.yaml
+++ b/sglang_fl/dispatch/config/cambricon.yaml
@@ -1,0 +1,24 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SGLang-FL Dispatch Configuration for Cambricon (MLU) platform.
+
+prefer: flagos
+
+# cumsum: flag_gems' cumsum miscompiles on MLU (empirically wrong results);
+# route it to the vendor/stock backend. Excluded via the plugin config path
+# because the vendor patch module loads at load_plugin step 5, after the
+# flag_gems blacklist is already read (step 1).
+flagos_blacklist:
+  - cumsum

--- a/sglang_fl/dispatch/config/cambricon.yaml
+++ b/sglang_fl/dispatch/config/cambricon.yaml
@@ -16,9 +16,271 @@
 
 prefer: flagos
 
+# Exclusion semantics: flag_gems.enable(unused=...) drops a registered impl
+# iff the impl fn __name__ is listed (GeneralOpRegistrar.config_filter keeps
+# a config item iff item[1].__name__ is absent). A family is therefore only
+# excluded by naming every registered member (out-of-place, in-place _,
+# *_scalar, *_tensor, *_out ...), and impl fns with a leading underscore are
+# invisible to any family-prefix sweep. The entries below are the empirically
+# converged set for neuware4.4.3 (flag_gems 5.3.5, runtime triton
+# 3.2.0+mlu1.7.2); each is a real registered impl fn in that version. All are
+# correct and healthy via the vendor/stock path once excluded.
+#
 # cumsum: flag_gems' cumsum miscompiles on MLU (empirically wrong results);
-# route it to the vendor/stock backend. Excluded via the plugin config path
-# because the vendor patch module loads at load_plugin step 5, after the
-# flag_gems blacklist is already read (step 1).
+# routed to vendor/stock. Excluded via the plugin config path because the
+# vendor patch module loads at load_plugin step 5, after the flag_gems
+# blacklist is already read (step 1).
+#
+# true_divide, pow_scalar, pow_tensor_scalar, sub, silu, clamp, to_copy,
+# copy_, reciprocal, scalar_tensor, fill_scalar_, mul, cos, sin, add:
+# neuware4.4.3's flag_gems pointwise kernels (cambricon _cambricon and
+# generic alike) launch with task_type="block" or fail to compile under
+# triton 3.2.0+mlu1.7.2 (KeyError / 'aten::copy_' KeyError / scalar-store
+# CompilationError / fill-store CompilationError / mul-store).
+#
+# The extended families below were converged under real decode traffic on
+# neuware4.4.3: pointwise in-place/tensor siblings of the above, compare
+# (gt/ge/lt/le/eq/ne), bitwise, repr/logging triggers (isfinite/isinf/isnan/
+# isneginf/isposinf/logical), index/masked writes (index_put/index_select/
+# masked_fill/masked_scatter), and sampling-chain compounds (sort/gather/
+# multinomial/softmax/topk/argmax/log/where/searchsorted). Their kernels
+# share the same compile-failure class under that triton, or would produce
+# wrong results at decode scale.
+#
+# The two underscore entries are the serve-scale crash fix: flag_gems'
+# index_put kernel sizes its grid to batch*vocab and exceeds the MLU hardware
+# grid limit 65535 at decode scale (Qwen3-4B, vocab 152064) ->
+# "OutOfResources: grid size, Required: ..." from _index_put_impl_ on the
+# sampler's top-k masked setitem (sglang sampler.py:583). Probe-scale passes
+# (4x16) were a false green (grid stayed under the limit); _index_put_impl_
+# and _unsafe_masked_index_put_accumulate lead with underscores, so a
+# family-prefix sweep never matched them. Routed to vendor/stock.
+#
+# neuware4.7.2's runtime triton 3.4.0+mlu accepts task_type and compiles
+# these kernels, so there the exclusions only keep the ops on the vendor path
+# that already yields correct output -- no behavioral difference (verified by
+# the 4.7.2 sampling smoke, 3/3).
 flagos_blacklist:
   - cumsum
+  - true_divide
+  - pow_scalar
+  - pow_tensor_scalar
+  - sub
+  - silu
+  - clamp
+  - to_copy
+  - copy_
+  - reciprocal
+  - scalar_tensor
+  - fill_scalar_
+  - mul
+  - cos
+  - sin
+  - add
+  - _index_put_impl_
+  - _unsafe_masked_index_put_accumulate
+  - add_
+  - add_rms_norm
+  - addbmm
+  - addbmm_
+  - addcdiv
+  - addcdiv_
+  - addcdiv_out
+  - addcmul
+  - addcmul_
+  - addcmul_out
+  - addmm
+  - addmm_
+  - addmm_dtype
+  - addmm_dtype_out
+  - addmm_out
+  - addmv
+  - addmv_
+  - addmv_out
+  - addr
+  - addr_
+  - argmax
+  - bitwise_and_scalar
+  - bitwise_and_scalar_
+  - bitwise_and_scalar_tensor
+  - bitwise_and_tensor
+  - bitwise_and_tensor_
+  - bitwise_left_shift
+  - bitwise_left_shift_
+  - bitwise_not
+  - bitwise_not_
+  - bitwise_or_scalar
+  - bitwise_or_scalar_
+  - bitwise_or_scalar_tensor
+  - bitwise_or_tensor
+  - bitwise_or_tensor_
+  - bitwise_right_shift
+  - bitwise_right_shift_
+  - bitwise_xor_scalar
+  - bitwise_xor_scalar_
+  - bitwise_xor_scalar_tensor
+  - bitwise_xor_tensor
+  - bitwise_xor_tensor_
+  - clamp_
+  - clamp_max
+  - clamp_max_
+  - clamp_min
+  - clamp_min_
+  - clamp_tensor
+  - clamp_tensor_
+  - copysign
+  - copysign_
+  - copysign_out
+  - cos_
+  - cosh
+  - cosh_
+  - cosh_out
+  - cumsum_
+  - cumsum_out
+  - div_mode
+  - div_mode_
+  - divide
+  - eq
+  - eq_
+  - eq_scalar
+  - eq_scalar_
+  - equal
+  - fill_scalar
+  - fill_scalar_out
+  - gather
+  - gather_backward
+  - gather_block_quantized
+  - ge
+  - ge_scalar
+  - gelu
+  - gelu_
+  - gelu_backward
+  - geometric
+  - geometric_
+  - gt
+  - gt_scalar
+  - gt_scalar_
+  - gt_tensor_
+  - index_put
+  - index_put_
+  - index_select
+  - index_select_backward
+  - isfinite
+  - isinf
+  - isnan
+  - isneginf
+  - isneginf_out
+  - isposinf
+  - le
+  - le_
+  - le_scalar
+  - le_scalar_
+  - leaky_relu
+  - leaky_relu_
+  - leaky_relu_backward
+  - leaky_relu_out
+  - lerp_scalar
+  - lerp_scalar_
+  - lerp_tensor
+  - lerp_tensor_
+  - less_
+  - less_equal
+  - less_equal_
+  - less_equal_scalar
+  - less_equal_scalar_
+  - less_scalar_
+  - log
+  - log_
+  - log_normal_
+  - log_sigmoid
+  - log_sigmoid_backward
+  - log_sigmoid_backward_out
+  - log_sigmoid_forward
+  - log_softmax
+  - log_softmax_backward
+  - log_softmax_backward_out
+  - log_softmax_out
+  - log10
+  - log10_
+  - log10_out
+  - log1p
+  - log1p_
+  - log1p_out
+  - log2
+  - log2_
+  - logaddexp
+  - logaddexp_out
+  - logaddexp2
+  - logaddexp2_out
+  - logcumsumexp
+  - logcumsumexp_out
+  - logical_and
+  - logical_and_
+  - logical_not
+  - logical_not_
+  - logical_or
+  - logical_or_
+  - logical_xor
+  - logical_xor_
+  - logit
+  - logit_
+  - logit_backward
+  - logit_out
+  - logspace
+  - logsumexp
+  - lt
+  - lt_
+  - lt_scalar
+  - lt_scalar_
+  - masked_fill
+  - masked_fill_
+  - masked_scatter
+  - masked_scatter_
+  - masked_scatter_backward
+  - mul_
+  - multinomial
+  - multiply
+  - multiply_
+  - ne
+  - ne_
+  - ne_scalar
+  - ne_scalar_
+  - neg
+  - neg_
+  - negative
+  - negative_
+  - new_full
+  - new_ones
+  - nextafter
+  - nextafter_
+  - pow_tensor_scalar_
+  - pow_tensor_tensor
+  - pow_tensor_tensor_
+  - reciprocal_
+  - searchsorted
+  - searchsorted_out
+  - searchsorted_scalar
+  - searchsorted_scalar_out
+  - silu_
+  - silu_backward
+  - sin_
+  - sinc
+  - sinc_
+  - sinh
+  - sinh_
+  - softmax
+  - softmax_backward
+  - softmax_backward_out
+  - softmax_out
+  - sort
+  - sort_stable
+  - sub_
+  - subtract
+  - subtract_
+  - topk
+  - true_divide_
+  - true_divide_out
+  - true_divide_tensor
+  - true_divide_tensor_
+  - where_self
+  - where_self_out

--- a/sglang_fl/dispatch/config/utils.py
+++ b/sglang_fl/dispatch/config/utils.py
@@ -62,6 +62,8 @@ def get_platform_name() -> str:
             return "musa"
         if hasattr(torch, "gcu") and torch.gcu.is_available():
             return "gcu"
+        if hasattr(torch, "mlu") and torch.mlu.is_available():
+            return "cambricon"
         if hasattr(torch, "corex") and torch.cuda.is_available():
             return "iluvatar"
         if torch.cuda.is_available():


### PR DESCRIPTION
Fixes #109

## What

New `sglang_fl/dispatch/backends/vendor/cambricon/` vendor patch for sglang
0.5.18 on Cambricon MLU (neuware4.7.2), plus the config plumbing to route it.

torch_mlu's CUDA-migration layer masquerades as CUDA but is incomplete, so
unmodified sglang code crashes on MLU. The patch fixes the torch_mlu facade at
class level (survives `from ... import` binding and spawn workers):
- `_MLUDeviceProperties.is_integrated = False` — `get_available_gpu_memory()`
  reads it off device properties; torch_mlu lacks it.
- `get_device_capability` → `(8,0)` — torch_mlu reports sm50, which trips
  sglang's arch gates into an fp16 downgrade + "sm75 only" error.
- SDPA `enable_gqa` expansion fallback — torch_mlu's math backend predates the
  kwarg (TypeError) and cannot expand KV heads itself.

Also adds cambricon to `get_platform_name()` and a `config/cambricon.yaml`
blacklisting flag_gems `cumsum` (miscompiles on MLU; the vendor patch module
loads after the flag_gems blacklist is read, so the exclusion must live in the
config, not the patch).

## Verified

E2E on neuware4.7.2 (triton path — cambricon has no flagtree): serve reaches
Uvicorn, /get_server_info answers `sampling_backend=pytorch`, 3x
chat/completions HTTP 200 with real completions.

This PR was written in part with the assistance of generative AI.
