### PR TITLE
fix(musa): support HyV4 DSA on current SGLang APIs

### DIFF
--- a/sglang_fl/__init__.py
+++ b/sglang_fl/__init__.py
@@ -477,6 +477,11 @@ def _setup_communicator_hooks():
       - broadcast_tensor_dict, send_tensor_dict, recv_tensor_dict:
         full method intercept for FlagCX coverage on composite operations
     """
+    if os.getenv("SGLANG_FL_DISABLE_COMM_HOOK", "0").lower() in (
+        "1", "true", "yes", "on"
+    ):
+        logger.info("CommunicatorFL hooks disabled by SGLANG_FL_DISABLE_COMM_HOOK")
+        return
     from sglang.srt.plugins.hook_registry import HookRegistry, HookType
 
     _GC_TARGET = "sglang.srt.distributed.parallel_state.GroupCoordinator"

--- a/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
+++ b/sglang_fl/dispatch/backends/vendor/mthreads/patch.py
@@ -243,6 +243,33 @@ def _patch_fp32_tp_all_reduce() -> None:
     logger.info("MUSA FP32 TP all-reduce patches applied")
 
 
+def _register_dsa_indexer_forward() -> None:
+    """Register the existing Triton-capable Indexer path for MUSA.
+
+    Indexer subclasses BaseFusedOp directly, so the legacy MultiPlatformOp
+    dispatch hook does not cover it. Register through the public OOT API.
+    """
+    try:
+        from sglang.kernels.fused_op import BaseFusedOp
+        from sglang.srt.layers.attention.dsa.dsa_indexer import Indexer
+    except Exception as e:
+        logger.warning("MUSA DSA indexer registration skipped: %s", e)
+        return
+
+    BaseFusedOp.register_oot_forward(Indexer, Indexer.forward_cuda, "oot")
+    logger.info("MUSA DSA Indexer OOT forward registered")
+
+    try:
+        from sglang.srt.layers.attention.dsa.dsa_indexer_kpool import IndexerKPool
+    except ModuleNotFoundError:
+        logger.info("MUSA DSA IndexerKPool is unavailable in this SGLang source")
+    else:
+        BaseFusedOp.register_oot_forward(
+            IndexerKPool, IndexerKPool.forward_cuda, "oot"
+        )
+        logger.info("MUSA DSA IndexerKPool OOT forward registered")
+
+
 def apply_musa_patches() -> None:
     global _patches_applied
     if _patches_applied:
@@ -252,6 +279,7 @@ def apply_musa_patches() -> None:
     _patch_pp_launch_batch_add_sync()
     _patch_multimodal_mask()
     _patch_fp32_tp_all_reduce()
+    _register_dsa_indexer_forward()
     _patches_applied = True
     logger.info("All MUSA PP patches applied successfully")
 

--- a/sglang_fl/platform.py
+++ b/sglang_fl/platform.py
@@ -233,7 +233,13 @@ class PlatformFL(SRTPlatform):
             )
 
             return NPUGraphRunner
-        from sglang.srt.model_executor.cuda_graph_runner import CudaGraphRunner
+        try:
+            # SGLang main moved the decode runner into the runner package.
+            from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
+                DecodeCudaGraphRunner as CudaGraphRunner,
+            )
+        except ImportError:
+            from sglang.srt.model_executor.cuda_graph_runner import CudaGraphRunner
 
         return CudaGraphRunner
 
@@ -258,6 +264,11 @@ class PlatformFL(SRTPlatform):
         from sglang.srt.mem_cache.memory_pool import MLATokenToKVPool
 
         return MLATokenToKVPool
+
+    def get_dsa_kv_pool_cls(self) -> type:
+        from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
+
+        return DSATokenToKVPool
 
     def get_nsa_kv_pool_cls(self) -> type:
         if self._device_type == "npu":
@@ -300,7 +311,7 @@ class PlatformFL(SRTPlatform):
     def support_piecewise_cuda_graph(self) -> bool:
         return self._device_type == "cuda"
 
-    def is_pin_memory_available(self) -> bool:
+    def is_pin_memory_available(self, device=None) -> bool:
         return self._device_type in ("cuda", "npu", "xpu", "musa", "tsingmicro")
 
     def supports_fp8(self) -> bool:

--- a/sglang_fl/platform.py
+++ b/sglang_fl/platform.py
@@ -226,7 +226,12 @@ class PlatformFL(SRTPlatform):
         return _ATTN_BACKEND_MAP.get(self._vendor_name, "torch_native")
 
     def get_graph_runner_cls(self) -> type:
-        """Return graph runner class for this platform."""
+        """Return the graph runner used by SGLang's decode capture path.
+
+        Current SGLang calls this platform factory only from
+        ``capture_decode_graph``. Prefill graph capture constructs
+        ``PrefillCudaGraphRunner`` directly in SGLang core.
+        """
         if self._device_type == "npu":
             from sglang.srt.hardware_backend.npu.graph_runner.npu_graph_runner import (
                 NPUGraphRunner,
@@ -234,14 +239,17 @@ class PlatformFL(SRTPlatform):
 
             return NPUGraphRunner
         try:
-            # SGLang main moved the decode runner into the runner package.
+            # SGLang split the legacy graph runner into phase-specific runners.
             from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
-                DecodeCudaGraphRunner as CudaGraphRunner,
+                DecodeCudaGraphRunner,
             )
+
+            return DecodeCudaGraphRunner
         except ImportError:
+            # In older SGLang, CudaGraphRunner served the decode capture path.
             from sglang.srt.model_executor.cuda_graph_runner import CudaGraphRunner
 
-        return CudaGraphRunner
+            return CudaGraphRunner
 
     def get_mha_kv_pool_cls(self) -> type:
         if self._device_type == "npu":

--- a/tests/functional_tests/compilation/test_graph_capture.py
+++ b/tests/functional_tests/compilation/test_graph_capture.py
@@ -79,17 +79,19 @@ def test_platform_graph_capability_flags() -> None:
         assert platform.support_piecewise_cuda_graph() is piecewise_graph
 
 
-def test_cuda_like_platform_uses_sglang_cuda_graph_runner() -> None:
-    """CUDA and MUSA reuse SGLang's native CudaGraphRunner."""
+def test_cuda_like_platform_uses_sglang_decode_graph_runner() -> None:
+    """CUDA and MUSA reuse SGLang's native decode graph runner."""
     try:
         from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
