### PR TITLE
feat(kunlunxin): make sglang 0.5.18 serve on the P800 XPU runtime

### DIFF
--- a/sglang_fl/dispatch/backends/vendor/kunlunxin/impl/attention_backend.py
+++ b/sglang_fl/dispatch/backends/vendor/kunlunxin/impl/attention_backend.py
@@ -57,6 +57,9 @@ class KunlunxinBackend(AttentionBackend):
         self.device = model_runner.device
         self.max_context_len = model_runner.model_config.context_len
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
+        # 0.5.18 moved the KV pool off ForwardBatch and onto the runner;
+        # capture it here like sglang's own attention backends do.
+        self.token_to_kv_pool = model_runner.token_to_kv_pool
         self.kv_cache_dtype = model_runner.kv_cache_dtype
         self.page_size = model_runner.page_size
         self.forward_metadata: Optional[KunlunxinForwardMetadata] = None
@@ -142,8 +145,8 @@ class KunlunxinBackend(AttentionBackend):
 
         # KV shared layer: k/v are None -> read from paged KV cache.
         if k is None and v is None:
-            k_buf = forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id)
-            v_buf = forward_batch.token_to_kv_pool.get_value_buffer(layer.layer_id)
+            k_buf = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
+            v_buf = self.token_to_kv_pool.get_value_buffer(layer.layer_id)
             page_ids = forward_batch.out_cache_loc // self.page_size
             offsets = forward_batch.out_cache_loc % self.page_size
             k = k_buf[page_ids, :, offsets, :]
@@ -155,7 +158,7 @@ class KunlunxinBackend(AttentionBackend):
             o = torch.empty_like(q)
 
         if save_kv_cache:
-            forward_batch.token_to_kv_pool.set_kv_buffer(
+            self.token_to_kv_pool.set_kv_buffer(
                 layer, forward_batch.out_cache_loc, k, v
             )
 
@@ -174,10 +177,10 @@ class KunlunxinBackend(AttentionBackend):
         )
 
         if use_kv_cache:
