### PR TITLE
feat(hygon): make sglang 0.5.18 serve on the DTK 26.04 CUDA-alias runtime

### DIFF
--- a/sglang_fl/__init__.py
+++ b/sglang_fl/__init__.py
@@ -69,6 +69,14 @@ if not logger.handlers:
     logger.addHandler(_handler)
     logger.setLevel(logging.INFO)
 
+# Seed sys.modules with inert aiter stand-ins before load_plugin() pulls in
+# sglang's quantization chain: on HIP platforms without an aiter wheel the
+# Quark/compressed-tensors scheme modules import aiter unconditionally at
+# module level and would crash the plugin load (see _aiter_stubs).
+from sglang_fl._aiter_stubs import install_aiter_stubs_if_needed  # noqa: E402
+
+install_aiter_stubs_if_needed()
+
 
 def _is_rank0() -> bool:
     """Return True if this is the main process (rank 0) — safe to call at any stage."""

--- a/sglang_fl/_aiter_stubs.py
+++ b/sglang_fl/_aiter_stubs.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shim aiter imports on HIP platforms that ship no aiter wheel.
+
+On ROCm-based stacks (Hygon DTK, real AMD ROCm), ``torch.version.hip`` is set, so
+sglang's quantization layer treats the platform as HIP and some Quark /
+compressed-tensors scheme modules do an unconditional module-level
+``from aiter...`` import (no try/except). sglang-plugin-FL loads sglang's
+quantization package during ``load_plugin`` (dispatch hook construction), so a
+HIP box without an ``aiter`` wheel crashes the plugin import itself — well
+before any quantization scheme is actually selected.
+
+The stub layer pre-seeds ``sys.modules`` with flat stand-in modules for the full
+aiter import surface found in the sglang 0.5.18 wheel (see the frozenset
+below), so those imports resolve. The stubs are inert objects: they answer
+attribute access and calls, and never touch hardware, so a scheme that ends up
+running on them would fail loudly (not silently) at the point a real value is
+needed — no dunder probing is ever faked.
+
+Installation is gated on the environment, not the vendor: only when HIP is
+active AND no real ``aiter`` is importable are stubs installed. A genuine
+aiter wheel (real AMD) therefore keeps full functionality and the stubs simply
+never engage.
+"""
+
+import importlib.util
+import logging
+import sys
+import types
+
+logger = logging.getLogger(__name__)
+
+# The full aiter import surface of the sglang 0.5.18 wheel's quantization tree.
+# Flat coverage is required: each intermediate parent package is also seeded,
+# because a stub parent without ``__path__`` cannot drive submodule traversal.
+_AITER_STUB_MODULES = frozenset(
+    {
+        "aiter",
+        "aiter.ops",
+        "aiter.ops.shuffle",
+        "aiter.ops.triton",
+        "aiter.ops.triton.gemm",
+        "aiter.ops.triton.gemm.fused",
+        "aiter.ops.triton.gemm.fused.fused_gemm_afp4wfp4_split_cat",
+        "aiter.ops.triton.gemm_afp4wfp4",
+        "aiter.ops.triton.gemm_afp4wfp4_pre_quant_atomic",
+        "aiter.ops.triton.gemm_a8w8_blockscale",
+        "aiter.ops.triton.quant",
+        "aiter.ops.triton.batched_gemm_afp4wfp4_pre_quant",
+        "aiter.ops.triton.fused_mxfp4_quant",
+        "aiter.utility",
+        "aiter.utility.fp4_utils",
+        "aiter.tuned_gemm",
+    }
+)
+
+
+class _StubLoader:
+    def create_module(self, spec):
+        return None
+
+    def exec_module(self, module):
+        pass
+
+
+class _StubObj:
+    """Attribute-and-call surrogate; never equal to a real kernel result."""
+
+    _call_logged: set = set()
+
+    def __init__(self, path: str = "") -> None:
+        object.__setattr__(self, "_path", path)
+
+    def __call__(self, *args, **kwargs):
+        path = self._path or "<anonymous>"
+        if path not in _StubObj._call_logged:
+            _StubObj._call_logged.add(path)
+            logger.debug("stub op called: %s(...)", path)
+        return self
+
+    def __getattr__(self, name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        path = self._path or ""
+        child_path = f"{path}.{name}" if path else name
+        val = _StubObj(path=child_path)
+        object.__setattr__(self, name, val)
+        return val
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+class _StubModule(types.ModuleType):
+    def __init__(self, name):
+        super().__init__(name)
+        try:
+            from importlib.machinery import ModuleSpec
+
+            self.__spec__ = ModuleSpec(name, loader=_StubLoader())
+        except ImportError:
+            self.__spec__ = None
+
+    def __getattr__(self, name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        val = _StubObj(path=f"{self.__name__}.{name}")
+        setattr(self, name, val)
+        return val
+
+
+_installed = False
+
+
+def install_aiter_stubs_if_needed() -> bool:
+    """Install the aiter stub tree when the platform is HIP without aiter.
+
+    No-op unless ``torch.version.hip`` is set and ``aiter`` is not importable,
+    which is exactly the configuration that would crash the quantization import
+    chain. Returns True when stubs were (or already had been) installed.
+    """
+    global _installed
+    if _installed:
+        return True
+
+    torch = sys.modules.get("torch")
+    if torch is None or getattr(torch.version, "hip", None) is None:
+        return False
+
+    if importlib.util.find_spec("aiter") is not None:
+        logger.info("aiter is importable — not installing aiter import stubs")
+        return False
+
+    installed = 0
+    for name in sorted(_AITER_STUB_MODULES):
+        if name in sys.modules:
+            continue
+        sys.modules[name] = _StubModule(name)
+        installed += 1
+    logger.info("installed aiter import stubs for HIP platform (%d modules)", installed)
+
+    _installed = True
+    return True

--- a/sglang_fl/dispatch/backends/vendor/hygon/impl/attention_backend.py
+++ b/sglang_fl/dispatch/backends/vendor/hygon/impl/attention_backend.py
@@ -24,13 +24,13 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 
-from sglang.srt.compilation.piecewise_context_manager import (
-    is_in_piecewise_cuda_graph,
+from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph.context_manager import (
+    is_in_tc_piecewise_cuda_graph as is_in_piecewise_cuda_graph,
 )
 from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
-from sglang.srt.layers.attention.utils import create_flashmla_kv_indices_triton
+from sglang.kernels.ops.attention.utils import create_flashmla_kv_indices_triton
 from sglang.srt.layers.radix_attention import AttentionType
-from sglang.srt.model_executor.breakable_cuda_graph.context import (
+from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.context import (
     is_in_breakable_cuda_graph,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
@@ -309,18 +309,42 @@ class HCUAttnBackend(TritonAttnBackend):
         controlled_config_errors = []
         if not getattr(server_args, "disable_radix_cache", False):
             controlled_config_errors.append("disable_radix_cache must be True")
-        if not getattr(server_args, "disable_piecewise_cuda_graph", False):
-            controlled_config_errors.append(
-                "disable_piecewise_cuda_graph must be True"
-            )
-        if getattr(server_args, "enable_breakable_cuda_graph", False):
-            controlled_config_errors.append(
-                "enable_breakable_cuda_graph must be False"
-            )
         if getattr(server_args, "enable_deterministic_inference", False):
             controlled_config_errors.append(
                 "enable_deterministic_inference must be False"
             )
+        # sglang 0.5.18 folds the legacy graph-control booleans into the
+        # per-phase cuda_graph_config (ServerArgs._parse_cuda_graph_config),
+        # so --disable-piecewise-cuda-graph / --enable-breakable-cuda-graph no
+        # longer set the old server_args attributes this check used to read.
+        # Judge the resolved per-phase backends instead. The strict backend
+        # supports eager everywhere plus a plain decode graph; tc_piecewise /
+        # breakable decode and any graph prefill (tc_piecewise / breakable /
+        # full) are unsupported and fail fast. Fall back to the legacy
+        # attribute checks on sglang wheels predating the per-phase config.
+        cuda_graph_config = getattr(server_args, "cuda_graph_config", None)
+        if cuda_graph_config is not None:
+            decode_backend = cuda_graph_config.decode.backend
+            if decode_backend not in ("full", "disabled"):
+                controlled_config_errors.append(
+                    f"decode cuda_graph backend must be 'full' or 'disabled' "
+                    f"(got '{decode_backend}')"
+                )
+            prefill_backend = cuda_graph_config.prefill.backend
+            if prefill_backend != "disabled":
+                controlled_config_errors.append(
+                    f"prefill cuda_graph backend must be 'disabled' "
+                    f"(got '{prefill_backend}')"
+                )
+        else:
+            if not getattr(server_args, "disable_piecewise_cuda_graph", False):
+                controlled_config_errors.append(
+                    "disable_piecewise_cuda_graph must be True"
+                )
+            if getattr(server_args, "enable_breakable_cuda_graph", False):
+                controlled_config_errors.append(
+                    "enable_breakable_cuda_graph must be False"
+                )
         if controlled_config_errors:
             raise RuntimeError(
                 "Strict HCU attention requires the controlled Qwen server "
@@ -945,7 +969,9 @@ class HCUAttnBackend(TritonAttnBackend):
         forward_batch,
         q: torch.Tensor,
     ) -> Optional[str]:
-        token_to_kv_pool = getattr(forward_batch, "token_to_kv_pool", None)
+        # 0.5.18 dropped the pool handle from ForwardBatch; it lives on the
+        # runner and TritonAttnBackend.__init__ captures it as self.token_to_kv_pool.
+        token_to_kv_pool = getattr(self, "token_to_kv_pool", None)
         if token_to_kv_pool is None:
             return "the token-to-KV pool is unavailable"
         try:
@@ -1043,7 +1069,7 @@ class HCUAttnBackend(TritonAttnBackend):
         k_view = None
         v_view = None
         if uses_paged_kv:
-            k_cache, v_cache = forward_batch.token_to_kv_pool.get_kv_buffer(
+            k_cache, v_cache = self.token_to_kv_pool.get_kv_buffer(
                 layer.layer_id
             )
             k_view = k_cache.view(
@@ -1060,7 +1086,7 @@ class HCUAttnBackend(TritonAttnBackend):
             )
 
         if save_kv_cache:
-            forward_batch.token_to_kv_pool.set_kv_buffer(
+            self.token_to_kv_pool.set_kv_buffer(
                 layer,
                 forward_batch.out_cache_loc,
                 k,
@@ -1223,14 +1249,14 @@ class HCUAttnBackend(TritonAttnBackend):
             )
 
         if save_kv_cache:
-            forward_batch.token_to_kv_pool.set_kv_buffer(
+            self.token_to_kv_pool.set_kv_buffer(
                 layer,
                 forward_batch.out_cache_loc,
                 k,
                 v,
             )
 
-        k_cache, v_cache = forward_batch.token_to_kv_pool.get_kv_buffer(
+        k_cache, v_cache = self.token_to_kv_pool.get_kv_buffer(
             layer.layer_id
         )
         if (

--- a/sglang_fl/dispatch/backends/vendor/hygon/impl/fla_packed_decode.py
+++ b/sglang_fl/dispatch/backends/vendor/hygon/impl/fla_packed_decode.py
@@ -4,7 +4,9 @@
 import torch
 import triton
 
-from sglang.srt.layers.attention.fla.fused_recurrent import fused_recurrent_gated_delta_rule_packed_decode_kernel
+from sglang.kernels.ops.attention.fla.fused_recurrent import (
+    fused_recurrent_gated_delta_rule_packed_decode_kernel,
+)
 
 
 def fused_recurrent_gated_delta_rule_packed_decode_hcu(


### PR DESCRIPTION
Fixes #112

## Problem

sglang 0.5.18 reworked the attention chain's config and KV-pool APIs. The
hygon plugin's pre-0.5.18 structure read the wrong objects, so serve startup
failed in three successive places on the DTK 26.04 runtime (CUDA-alias,
`PlatformFL: vendor=hygon, device=cuda`): the attention APIs moved import
paths inside the 0.5.18 wheel; `cuda_graph_config` became per-phase while the
controlled serve gate still read the old single object; and `ForwardBatch` no
longer carries `token_to_kv_pool` (the pool moved to `ModelRunner`).
Separately, the plugin's `load_plugin` dispatch construction imports sglang's
quantization package, which on HIP-based stacks (Hygon DTK sets
`torch.version.hip`) pulls `aiter` unconditionally and crashes plugin load on
a box without an aiter wheel.

## Change

One squashed commit on `exp/0.5.18-hygon` (based on `exp/0.5.18`; tree
identical to the verified head `440208b`, the source of the formal wheel
`0.1.dev1+g440208beb` built by the sglang-plugin-wheel workflow):
- quantization: pre-seed `sys.modules` with inert aiter stand-ins when
  `torch.version.hip` is set and aiter is not importable (env-gated — a real
  aiter wheel keeps full functionality).
- attention APIs imported from their sglang 0.5.18 wheel paths.
- controlled cuda-graph check reads from the per-phase `cuda_graph_config`.
- KV pool read from the `ModelRunner` instead of the `ForwardBatch` (root
  cause of the 0.5.18 KV-pool drift).

## Verified

E2E on dtk26.04 with the formal plugin wheel `0.1.dev1+g440208beb` (built by
the sglang-plugin-wheel workflow): F (flagtree) and T (triton) each serve
Qwen3-0.6B under the controlled serve config, 3x chat/completions HTTP 200
with real completions, `sampling_backend=pytorch`, log confirms "Using HCU
attention backend".

This PR was written in part with the assistance of generative AI.