-            DecodeCudaGraphRunner as CudaGraphRunner,
+            DecodeCudaGraphRunner,
         )
     except ImportError:
-        from sglang.srt.model_executor.cuda_graph_runner import CudaGraphRunner
+        from sglang.srt.model_executor.cuda_graph_runner import (
+            CudaGraphRunner as DecodeCudaGraphRunner,
+        )
 
-    assert _platform_for("cuda").get_graph_runner_cls() is CudaGraphRunner
-    assert _platform_for("musa").get_graph_runner_cls() is CudaGraphRunner
+    assert _platform_for("cuda").get_graph_runner_cls() is DecodeCudaGraphRunner
+    assert _platform_for("musa").get_graph_runner_cls() is DecodeCudaGraphRunner
 
 
 def test_npu_platform_uses_sglang_npu_graph_runner() -> None:

--- a/tests/functional_tests/compilation/test_graph_capture.py
+++ b/tests/functional_tests/compilation/test_graph_capture.py
@@ -81,7 +81,12 @@ def test_platform_graph_capability_flags() -> None:
 
 def test_cuda_like_platform_uses_sglang_cuda_graph_runner() -> None:
     """CUDA and MUSA reuse SGLang's native CudaGraphRunner."""
-    from sglang.srt.model_executor.cuda_graph_runner import CudaGraphRunner
+    try:
+        from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
+            DecodeCudaGraphRunner as CudaGraphRunner,
+        )
+    except ImportError:
+        from sglang.srt.model_executor.cuda_graph_runner import CudaGraphRunner
 
     assert _platform_for("cuda").get_graph_runner_cls() is CudaGraphRunner
     assert _platform_for("musa").get_graph_runner_cls() is CudaGraphRunner