-            k_cache = forward_batch.token_to_kv_pool.get_key_buffer(
+            k_cache = self.token_to_kv_pool.get_key_buffer(
                 layer.layer_id
             ).contiguous()
-            v_cache = forward_batch.token_to_kv_pool.get_value_buffer(
+            v_cache = self.token_to_kv_pool.get_value_buffer(
                 layer.layer_id
             ).contiguous()
             k_cache_max, v_cache_max = None, None
@@ -237,8 +240,8 @@ class KunlunxinBackend(AttentionBackend):
             sinks = sinks.float().contiguous()
 
         if k is None and v is None:
-            k_buf = forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id)
-            v_buf = forward_batch.token_to_kv_pool.get_value_buffer(layer.layer_id)
+            k_buf = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
+            v_buf = self.token_to_kv_pool.get_value_buffer(layer.layer_id)
             page_ids = forward_batch.out_cache_loc // self.page_size
             offsets = forward_batch.out_cache_loc % self.page_size
             k = k_buf[page_ids, :, offsets, :]
@@ -247,14 +250,14 @@ class KunlunxinBackend(AttentionBackend):
         assert self.forward_metadata is not None
 
         if save_kv_cache:
-            forward_batch.token_to_kv_pool.set_kv_buffer(
+            self.token_to_kv_pool.set_kv_buffer(
                 layer, forward_batch.out_cache_loc, k, v
             )
 
-        k_cache = forward_batch.token_to_kv_pool.get_key_buffer(
+        k_cache = self.token_to_kv_pool.get_key_buffer(
             layer.layer_id
         ).contiguous()
-        v_cache = forward_batch.token_to_kv_pool.get_value_buffer(
+        v_cache = self.token_to_kv_pool.get_value_buffer(
             layer.layer_id
         ).contiguous()
 

--- a/sglang_fl/dispatch/backends/vendor/kunlunxin/patch.py
+++ b/sglang_fl/dispatch/backends/vendor/kunlunxin/patch.py
@@ -23,6 +23,7 @@ import logging
 from .patches.attention_backend_choice import patch_attention_backend_choice
 from .patches.causal_conv1d import patch_causal_conv1d
 from .patches.clamp_position import patch_clamp_position
+from .patches.jit_kernels import patch_jit_kernel_predicates
 from .patches.pp_send_first import patch_pp_send_recv_and_preprocess_output_tensors
 from .patches.suppress_pynccl import patch_suppress_pynccl
 
@@ -31,17 +32,30 @@ _patches_applied = False
 
 
 def apply_kunlunxin_patches():
-    """Apply all kunlunxin-specific patches."""
+    """Apply all kunlunxin-specific patches.
+
+    Each patch is isolated: one that no longer matches sglang's API must not
+    take the rest down with it. That is not hypothetical — a rebind left over
+    from an older sglang raised AttributeError here and silently disabled every
+    patch behind it, including the ones this backend needs to run at all.
+    """
     global _patches_applied
     if _patches_applied:
         return
     _patches_applied = True
 
-    patch_clamp_position()
-    patch_causal_conv1d()
-    patch_suppress_pynccl()
-    patch_pp_send_recv_and_preprocess_output_tensors()
-    patch_attention_backend_choice()
+    for name, patch in (
+        ("clamp_position", patch_clamp_position),
+        ("causal_conv1d", patch_causal_conv1d),
+        ("jit_kernels", patch_jit_kernel_predicates),
+        ("suppress_pynccl", patch_suppress_pynccl),
+        ("pp_send_recv", patch_pp_send_recv_and_preprocess_output_tensors),
+        ("attention_backend_choice", patch_attention_backend_choice),
+    ):
+        try:
+            patch()
+        except Exception as e:
+            logger.warning("kunlunxin patch %s failed (continuing): %r", name, e)
 
 
 apply_kunlunxin_patches()

--- a/sglang_fl/dispatch/backends/vendor/kunlunxin/patches/clamp_position.py
+++ b/sglang_fl/dispatch/backends/vendor/kunlunxin/patches/clamp_position.py
@@ -59,16 +59,16 @@ def patch_clamp_position():
     if _applied:
         return
 
-    from sglang.srt.managers import overlap_utils
     from sglang.srt.model_executor import forward_batch_info
 
-    overlap_utils._resolve_future_token_ids = (
-        overlap_utils._resolve_future_token_ids_native
-    )
+    # 0.5.18 dropped overlap_utils._resolve_future_token_ids (and its _native
+    # twin) — that rebind used to live here and now raises AttributeError at
+    # plugin-import time, which aborted every kunlunxin patch behind it. Only
+    # the clamp_position seam survives the API drift.
     forward_batch_info.clamp_position = forward_batch_info._clamp_position_native
 
     _applied = True
     logger.info(
         "patched JIT-CUDA plumbing kernels -> torch-native "
-        "(resolve_future_token_ids, clamp_position; avoids nvcc -std=c++20 on Kunlunxin)"
+        "(clamp_position; avoids nvcc -std=c++20 on Kunlunxin)"
     )

--- a/sglang_fl/dispatch/backends/vendor/kunlunxin/patches/jit_kernels.py
+++ b/sglang_fl/dispatch/backends/vendor/kunlunxin/patches/jit_kernels.py
@@ -1,0 +1,98 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Kunlunxin: make sglang's JIT CUDA predicates answer False.
+
+Several `can_use_*` predicates decide whether to use a JIT-compiled CUDA kernel
+by compiling it and reporting success:
+
+    def can_use_x(...):
+        try:
+            _jit_x_module(...)   # nvcc, never launched
+            return True
+        except Exception:
+            return False
+
+The build targets the capability the device reports, and kunlunxin's
+cuda-compat device answers (8, 6), so nvcc emits sm_86 SASS. Compilation
+succeeds; the failure lands at the launch, far from the decision that was
+wrong:
+
+    RuntimeError: ... qknorm.cuh:173: CUDA error: invalid device function
+    RuntimeError: ... kvcache.cuh:316: CUDA error: invalid device function
+
+"invalid device function" is the driver reporting that no SASS in the image
+matches this device. sm_86 is an NVIDIA architecture and this device executes
+its own instruction set, so no nvcc-produced SASS can run here — the toolchain
+being a real nvcc is exactly why nothing notices.
+
+Each entry below names one predicate and the import sites that copy it. The
+predicates are rebound in their defining module and in every module that
+already did a from-import (the name is copied at import time, so patching only
+the definition would miss a caller that imported first). A module not yet
+imported needs nothing: it picks the rebind up from the definition.
+
+Add an entry here when a new kernel proves unrunnable on this device; the
+predicate's own `except` path is what routes the caller to native.
+"""
+
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+_applied = False
+
+# (defining module, attribute) -> module paths that from-import the same name.
+# The attribute name differs where a consumer aliases it (vision.py).
+_PREDICATES = (
+    (
+        ("sglang.kernels.ops.layernorm.norm", "can_use_fused_inplace_qknorm"),
+        (
+            ("sglang.srt.models.utils", "can_use_fused_inplace_qknorm"),
+            ("sglang.srt.layers.attention.vision", "can_use_jit_qk_norm"),
+        ),
+    ),
+    (
+        ("sglang.kernels.ops.kvcache.kvcache", "can_use_store_cache"),
+        (("sglang.srt.mem_cache.memory_pool", "can_use_store_cache"),),
+    ),
+)
+
+
+def patch_jit_kernel_predicates():
+    """Force the named JIT-CUDA predicates to False on kunlunxin."""
+    global _applied
+    if _applied:
+        return
+    _applied = True
+
+    def _always_false(*args, **kwargs) -> bool:
+        return False
+
+    for (def_module, def_name), consumers in _PREDICATES:
+        try:
+            module = __import__(def_module, fromlist=[def_name])
+            setattr(module, def_name, _always_false)
+        except Exception as e:
+            logger.warning("kunlunxin: cannot rebind %s.%s: %r", def_module, def_name, e)
+            continue
+        for mod_path, attr in consumers:
+            mod = sys.modules.get(mod_path)
+            if mod is not None and hasattr(mod, attr):
+                setattr(mod, attr, _always_false)
+
+    logger.info(
+        "kunlunxin: JIT CUDA kernel predicates forced False "
+        "(nvcc emits sm_86 SASS, which this device cannot execute)"
+    )

--- a/sglang_fl/dispatch/config/kunlunxin.yaml
+++ b/sglang_fl/dispatch/config/kunlunxin.yaml
@@ -50,6 +50,16 @@ flagos_blacklist:
   - to_copy
   - nonzero
   - argmax
+  # SDPA family: torch_native routes attention through
+  # torch.nn.functional.scaled_dot_product_attention, and flag_gems hijacks
+  # aten::_scaled_dot_product_* — its flash kernel then hits the XPU
+  # compiler's flash-attention failure (pass pipeline aborts, surfaced as the
+  # placeholder OutOfResources 'uni_sram'). Blacklisting the family keeps the
+  # native torch path, which is what runs here.
+  - _scaled_dot_product_flash_attention
+  - _scaled_dot_product_attention_math
+  - _scaled_dot_product_efficient_attention
+  - _scaled_dot_product_cudnn_attention
 
 # Per-op backend order (overrides `prefer` for the listed op only).
 #   silu_and_mul : route to the kunlunxin VENDOR impl (sgl_kernel klx build),

--- a/sglang_fl/dispatch/config/utils.py
+++ b/sglang_fl/dispatch/config/utils.py
@@ -46,33 +46,31 @@ _CONFIG_DIR = Path(__file__).parent
 
 
 def get_platform_name() -> str:
-    """
-    Detect the current hardware platform.
+    """Vendor name for configuration lookup, e.g. 'kunlunxin', 'ascend'.
 
-    Returns:
-        Platform name string: 'ascend', 'musa', 'iluvatar', 'nvidia', or 'unknown'
+    Delegates to the FlagGems-backed detector (``sglang_fl.utils.get_device_info``)
+    rather than re-deriving the vendor from torch attributes here. The two used
+    to disagree: a hand-rolled chain returned 'nvidia' for every CUDA-alias
+    vendor (kunlunxin, and any future one), because it only knew about torch's
+    own device namespaces — so kunlunxin.yaml, with its bisected operator
+    blacklist and per-op routing, was never loaded and the platform silently ran
+    on nvidia.yaml.
+
+    The environment override stays here: it is a config-loader concern, not a
+    device fact.
     """
+    override = os.environ.get("SGLANG_FL_PLATFORM", "").strip().lower()
+    if override:
+        return override
+
     try:
-        import torch
-        if hasattr(torch, "txda") and torch.txda.is_available():
-            return "tsingmicro"
-        if hasattr(torch, "npu") and torch.npu.is_available():
-            return "ascend"
-        if hasattr(torch, "musa") and torch.musa.is_available():
-            return "musa"
-        if hasattr(torch, "gcu") and torch.gcu.is_available():
-            return "gcu"
-        if hasattr(torch, "corex") and torch.cuda.is_available():
-            return "iluvatar"
-        if torch.cuda.is_available():
-            return "nvidia"
-    except ImportError:
-        pass
+        from sglang_fl.utils import get_device_info
 
-    # Check environment variable override
-    platform_override = os.environ.get("SGLANG_FL_PLATFORM", "").strip().lower()
-    if platform_override:
-        return platform_override
+        info = get_device_info()
+        if info is not None:
+            return info.vendor_name
+    except Exception:
+        pass
 
     return "unknown"
 

--- a/sglang_fl/platform.py
+++ b/sglang_fl/platform.py
@@ -62,7 +62,17 @@ _ATTN_BACKEND_MAP = {
     "mthreads": "fa3",
     "enflame": "fa3",
     "thead": "fa3",
-    "kunlunxin": "kunlunxin",
+    # torch_native rather than the vendor backend: the latter calls
+    # sgl_kernel's klx_attention_* ops, which exist only in a vendor-compiled
+    # sgl_kernel build (not on any index we publish, and not something the
+    # import-face shim can satisfy — torch.ops lookups go through the
+    # dispatcher, not Python module attributes). The triton backend is not an
+    # alternative here either: the XPU compiler fails on flash-style attention
+    # kernels (see packaging/vllm/docs/handoffs/kunlunxin-xpu-triton-attention-
+    # compiler-bug.md), which torch_native reaches too — flag_gems hijacks
+    # aten::_scaled_dot_product_flash_attention — hence the SDPA entries in
+    # kunlunxin.yaml's flagos_blacklist.
+    "kunlunxin": "torch_native",
     "iluvatar": "triton",
     "hygon": "hcu",
 }


### PR DESCRIPTION
Fixes #115

## What

Makes sglang 0.5.18 serve end-to-end on Kunlunxin (P800 XPU, XRE 5.37.1), F/T
dual-compiler verified (Qwen3-4B, 3/3 requests, `sampling_backend=pytorch`).

Companion build-infra PR: https://github.com/flagos-ai/build-infra/pull/857

## Changes

**1. Resolve the platform through the device detector (`323940c`)**

`get_platform_name()` re-derived the vendor from torch attributes instead of
asking the FlagGems-backed detector the rest of the plugin uses, and the two
disagreed. On kunlunxin it returned `nvidia` — the hand-rolled chain only knew
torch's own device namespaces, so every CUDA-alias vendor fell through to the
`cuda.is_available()` branch:

    get_device_info   -> kunlunxin
    get_platform_name -> nvidia
    config path       -> .../config/nvidia.yaml
    flagos_blacklist  -> 0 entries

`kunlunxin.yaml` was therefore never loaded: its bisected operator blacklist,
the `silu_and_mul -> vendor` routing, and the `oot_blacklist` all silently did
nothing. It now resolves correctly (19 entries loaded).

The same chain also made `SGLANG_FL_PLATFORM` unreachable on any real device:
the early `return "nvidia"` ran before the override check.

**2. Adapt the vendor layer to sglang 0.5.18 (`b8d7099`)**

- `overlap_utils._resolve_future_token_ids` (and its `_native` twin) is gone.
  The leftover rebind raised AttributeError at plugin-import time, and because
  the patches ran in sequence, that one failure silently disabled every patch
  behind it — the whole vendor layer has been dead since 0.5.18.
- The KV pool moved off `ForwardBatch` onto the runner; ten call sites read
  `forward_batch.token_to_kv_pool`. Captured once in `__init__`, the way
  sglang's own attention backends do.

The patch runner now isolates each patch, so the next API drift cannot take the
rest down with it.

**3. Force the JIT CUDA predicates False (`5de5849`)**

`can_use_*` predicates decide by building the kernel and reporting success. The
build targets the capability the device reports — kunlunxin's cuda-compat device
answers (8, 6) — so nvcc emits sm_86 SASS; the compile succeeds and the launch
fails with `invalid device function`. Forcing the predicates False sends each
caller down the native branch it already has.

**4. Attention on torch_native + the SDPA blacklist (`596820d`)**

The vendor backend calls `sgl_kernel.klx_attention_extend` /
`klx_attention_decode` — a vendor-compiled artifact, absent from every index we
publish and out of reach of the import-face shim (`torch.ops` resolves through
the dispatcher, not Python module attributes). The triton backend is not an
alternative: the XPU compiler aborts on flash-style attention kernels, which
torch_native reaches too through flag_gems hijacking
`aten::_scaled_dot_product_flash_attention` — hence the four SDPA entries added
to `kunlunxin.yaml`.

## Verification

| Path | Compiler | Result |
|---|---|---|
| F | flagtree 0.6.1+xpu3.6 | ready ~60s, 3/3, ct=144, `sampling_backend=pytorch` |
| T | vendor triton | ready ~60s, 3/3, ct=144, `sampling_backend=pytorch` |

Same config on both paths; only the compiler variable differs.

## Note

The SDPA blacklist had to go into the platform config rather than
`SGLANG_FL_FLAGOS_BLACKLIST`: the env var *replaces* the platform list rather
than appending, which silently dropped the 19 bisected entries and made serve
fail somewhere else entirely.

This PR was written in part with the assistance of generative AI.
