### PR TITLE
feat(iluvatar): run sglang 0.5.18 on a torch 2.7 build

### DIFF
--- a/addon/torch-compat/README.md
+++ b/addon/torch-compat/README.md
@@ -1,0 +1,54 @@
+# torch-compat-shim
+
+On-disk compat layer for running sglang 0.5.18 on a torch < 2.8 build
+(iluvatar/corex 4.4.0 today, whose SDK pins torch 2.7.1).
+
+## Why this exists
+
+sglang 0.5.18 imports two torch surfaces that torch < 2.8 does not have, on the
+plain Qwen3 startup path:
+
+| gap | where | torch 2.7 has |
+|---|---|---|
+| `torch.cuda.memory._cuda_beginAllocateCurrentThreadToPool`, `_cuda_endAllocateToPool` | `pynccl_allocator` | the same two operations as `_cuda_beginAllocateToPool` / `_cuda_endAllocateCurrentStreamToPool` |
+| `torch.distributed._symmetric_memory` (import fails: no `_C._distributed_c10d._SymmetricMemory`) | `logits_processor` → `triton_symm_mem_ag` | nothing — it is an NVLink multicast all-gather |
+
+The first is a rename, not a different operation: `pynccl_allocator` itself
+chooses between the two spellings by version (`after_2_8_0`). The second is an
+NVLink feature this platform never runs.
+
+## Why nothing is called
+
+Symmetric memory is off through sglang's own gate —
+`pynccl_allocator.is_symmetric_memory_enabled()` returns
+`get_exec().comm.enable_symm_mem`, False without real symmetric memory. So the
+aliased entry points and the stubbed names are imported and never reached. The
+stub keeps the flashinfer-shim discipline: stubbed symbols are an explicit
+allowlist, every other name raises `AttributeError` (capability probes stay
+honest) and every stub *call* raises `RuntimeError` — nothing silently computes
+a wrong result.
+
+## Why `sitecustomize` instead of a plugin patch
+
+sglang runs its scheduler in a *spawned* worker, and that worker imports
+`sglang.srt.managers.scheduler` — taking in both surfaces — before any sglang
+plugin is loaded. A plugin-side patch is never in place early enough; the fix
+must be on disk. Same ordering that made `addon/flashinfer-shim` an installed
+package.
+
+`site` imports `sitecustomize` at interpreter startup, so the patch is in place
+in the worker too. The hook only wraps the import of the `sglang` package, so
+the cost is paid by interpreters that import sglang and by no others. Both
+patches are no-ops on torch >= 2.8.
+
+## Install scope
+
+Publish to the vendor index of the backends that need it and list it in their
+`deps_app`. This shim exists only for platforms whose SDK pins torch < 2.8 —
+installing it where torch is newer is harmless but pointless.
+
+## Build
+
+```bash
+bash build.sh [outdir]
+```

--- a/addon/torch-compat/build.sh
+++ b/addon/torch-compat/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Build the torch<2.8 compat shim wheel. Pure Python, zero deps.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+OUT="${1:-out}"
+python3 -m pip wheel . --no-deps -w "$OUT"
+ls -l "$OUT"

--- a/addon/torch-compat/pyproject.toml
+++ b/addon/torch-compat/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "torch-compat-shim"
+version = "0.1.0"
+description = "Give a torch < 2.8 build the two surfaces sglang 0.5.18 imports at startup"
+requires-python = ">=3.10"
+license = {text = "Apache-2.0"}
+
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+# Import name is `sitecustomize` on purpose: `site` imports it at interpreter
+# startup, which is the only point early enough for the spawned scheduler
+# worker (see the module docstring).
+[tool.setuptools]
+py-modules = ["sitecustomize"]