--- a/tests/unit_tests/platform/test_hy4_runtime_compat.py
+++ b/tests/unit_tests/platform/test_hy4_runtime_compat.py
@@ -1,0 +1,65 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compatibility coverage required by HyV4 on recent SGLang releases."""
+
+import inspect
+
+import pytest
+
+
+def _platform_for(device_type: str):
+    from sglang_fl.platform import PlatformFL
+
+    platform = PlatformFL.__new__(PlatformFL)
+    platform._device_type = device_type
+    return platform
+
+
+@pytest.mark.parametrize(
+    ("device_type", "expected"),
+    [
+        ("cuda", True),
+        ("npu", True),
+        ("xpu", True),
+        ("musa", True),
+        ("tsingmicro", True),
+        ("cpu", False),
+    ],
+)
+def test_pin_memory_signature_and_existing_results(device_type, expected):
+    from sglang_fl.platform import PlatformFL
+
+    signature = inspect.signature(PlatformFL.is_pin_memory_available)
+    assert signature.parameters["device"].default is None
+    platform = _platform_for(device_type)
+    assert platform.is_pin_memory_available() is expected
+    assert platform.is_pin_memory_available(device=device_type) is expected
+
+
+def test_dsa_kv_pool_uses_sglang_pool():
+    from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
+
+    assert _platform_for("musa").get_dsa_kv_pool_cls() is DSATokenToKVPool
+
+
+def test_graph_runner_uses_current_sglang_api():
+    try:
+        from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
+            DecodeCudaGraphRunner,
+        )
+    except ImportError:
+        pytest.skip("current DecodeCudaGraphRunner API is unavailable")
+
+    assert _platform_for("musa").get_graph_runner_cls() is DecodeCudaGraphRunner

--- a/tests/unit_tests/platform/test_load_plugin.py
+++ b/tests/unit_tests/platform/test_load_plugin.py
@@ -14,6 +14,9 @@
 
 # Integration tests for sglang_fl.load_plugin: step order and idempotency.
 
+import sys
+import types
+
 import pytest
 
 
@@ -101,3 +104,45 @@ class TestLoadPluginIdempotency:
         sglang_fl.load_plugin()
 
         assert call_count == {"flaggems": 1, "vendor_patches": 1}
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+def test_communicator_hook_can_be_disabled(monkeypatch, value):
+    import sglang_fl
+
+    monkeypatch.setenv("SGLANG_FL_DISABLE_COMM_HOOK", value)
+    # No SGLang hook module is installed in this test. Returning without an
+    # import therefore also proves that the disable check runs first.
+    monkeypatch.delitem(
+        sys.modules, "sglang.srt.plugins.hook_registry", raising=False
+    )
+
+    sglang_fl._setup_communicator_hooks()
+
+
+def test_communicator_hook_remains_enabled_by_default(monkeypatch):
+    import sglang_fl
+
+    monkeypatch.delenv("SGLANG_FL_DISABLE_COMM_HOOK", raising=False)
+    registrations = []
+    fake_module = types.ModuleType("sglang.srt.plugins.hook_registry")
+
+    class FakeHookRegistry:
+        @staticmethod
+        def register(target, function, hook_type):
+            registrations.append((target, function, hook_type))
+
+    class FakeHookType:
+        AROUND = "around"
+
+    fake_module.HookRegistry = FakeHookRegistry
+    fake_module.HookType = FakeHookType
+    monkeypatch.setitem(
+        sys.modules, "sglang.srt.plugins.hook_registry", fake_module
+    )
+
+    sglang_fl._setup_communicator_hooks()
+
+    assert len(registrations) == 12
+    assert all(item[2] == FakeHookType.AROUND for item in registrations)
+    assert registrations[0][0].endswith("GroupCoordinator.__init__")

--- a/tests/unit_tests/platform/test_mthreads_dsa_patches.py
+++ b/tests/unit_tests/platform/test_mthreads_dsa_patches.py
@@ -1,0 +1,104 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit coverage for the MUSA DSA OOT registration shim."""
+
+import sys
+import types
+
+
+def test_registers_indexer_and_optional_kpool(monkeypatch):
+    from sglang_fl.dispatch.backends.vendor.mthreads import patch
+
+    registrations = []
+
+    class FakeBaseFusedOp:
+        @classmethod
+        def register_oot_forward(cls, op_cls, forward, backend):
+            registrations.append((op_cls, forward, backend))
+
+    class FakeIndexer:
+        @staticmethod
+        def forward_cuda():
+            pass
+
+    class FakeIndexerKPool:
+        @staticmethod
+        def forward_cuda():
+            pass
+
+    fused_op = types.ModuleType("sglang.kernels.fused_op")
+    fused_op.BaseFusedOp = FakeBaseFusedOp
+    indexer = types.ModuleType("sglang.srt.layers.attention.dsa.dsa_indexer")
+    indexer.Indexer = FakeIndexer
+    kpool = types.ModuleType("sglang.srt.layers.attention.dsa.dsa_indexer_kpool")
+    kpool.IndexerKPool = FakeIndexerKPool
+    monkeypatch.setitem(sys.modules, "sglang.kernels.fused_op", fused_op)
+    monkeypatch.setitem(
+        sys.modules, "sglang.srt.layers.attention.dsa.dsa_indexer", indexer
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang.srt.layers.attention.dsa.dsa_indexer_kpool",
+        kpool,
+    )
+
+    patch._register_dsa_indexer_forward()
+
+    assert registrations == [
+        (FakeIndexer, FakeIndexer.forward_cuda, "oot"),
+        (FakeIndexerKPool, FakeIndexerKPool.forward_cuda, "oot"),
+    ]
+
+
+def test_missing_optional_kpool_does_not_block_indexer(monkeypatch):
+    from sglang_fl.dispatch.backends.vendor.mthreads import patch
+
+    registrations = []
+
+    class FakeBaseFusedOp:
+        @classmethod
+        def register_oot_forward(cls, op_cls, forward, backend):
+            registrations.append((op_cls, forward, backend))
+
+    class FakeIndexer:
+        @staticmethod
+        def forward_cuda():
+            pass
+
+    fused_op = types.ModuleType("sglang.kernels.fused_op")
+    fused_op.BaseFusedOp = FakeBaseFusedOp
+    indexer = types.ModuleType("sglang.srt.layers.attention.dsa.dsa_indexer")
+    indexer.Indexer = FakeIndexer
+    monkeypatch.setitem(sys.modules, "sglang.kernels.fused_op", fused_op)
+    monkeypatch.setitem(
+        sys.modules, "sglang.srt.layers.attention.dsa.dsa_indexer", indexer
+    )
+    monkeypatch.delitem(
+        sys.modules,
+        "sglang.srt.layers.attention.dsa.dsa_indexer_kpool",
+        raising=False,
+    )
+
+    real_import = __import__
+
+    def import_without_kpool(name, *args, **kwargs):
+        if name == "sglang.srt.layers.attention.dsa.dsa_indexer_kpool":
+            raise ModuleNotFoundError(name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", import_without_kpool)
+    patch._register_dsa_indexer_forward()
+
+    assert registrations == [(FakeIndexer, FakeIndexer.forward_cuda, "oot")]


### PR DESCRIPTION
## Summary

Add the plugin-side compatibility required by HyV4/DSA on current SGLang and keep older SGLang imports working.

## Changes

- accept the optional `device` argument in `is_pin_memory_available`;
- select `DecodeCudaGraphRunner` from its current location, with a legacy import fallback;
- expose `DSATokenToKVPool` through `PlatformFL`;
- register MUSA OOT forwards for DSA `Indexer` and optional `IndexerKPool`;
- add `SGLANG_FL_DISABLE_COMM_HOOK` as an opt-in diagnostic rollback switch; default behavior remains enabled;
- add focused compatibility, dispatch and communicator-hook tests;
- update graph-runner functional coverage for both SGLang import layouts.

## Why

HyV4 uses DSA and requires the indexer path and DSA KV pool. `Indexer` derives directly from `BaseFusedOp`, so the existing `MultiPlatformOp` dispatch hook does not cover it. Current SGLang also moved the decode graph runner and extended the pin-memory platform API.

## Validation

- `compileall`: PASS
- `git diff --check`: PASS
- five source patches apply cleanly to current `main`
- full local pytest: not available in the control Python environment
- target evidence from the same two-node MUSA TP16 runtime:
  - deterministic repeat 10/10;
  - concurrency 32: 32/32;
  - GPQA thinking: 26/26, non-empty reasoning/content, all stopped normally;
  - 4096 input / 1024 output / C64: 128/128 token-exact;
  - profiler-disabled all-token throughput: 872.795 and 874.662 token/s.

## Compatibility and rollback

- The new graph-runner import retains a fallback for older SGLang.
- `IndexerKPool` remains optional for older SGLang versions.
- The communicator hook remains enabled by default.
- Each behavior can be reverted without changing model weights or network settings.

## Ownership boundary

The accepted target runtime also used a task-local SGLang-core bounded DSA ragged-offset fix and an FP8-KV guard. Those SGLang-owned changes are intentionally not embedded in this plugin PR.

