### PR TITLE
feat(mthreads): make sglang 0.5.18 serve on the torch_musa runtime

### DIFF
--- a/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
@@ -243,11 +243,70 @@ def _patch_fp32_tp_all_reduce() -> None:
     logger.info("MUSA FP32 TP all-reduce patches applied")
 
 
+def _patch_device_support() -> None:
+    """Teach sglang.srt.utils.common to recognise torch_musa (no torchada)."""
+    try:
+        from sglang_fl.dispatch.backends.vendor.mthreads.patches import (
+            patch_device_support,
+        )
+
+        patch_device_support()
+    except Exception as e:
+        logger.warning("MUSA device-support patch skipped: %s", e)
+
+
+def _patch_flash_attn_interface() -> None:
+    """Let MUSA-gated flash_attn_interface import sites survive when the
+    package is absent (vision.py / musa fa3 backend)."""
+    try:
+        from sglang_fl.dispatch.backends.vendor.mthreads.patches import (
+            patch_flash_attn_interface,
+        )
+
+        patch_flash_attn_interface()
+    except Exception as e:
+        logger.warning("MUSA flash_attn_interface guard skipped: %s", e)
+
+
+def _patch_attention_backend_default() -> None:
+    """Default mthreads attention backend to torch_native, not fa3.
+
+    PlatformFL's shared ``_ATTN_BACKEND_MAP`` routes mthreads to ``fa3``, but
+    the flagos mthreads runtime ships no Moore Threads flash-attention-v3
+    interface wheel, so the fa3 backend calls the stub's
+    ``flash_attn_varlen_func`` and raises NotImplementedError on the first
+    forward.  Cambricon (also PrivateUse1, no flash-attn wheel) is absent from
+    the map and falls through to torch_native (PyTorch SDPA) — mthreads should
+    behave the same.  The shared map stays untouched so an explicit
+    ``--attention-backend fa3`` (a deliberate user choice) still resolves to
+    fa3; only the value filled when the user did not pick a backend is
+    rewritten.
+    """
+    try:
+        from sglang_fl.platform import PlatformFL
+
+        orig = PlatformFL.get_default_attention_backend
+
+        @wraps(orig)
+        def get_default_attention_backend_musa(self):
+            backend = orig(self)
+            if getattr(self, "_vendor_name", None) == "mthreads" and backend == "fa3":
+                return "torch_native"
+            return backend
+
+        PlatformFL.get_default_attention_backend = get_default_attention_backend_musa
+    except Exception as e:
+        logger.warning("MUSA attention-backend default patch skipped: %s", e)
+
+
 def apply_musa_patches() -> None:
     global _patches_applied
     if _patches_applied:
         return
 