--- a/addon/torch-compat/sitecustomize.py
+++ b/addon/torch-compat/sitecustomize.py
@@ -1,0 +1,191 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Give a torch < 2.8 build the two surfaces sglang 0.5.18 imports at startup.
+
+Both gaps are on the plain Qwen3 startup path, both are module-level imports
+that no plugin can pre-empt, and both are imports only — the code behind them
+is gated off on this platform (see "Why nothing is called" below).
+
+1. ``torch.cuda.memory._cuda_beginAllocateCurrentThreadToPool`` and
+   ``_cuda_endAllocateToPool``, imported by
+   ``sglang.srt.distributed.device_communicators.pynccl_allocator``. torch 2.7
+   spells the same two operations ``_cuda_beginAllocateToPool`` and
+   ``_cuda_endAllocateCurrentStreamToPool``. This is torch's rename, not a
+   substitute: upstream picks between the two spellings by version itself
+   (``after_2_8_0`` in that file chooses ``torch._C._cuda_endAllocateToPool``
+   on >= 2.8 and ``torch._C._cuda_endAllocateCurrentStreamToPool`` below it).
+
+2. ``torch.distributed._symmetric_memory``, imported by
+   ``sglang.srt.layers.logits_processor`` ->
+   ``triton_symm_mem_ag``. The module's own import fails on torch < 2.8
+   because ``torch._C._distributed_c10d._SymmetricMemory`` does not exist
+   there. It is an NVLink multicast all-gather: this platform never runs it.
+
+Why nothing is called
+---------------------
+
+Symmetric memory is off on this stack through sglang's own gate —
+``pynccl_allocator.is_symmetric_memory_enabled()`` returns
+``get_exec().comm.enable_symm_mem``, which is False without real symmetric
+memory. So the aliased allocator entry points and the stubbed module names are
+imported and never reached; a stub *call* raises, so a path that unexpectedly
+reaches them fails loudly instead of computing something wrong.
+
+Why ``sitecustomize``
+---------------------
+
+sglang runs its scheduler in a *spawned* worker, and that worker imports
+``sglang.srt.managers.scheduler`` — taking in both surfaces above — before any
+sglang plugin is loaded. A patch applied from the plugin is therefore never in
+place early enough; the fix has to be on disk. This is the same ordering that
+made ``addon/flashinfer-shim`` an installed package rather than a plugin patch.
+``site`` imports this module at interpreter startup, so the patch is in place
+in the worker too.
+
+The hook only wraps the import of the ``sglang`` package: the patch runs
+immediately before sglang's own code executes, so nothing heavier (importing
+torch, say) is paid by interpreters that never import sglang. Both patches are
+no-ops on torch >= 2.8.
+
+Install scope
+-------------
+
+Publish to the vendor index of the backends that need it and list it in their
+``deps_app``: this shim exists only for platforms whose SDK pins torch < 2.8.
+"""
+
+import importlib.machinery
+import sys
+
+# (name sglang imports, name this torch spells it as)
+_CUDA_MEMORY_ALIASES = (
+    ("_cuda_beginAllocateCurrentThreadToPool", "_cuda_beginAllocateToPool"),
+    ("_cuda_endAllocateToPool", "_cuda_endAllocateCurrentStreamToPool"),
+)
+
+_SYMM_MEM_MODULE = "torch.distributed._symmetric_memory"
+
+# Every name sglang reaches for on this module, taken from its call sites.
+# Anything else raises AttributeError, so capability probes stay honest.
+_SYMM_MEM_ALLOWED = (
+    "empty",
+    "enable_symm_mem_for_group",
+    "get_buffer",
+    "get_signal_pad_size",
+    "multicast_ptr",
+    "rendezvous",
+    "set_signal_pad_size",
+)
+
+_MARKER = "_sglang_torch_compat_applied"
+_installed = False
+
+
+def _unavailable(name):
+    def _raise(*args, **kwargs):
+        raise RuntimeError(
+            f"{_SYMM_MEM_MODULE}.{name} was called on a torch build without "
+            f"symmetric memory — this call belongs behind "
+            f"is_symmetric_memory_enabled()"
+        )
+
+    _raise.__name__ = name
+    return _raise
+
+
+def _apply():
+    """Patch the two surfaces in the current interpreter. Idempotent."""
+    module = sys.modules.get(__name__)
+    if module is not None and getattr(module, _MARKER, False):
+        return
+    if module is not None:
+        setattr(module, _MARKER, True)
+
+    # 1. the renamed torch.cuda.memory entry points
+    try:
+        import torch.cuda.memory as _memory
+    except Exception:  # no torch, or a build without the cuda module
+        _memory = None
+    if _memory is not None:
+        for imported, present in _CUDA_MEMORY_ALIASES:
+            if not hasattr(_memory, imported) and hasattr(_memory, present):
+                setattr(_memory, imported, getattr(_memory, present))
+
+    # 2. torch.distributed._symmetric_memory, when this torch cannot import it
+    if _SYMM_MEM_MODULE not in sys.modules:
+        try:
+            import torch.distributed._symmetric_memory  # noqa: F401
+        except ImportError:
+            import types
+
+            stub = types.ModuleType(_SYMM_MEM_MODULE)
+            stub.__doc__ = (
+                "sglang torch-compat shim: this torch build has no symmetric "
+                "memory. Import-face only — every stubbed call raises."
+            )
+            for name in _SYMM_MEM_ALLOWED:
+                setattr(stub, name, _unavailable(name))
+            sys.modules[_SYMM_MEM_MODULE] = stub
+            try:
+                import torch.distributed as _distributed
+
+                _distributed._symmetric_memory = stub
+            except Exception:
+                pass
+
+
+class _ApplyBeforeExec:
+    """Loader proxy: patch, then let the package's own code run."""
+
+    def __init__(self, loader):
+        self._loader = loader
+
+    def create_module(self, spec):
+        return self._loader.create_module(spec)
+
+    def exec_module(self, module):
+        _apply()
+        self._loader.exec_module(module)
+
+
+class _SglangImportHook:
+    """Wrap the import of the ``sglang`` package itself."""
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname != "sglang" or fullname in sys.modules:
+            return None
+        try:
+            spec = importlib.machinery.PathFinder.find_spec(fullname, path)
+        except Exception:
+            return None
+        if spec is not None and spec.loader is not None:
+            spec.loader = _ApplyBeforeExec(spec.loader)
+        return spec
+
+
+def install():
+    """Register the hook once, at interpreter start."""
+    global _installed
+    if _installed:
+        return
+    _installed = True
+    sys.meta_path.insert(0, _SglangImportHook())
+    if "sglang" in sys.modules:
+        # Already imported (an embedded interpreter, or a test harness that
+        # imported sglang before this module): patch now.
+        _apply()
+
+
+install()

