### PR TITLE
feat(sunrise): make sglang 0.5.18 serve on the TANGRT/PTPU runtime

### DIFF
--- a/sglang_fl/platform.py
+++ b/sglang_fl/platform.py
@@ -173,11 +173,28 @@ class PlatformFL(SRTPlatform):
     # Planned methods (provide implementations for future core migration)
     # ------------------------------------------------------------------
 
-    def get_device(self, local_rank: int) -> torch.device:
-        return torch.device(self._device_type, local_rank)
+    def get_device(self, device_id: Optional[int] = None) -> str:
+        """Device string for the core to consume, e.g. 'ptpu' / 'ptpu:3'.
 
-    def set_device(self, device: torch.device) -> None:
+        The core stores this in ``ServerArgs.device`` and strips a trailing
+        index from it (``server_args._handle_missing_default_values``), and
+        ``utils.common.get_device()`` delegates here whenever none of the
+        known accelerators matched. Both expect a *string*; returning a
+        ``torch.device`` object fails at the first ``.split(":")``. Devices
+        whose torch exposes ``cuda.is_available()`` never reach this method
+        (the core answers "cuda" first), which is why the wrong return type
+        went unnoticed until a non-CUDA-alias platform — sunrise/ptpu — hit it.
+        """
+        if device_id is None:
+            return self._device_type
+        return f"{self._device_type}:{device_id}"
+
+    def set_device(self, device) -> None:
         if self._info.torch_device_fn is not None:
+            # Callers pass what get_device() handed them (a string, or an
+            # index); the torch backend device fn wants a torch.device.
+            if isinstance(device, str):
+                device = torch.device(device)
             self._info.torch_device_fn.set_device(device)
 
     def get_device_name(self, device_id: int = 0) -> str:

--- a/sglang_fl/platform.py
+++ b/sglang_fl/platform.py
@@ -52,6 +52,10 @@ _DIST_BACKEND_MAP = {
     "enflame": "eccl",
     "tsingmicro": "tccl",
     "hygon": "nccl",
+    # sunrise's torch is a +cpu build carrying the PTPU ProcessGroup; its
+    # available backends are pccl and gloo (no NCCL), so the nccl fallback
+    # aborts every startup with "Distributed package doesn't have NCCL built in".
+    "sunrise": "pccl",
 }
 
 # Attention backend mapping: vendor_name -> default backend


### PR DESCRIPTION
Fixes #114

## What

Makes sglang 0.5.18 serve end-to-end on Sunrise (TANGRT 1.2.0 / PTPU), F/T
dual-compiler verified (Qwen3-4B, 3/3 requests, `sampling_backend=pytorch`).

## Why Sunrise needs its own vendor layer

Sunrise's torch is a `+cpu` build carrying the PTPU device, so it is **not**
CUDA-alias: `torch.cuda.is_available()` is False. Every other vendor this plugin
carries (MetaX, Iluvatar, Hygon) answers that question with True, and the core
short-circuits before reaching the plugin's fallbacks — so two defects in those
fallbacks went unnoticed until a platform actually reached them.

## Changes

**1. `get_device` returned the wrong type (`8601ed7`)**

`PlatformFL.get_device()` returned a `torch.device`; every caller wants the
string form, and the core immediately splits it:

```
File "sglang/srt/server_args.py", line 4264, in _handle_missing_default_values
  self.device = self.device.split(":")[0]
AttributeError: 'torch.device' object has no attribute 'split'
```

`utils.common.get_device()` delegates here only when none of the known
accelerators matched, which is why CUDA-alias platforms never saw it. Returns
`'ptpu'` / `'ptpu:N'` now, and `set_device` accepts what `get_device` hands back.

**2. `_DIST_BACKEND_MAP` lacked a sunrise entry (`3b94dae`)**

Falling through to the `nccl` default aborted every startup:

```
RuntimeError: Distributed package doesn't have NCCL built in
```

Sunrise's torch exposes `pccl` and `gloo` only (verified on-device with
`torch.distributed.is_backend_available()`). Mapped to `pccl`, matching what
vllm-plugin-FL's sunrise layer does for its process groups.

`_ATTN_BACKEND_MAP` also has no sunrise entry, so attention falls back to
`torch_native` — correct, and left as-is here; a faster vendor backend is a
separate change.

## Verification

Both compiler paths, same plugin head (`0.1.dev1+g3b94dae1f`), same config
(identical blacklist), Qwen3-4B on the sunrise node, runtime
`flagos-runtime-sunrise-tangrt1.2.0:2.1.2`, `flag_gems 5.3.6`:

| Path | Compiler | Result |
|---|---|---|
| F | flagtree 0.6.0+sunrise3.6 | ready ~50s, 3/3, ct=144, `sampling_backend=pytorch` |
| T | vendor triton 3.6.0.1+git0a5cfb35 | ready ~50s, 3/3, ct=144, `sampling_backend=pytorch` |

## Related

Four flag_gems vendor-override defects were needed on the way and are filed
upstream: #6164 (summary), #6172 (`_scaled_dot_product_attention_math` rejects
`enable_gqa`), #6173 (`_fallback_pow` breaks on `scalar ** tensor`). The first
two are blacklisted at delivery, which is the normal mechanism for this.

This PR was written in part with the assistance of generative AI.