+    _patch_flash_attn_interface()
+    _patch_attention_backend_default()
+    _patch_device_support()
     _patch_pp_send_recv_order()
     _patch_pp_launch_batch_add_sync()
     _patch_multimodal_mask()

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patches/__init__.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patches/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MUSA patches on sglang internals — package entrypoint."""
+
+from sglang_fl.dispatch.backends.vendor.mthreads.patches.device_support import (
+    patch_device_support,
+)
+from sglang_fl.dispatch.backends.vendor.mthreads.patches.flash_attn_interface import (
+    patch_flash_attn_interface,
+)
+
+__all__ = ["patch_device_support", "patch_flash_attn_interface"]

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patches/device_support.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patches/device_support.py
@@ -1,0 +1,183 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MUSA device-support monkey-patches on ``sglang.srt.utils.common``.
+
+Upstream sglang detects MUSA by importing ``torchada``, a CUDA-alias layer
+that routes ``torch.cuda.*`` onto MUSA.  The flagos mthreads runtime ships
+``torch_musa`` instead (``torch.musa``, PrivateUse1, no CUDA alias), so
+upstream ``is_musa()`` returns False and the capability helpers it gates on
+(implemented through ``torch.cuda.*``) assert.  These patches:
+
+  1. ``common.is_musa`` — recognise ``torch_musa`` in addition to ``torchada``.
+  2. ``common.get_device_sm`` / ``get_device_capability`` /
+     ``get_device_core_count`` / ``get_device_count`` — when MUSA is active
+     but ``torch.cuda`` is not a live alias, route to ``torch.musa`` instead.
+
+Already-imported copies of these names (``sglang.srt.utils`` re-exports and
+module-level ``from ... import`` bindings) are rebound so the patch holds
+regardless of import order.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import sys
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+_patched = False
+_originals: dict[str, object] = {}
+_replacements: dict[str, object] = {}
+
+
+@functools.lru_cache(maxsize=1)
+def _is_musa() -> bool:
+    """True when a MUSA torch stack is importable and live.
+
+    Accepts both upstream's ``torchada`` CUDA-alias layer and the flagos
+    runtime's ``torch_musa`` (PrivateUse1) plugin.
+    """
+    for pkg in ("torchada", "torch_musa"):
+        try:
+            __import__(pkg)
+        except ImportError:
+            continue
+        if getattr(torch.version, "musa", None) is not None:
+            return True
+        if hasattr(torch, "musa"):
+            try:
+                if torch.musa.is_available():
+                    return True
+            except Exception:
+                # is_available() can raise in forked children (MUSA cannot
+                # re-initialise); only the version attribute remains usable.
+                pass
+    return False
+
+
+def _use_musa_direct() -> bool:
+    """MUSA active but no CUDA alias — helpers must call torch.musa directly."""
+    return _is_musa() and not torch.cuda.is_available()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Patched helper implementations (MUSA-direct branches)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _get_device_sm() -> int:
+    if _use_musa_direct():
+        major, minor = torch.musa.get_device_capability()
+        return major * 10 + minor
+    return _originals["get_device_sm"]()  # type: ignore[no-any-return]
+
+
+def _get_device_capability(device_id: int = 0):
+    if _use_musa_direct():
+        return torch.musa.get_device_capability(device_id)
+    return _originals["get_device_capability"](device_id)
+
+
+def _get_device_core_count(device_id: int = 0) -> int:
+    if _use_musa_direct():
+        return torch.musa.get_device_properties(device_id).multi_processor_count
+    return _originals["get_device_core_count"](device_id)
+
+
+@functools.lru_cache(maxsize=1)
+def _get_device_count() -> int:
+    if _use_musa_direct():
+        return torch.musa.device_count()
+    return _originals["get_device_count"]()  # type: ignore[no-any-return]
+
+
+def _init_cublas():
+    """Warmup matmul that initialises the vendor BLAS library.
+
+    Upstream hardcodes ``device="cuda"`` (common.init_cublas), written against
+    the torchada CUDA-alias MUSA stack.  The flagos runtime ships torch_musa
+    (PrivateUse1, no CUDA alias), so route the warmup to ``torch.musa`` when
+    CUDA is not live.  On real CUDA this replacement is never selected.
+    """
+    if _use_musa_direct():
+        dtype = torch.float16
+        a = torch.ones((16, 16), dtype=dtype, device="musa")
+        b = torch.ones((16, 16), dtype=dtype, device="musa")
+        return a @ b
+    return _originals["init_cublas"]()  # type: ignore[no-any-return]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Patch application
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _rebind_importers() -> None:
+    """Point already-imported copies of patched names at the replacements."""
+    for mod in tuple(sys.modules.values()):
+        for name, orig in _originals.items():
+            if getattr(mod, name, None) is orig:
+                setattr(mod, name, _replacements[name])
+
+
+def patch_device_support() -> None:
+    """Apply MUSA device-support patches.  Idempotent, no-op off-MUSA."""
+    global _patched
+    if _patched:
+        return
+    _patched = True
+
+    if not _is_musa():
+        logger.info("MUSA torch stack not detected; device-support patch skipped")
+        return
+
+    from sglang.srt.utils import common
+
+    # is_musa supersedes upstream's torchada-only body; no original fallback.
+    _originals["is_musa"] = common.is_musa
+    _replacements["is_musa"] = _is_musa
+    common.is_musa = _is_musa
+
+    # Results cached under the old (torchada-only) detection are stale now.
+    for name in ("get_device", "get_device_count", "get_device_sm"):
+        fn = getattr(common, name, None)
+        if fn is not None and hasattr(fn, "cache_clear"):
+            fn.cache_clear()
+
+    # Capability/count helpers: route to torch.musa only when torch.cuda is
+    # not an alias (torch_musa runtime); upstream behaviour is kept otherwise.
+    for name, replacement in (
+        ("get_device_sm", _get_device_sm),
+        ("get_device_capability", _get_device_capability),
+        ("get_device_core_count", _get_device_core_count),
+        ("get_device_count", _get_device_count),
+        ("init_cublas", _init_cublas),
+    ):
+        orig = getattr(common, name, None)
+        if orig is None:
+            logger.warning("common.%s not found; skipping its MUSA routing", name)
+            continue
+        _originals[name] = orig
+        _replacements[name] = replacement
+        setattr(common, name, replacement)
+
+    _rebind_importers()
+    logger.info(
+        "MUSA device-support patches applied "
+        "(is_musa + torch.musa capability routing)"
+    )

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patches/flash_attn_interface.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patches/flash_attn_interface.py
@@ -1,0 +1,128 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Guard the MUSA-branch ``flash_attn_interface`` import on sglang internals.
+
+Upstream sglang 0.5.18 gates two import sites on MUSA:
+
+  - ``sglang.srt.layers.attention.vision`` binds ``flash_attn_varlen_func``
+    from ``flash_attn_interface`` at module level whenever ``is_musa()`` is
+    live (vision.py:66-67), and that module is pulled in model-independently
+    (http_server -> openai -> realtime ASR -> qwen3_omni_moe).
+  - ``sglang.srt.hardware_backend.musa.attention.flashattention_backend``
+    imports ``flash_attn_varlen_func`` / ``flash_attn_with_kvcache`` /
+    ``get_scheduler_metadata`` from the package at module top (the ``fa3``
+    text attention backend for MUSA).
+
+The flagos mthreads runtime ships ``torch_musa`` but no ``flash_attn_interface``
+(Moore Threads' flash-attention v3 interface wheel), so with MUSA detection
+correct these imports raise ``ModuleNotFoundError`` before the engine starts.
+This patch injects a stub ``flash_attn_interface`` into ``sys.modules`` when
+the real package is absent, letting those modules import.  The stub's callables
+raise ``NotImplementedError`` if actually invoked, so any MUSA code path that
+needs the flash-attention v3 kernels fails loudly at the call site instead of
+producing wrong numerics.
+
+The stub is only installed when (a) the MUSA torch stack is live and (b) the
+real package cannot be imported, so upstream-style MUSA runtimes that do carry
+``flash_attn_interface`` are untouched.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+
+from sglang_fl.dispatch.backends.vendor.mthreads.patches.device_support import (
+    _is_musa,
+)
+
+logger = logging.getLogger(__name__)
+
+_patched = False
+
+_UNSUPPORTED_MSG = (
+    "flash_attn_interface.{name} is unavailable on the flagos mthreads runtime "
+    "(no Moore Threads flash-attention v3 interface wheel is installed).  A "
+    "MUSA code path that requires it was reached; this attention backend is "
+    "not supported here."
+)
+
+
+class _UnavailableCallable:
+    """Callable that raises ``NotImplementedError`` when invoked."""
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def __repr__(self) -> str:
+        return f"<unavailable flash_attn_interface.{self._name}>"
+
+    def __call__(self, *args, **kwargs):
+        raise NotImplementedError(_UNSUPPORTED_MSG.format(name=self._name))
+
+
+class _StubModule(types.ModuleType):
+    """Module whose every attribute access yields a raising callable.
+
+    ``from flash_attn_interface import <symbol>`` succeeds for any symbol;
+    the bound name fails only when actually called.
+    """
+
+    def __getattr__(self, name: str) -> _UnavailableCallable:
+        if name.startswith("__"):
+            raise AttributeError(name)
+        callable_ = _UnavailableCallable(name)
+        setattr(self, name, callable_)
+        return callable_
+
+
+def patch_flash_attn_interface() -> None:
+    """Insert the ``flash_attn_interface`` stub when MUSA needs it and it is
+    missing.  Idempotent; no-op when the real package is importable.
+    """
+    global _patched
+    if _patched:
+        return
+    _patched = True
+
+    if not _is_musa():
+        logger.info("MUSA not active; flash_attn_interface guard skipped")
+        return
+
+    try:
+        import flash_attn_interface  # noqa: F401
+    except ImportError:
+        pass
+    else:
+        logger.info(
+            "flash_attn_interface is importable; no stub needed"
+        )
+        return
+
+    if "flash_attn_interface" in sys.modules:
+        logger.info("flash_attn_interface already present in sys.modules")
+        return
+
+    stub = _StubModule("flash_attn_interface")
+    stub.__doc__ = (
+        "FlagOS mthreads stub: the real flash_attn_interface is not installed; "
+        "imports survive, calls raise NotImplementedError."
+    )
+    sys.modules["flash_attn_interface"] = stub
+    logger.info(
+        "MUSA runtime has no flash_attn_interface; installed raising stub "
+        "so sglang's flash_attn_interface import sites survive"
+    )


### PR DESCRIPTION
Fixes #111

## Problem

sglang 0.5.18's MUSA support targets upstream's torchada CUDA-alias stack,
but the flagos mthreads runtime ships the classical `torch_musa`
(PrivateUse1, no CUDA alias). Serve crashed in four successive places:
`is_musa()` didn't accept torch_musa (server_args `.split(':')` crash);
`init_cublas()` hardcodes device=cuda on a dead CUDA; the
flash_attn_interface import (vision.py / musa fa3 backend) was absent; and
the default fa3 backend needs a real MUSA flash-attention wheel the runtime
does not ship.

## Change

Four vendor fixes (mthreads patches, mirrors tsingmicro/cambricon patterns):
- `is_musa()` accepts torch_musa; device-capability/count helpers route to
  `torch.musa` when `torch.cuda` is not live.
- `init_cublas` hijacked to run a torch.musa warmup when CUDA is not
  aliased.
- `flash_attn_interface` import satisfied by a raising stub (no MUSA
  flash-attn wheel shipped).
- Default attention backend demoted fa3 → torch_native (SDPA), matching
  cambricon; the shared map keeps fa3 for an explicit user choice.

## Verified

E2E on musa5.2.0: F (flagtree) and T (triton) each serve Qwen3-4B, 3x
chat/completions HTTP 200 with real completions, sampling_backend=pytorch.

This PR was written in part with the assistance of generative AI.