--- a/sglang_fl/dispatch/backends/vendor/iluvatar/patches/triton_pdl.py
+++ b/sglang_fl/dispatch/backends/vendor/iluvatar/patches/triton_pdl.py
@@ -47,6 +47,19 @@ def _noop(*args, **kwargs):
     return None
 
 
+# triton's dependency pass only accepts a call it recognises as triton-side:
+# `func.__module__.startswith("triton")`. Vendor triton 3.1.0 (corex 4.4.0)
+# *asserts* on that during the AST pre-pass and aborts the compile:
+#
+#     AssertionError: Function "_noop" is being called from a Triton function
+#     but is not a Triton function itself. Decorate it with @triton.jit
+#
+# 3.2.0 (corex 4.5.0) runs the same test without asserting, which is why the
+# plain function was enough there. The function is installed *into*
+# triton.language.extra.cuda, so answering for that namespace is truthful.
+_noop.__module__ = "triton.language.extra.cuda"
+
+
 def patch_triton_pdl_intrinsics():
     """Add no-op PDL intrinsics to triton.language.extra.cuda when absent."""
     global _applied


### PR DESCRIPTION
Fixes #116

## What

Runs sglang 0.5.18 on iluvatar CoreX 4.4.0, whose SDK pins torch 2.7.1. Two
torch surfaces sglang imports at startup exist only from torch 2.8, and both sit
on the plain Qwen3 startup path:

| gap | import site | torch 2.7 has |
|---|---|---|
| `torch.cuda.memory._cuda_beginAllocateCurrentThreadToPool`, `_cuda_endAllocateToPool` | `pynccl_allocator` | the same two operations as `_cuda_beginAllocateToPool` / `_cuda_endAllocateCurrentStreamToPool` |
| `torch.distributed._symmetric_memory` (import fails: no `_C._distributed_c10d._SymmetricMemory`) | `logits_processor` → `triton_symm_mem_ag` | nothing — NVLink multicast all-gather |

The first is torch's rename, not a stand-in for a different operation:
`pynccl_allocator` itself selects between the two spellings by version
(`after_2_8_0`). The second is an NVLink feature this platform never runs.

## Why an installed package, not a plugin patch

The scheduler runs in a *spawned* worker, and that worker imports
`sglang.srt.managers.scheduler` — taking in both surfaces — before any sglang
plugin loads. A plugin-side patch is never in place early enough. This is the
ordering documented in `addon/flashinfer-shim`, and it applies here unchanged.

The shim therefore installs as `sitecustomize`, which `site` imports at
interpreter start. Its hook only wraps the import of the `sglang` package, so
interpreters that never import sglang pay nothing, and both patches are no-ops
on torch >= 2.8.

## Not called on this platform

Symmetric memory is off through sglang's own gate:
`pynccl_allocator.is_symmetric_memory_enabled()` reads
`get_exec().comm.enable_symm_mem`, which is False without real symmetric memory.
So the aliased entry points and the stubbed names are imported and never
reached. The stub keeps flashinfer-shim's discipline — explicit allowlist,
`AttributeError` for anything else, and every stub *call* raises.

## Verification

F (flagtree 0.6.1+xpu3.6) E2E on Qwen3-4B: serve ready, 3/3 chat/completions,
ct=144. The build-infra side pins the shim in `deps_app.sglang0.5.18` for
corex4.4.0 only.

This PR was written in part with the assistance of generative AI.
